### PR TITLE
Support `index.knn.advanced.approximate_threshold` for Lucene engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
 
 ### Enhancements
+* Support `index.knn.advanced.approximate_threshold` for the Lucene engine [#3451](https://github.com/opensearch-project/k-NN/pull/3451)

--- a/src/main/java/org/apache/lucene/backward_codecs/lucene99/Lucene99RWHnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/apache/lucene/backward_codecs/lucene99/Lucene99RWHnswScalarQuantizedVectorsFormat.java
@@ -14,6 +14,8 @@ import org.apache.lucene.search.TaskExecutor;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_GRAPH_THRESHOLD;
+
 /**
  * A read-write implementation of {@link Lucene99HnswScalarQuantizedVectorsFormat}.
  *
@@ -32,10 +34,13 @@ public class Lucene99RWHnswScalarQuantizedVectorsFormat extends Lucene99HnswScal
     private final int maxConn;
     private final int beamWidth;
     private final int numMergeThreads;
+    private final int tinySegmentsThreshold;
     private final TaskExecutor executorService;
 
     /**
      * Constructs a new format with the specified HNSW and scalar quantization parameters.
+     * The {@code tinySegmentsThreshold} used by the underlying writer defaults to
+     * {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat#HNSW_GRAPH_THRESHOLD}.
      *
      * @param maxConn            the maximum number of connections per node in the HNSW graph
      * @param beamWidth          the size of the queue maintained during graph construction
@@ -54,11 +59,39 @@ public class Lucene99RWHnswScalarQuantizedVectorsFormat extends Lucene99HnswScal
         Float confidenceInterval,
         ExecutorService executor
     ) {
+        this(maxConn, beamWidth, numMergeThreads, bits, compressFlag, confidenceInterval, executor, HNSW_GRAPH_THRESHOLD);
+    }
+
+    /**
+     * Constructs a new format with the specified HNSW, scalar quantization parameters and an
+     * explicit {@code tinySegmentsThreshold} that the underlying {@link Lucene99HnswVectorsWriter}
+     * uses to decide whether to build an HNSW graph for a segment.
+     *
+     * @param maxConn                the maximum number of connections per node in the HNSW graph
+     * @param beamWidth              the size of the queue maintained during graph construction
+     * @param numMergeThreads        the number of threads to use during segment merges
+     * @param bits                   the number of bits for scalar quantization (typically 7 or 8)
+     * @param compressFlag           whether to compress the quantized vectors
+     * @param confidenceInterval     the confidence interval for quantization (0.0 to 1.0)
+     * @param executor               the executor service for parallel operations, or null for single-threaded
+     * @param tinySegmentsThreshold  the docCount threshold below which the writer skips building the HNSW graph
+     */
+    public Lucene99RWHnswScalarQuantizedVectorsFormat(
+        int maxConn,
+        int beamWidth,
+        int numMergeThreads,
+        int bits,
+        boolean compressFlag,
+        Float confidenceInterval,
+        ExecutorService executor,
+        int tinySegmentsThreshold
+    ) {
         super(maxConn, beamWidth, numMergeThreads, bits, compressFlag, confidenceInterval, executor);
         this.flatVectorsFormat = new Lucene99RWScalarQuantizedVectorsFormat(confidenceInterval, bits, compressFlag);
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
         this.numMergeThreads = numMergeThreads;
+        this.tinySegmentsThreshold = tinySegmentsThreshold;
         if (executor != null) {
             this.executorService = new TaskExecutor(executor);
         } else {
@@ -75,7 +108,8 @@ public class Lucene99RWHnswScalarQuantizedVectorsFormat extends Lucene99HnswScal
             flatVectorsFormat,
             flatVectorsFormat.fieldsWriter(state),
             numMergeThreads,
-            executorService
+            executorService,
+            tinySegmentsThreshold
         );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -16,6 +16,7 @@ import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRespons
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Booleans;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.SecureSetting;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -25,6 +26,8 @@ import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.IndexModule;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManagerDto;
@@ -1118,6 +1121,23 @@ public class KNNSettings {
      */
     public static int getIndexThreadQty() {
         return KNNSettings.state().getSettingValue(KNN_ALGO_PARAM_INDEX_THREAD_QTY);
+    }
+
+    /**
+     * Retrieves the {@code index.knn.advanced.approximate_threshold} value from the given
+     * {@link org.opensearch.index.mapper.MapperService}'s index settings, or returns the default
+     * value when {@code mapperService} is null or the setting is not explicitly configured.
+     *
+     * @param mapperService the mapper service (nullable)
+     * @return the configured threshold or default
+     */
+    public static int getApproximateThresholdValue(@Nullable MapperService mapperService) {
+        if (mapperService == null) {
+            return INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
+        }
+        final IndexSettings indexSettings = mapperService.getIndexSettings();
+        final Integer approximateThresholdValue = indexSettings.getValue(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
+        return approximateThresholdValue != null ? approximateThresholdValue : INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 
     private static String percentageAsString(Integer percentage) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -57,10 +57,25 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN,
             Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
             Lucene99HnswVectorsFormat::new,
-            new LuceneCodecFormatResolver(buildLuceneFormatResolvers()),
+            new LuceneCodecFormatResolver(buildLuceneFormatResolvers(), mapperService),
             new FaissCodecFormatResolver(mapperService, nativeIndexBuildStrategyFactory),
             nativeIndexBuildStrategyFactory
         );
+    }
+
+    /**
+     * Maps the {@code index.knn.advanced.approximate_threshold} setting value to the
+     * {@code tinySegmentsThreshold} used by Lucene HNSW writers.
+     * <ul>
+     *   <li>{@code approximateThreshold < 0} (e.g. {@code -1}) → {@link Integer#MAX_VALUE} (never build the graph)</li>
+     *   <li>{@code approximateThreshold >= 0} → returned as-is (0 = always build, N = skip when docCount &lt; N)</li>
+     * </ul>
+     */
+    static int toTinySegmentsThreshold(int approximateThreshold) {
+        if (approximateThreshold < 0) {
+            return Integer.MAX_VALUE;
+        }
+        return approximateThreshold;
     }
 
     private static Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> buildLuceneFormatResolvers() {
@@ -72,10 +87,11 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 ctx.getMethodContext().getSpaceType()
             );
             final Tuple<Integer, ExecutorService> merge = getMergeThreadCountAndExecutorService();
+            final int threshold = toTinySegmentsThreshold(ctx.getApproximateThreshold());
             if (p.getSpaceType() == SpaceType.HAMMING) {
-                return new KNN9120HnswBinaryVectorsFormat(p.getMaxConnections(), p.getBeamWidth(), merge.v1(), merge.v2());
+                return new KNN9120HnswBinaryVectorsFormat(p.getMaxConnections(), p.getBeamWidth(), merge.v1(), merge.v2(), threshold);
             }
-            return new Lucene99HnswVectorsFormat(p.getMaxConnections(), p.getBeamWidth(), merge.v1(), merge.v2());
+            return new Lucene99HnswVectorsFormat(p.getMaxConnections(), p.getBeamWidth(), merge.v1(), merge.v2(), threshold);
         }, LuceneVectorsFormatType.SCALAR_QUANTIZED, ctx -> {
             final KNNScalarQuantizedVectorsFormatParams p = new KNNScalarQuantizedVectorsFormatParams(
                 ctx.getParams(),
@@ -83,13 +99,15 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 ctx.getDefaultBeamWidth()
             );
             final Tuple<Integer, ExecutorService> merge = getMergeThreadCountAndExecutorService();
+            final int threshold = toTinySegmentsThreshold(ctx.getApproximateThreshold());
             if (p.getBits() == LuceneSQEncoder.Bits.ONE.getValue()) {
                 return new KNN1040HnswScalarQuantizedVectorsFormat(
                     p.getBitEncoding(),
                     p.getMaxConnections(),
                     p.getBeamWidth(),
                     merge.v1(),
-                    merge.v2()
+                    merge.v2(),
+                    threshold
                 );
             }
             return new Lucene99RWHnswScalarQuantizedVectorsFormat(
@@ -99,7 +117,8 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 p.getBits(),
                 p.isCompressFlag(),
                 p.getConfidenceInterval(),
-                merge.v2()
+                merge.v2(),
+                threshold
             );
         }, LuceneVectorsFormatType.FLAT, ctx -> new KNN1040ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE));
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -57,7 +57,7 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN,
             Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
             Lucene99HnswVectorsFormat::new,
-            new LuceneCodecFormatResolver(buildLuceneFormatResolvers(), mapperService),
+            new LuceneCodecFormatResolver(buildLuceneFormatResolvers(), mapperService.orElse(null)),
             new FaissCodecFormatResolver(mapperService, nativeIndexBuildStrategyFactory),
             nativeIndexBuildStrategyFactory
         );

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -58,7 +58,7 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
             Lucene99HnswVectorsFormat::new,
             new LuceneCodecFormatResolver(buildLuceneFormatResolvers(), mapperService.orElse(null)),
-            new FaissCodecFormatResolver(mapperService, nativeIndexBuildStrategyFactory),
+            new FaissCodecFormatResolver(mapperService.orElse(null), nativeIndexBuildStrategyFactory),
             nativeIndexBuildStrategyFactory
         );
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_NUM_MERGE_WORKER;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_GRAPH_THRESHOLD;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.MAXIMUM_BEAM_WIDTH;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.MAXIMUM_MAX_CONN;
 import static org.opensearch.knn.index.engine.KNNEngine.getMaxDimensionByEngine;
@@ -36,6 +37,7 @@ public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
 
     private final int maxConn;
     private final int beamWidth;
+    private final int tinySegmentsThreshold;
     private static final FlatVectorsFormat flatVectorsFormat = new Lucene99FlatVectorsFormat(new KNN9120BinaryVectorScorer());
     private final int numMergeWorkers;
     private final TaskExecutor mergeExec;
@@ -60,6 +62,21 @@ public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
      * Constructor logic is identical to {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat#Lucene99HnswVectorsFormat(int, int, int, java.util.concurrent.ExecutorService)}
      */
     public KNN9120HnswBinaryVectorsFormat(int maxConn, int beamWidth, int numMergeWorkers, ExecutorService mergeExec) {
+        this(maxConn, beamWidth, numMergeWorkers, mergeExec, HNSW_GRAPH_THRESHOLD);
+    }
+
+    /**
+     * Constructor that mirrors {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat#Lucene99HnswVectorsFormat(int, int, int, java.util.concurrent.ExecutorService, int)}
+     * and accepts an explicit {@code tinySegmentsThreshold} used by the underlying
+     * {@link Lucene99HnswVectorsWriter} to decide whether to build an HNSW graph for a segment.
+     */
+    public KNN9120HnswBinaryVectorsFormat(
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec,
+        int tinySegmentsThreshold
+    ) {
         super(NAME);
         if (maxConn <= 0 || maxConn > MAXIMUM_MAX_CONN) {
             throw new IllegalArgumentException(
@@ -73,6 +90,7 @@ public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
         }
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
+        this.tinySegmentsThreshold = tinySegmentsThreshold;
         if (numMergeWorkers == 1 && mergeExec != null) {
             throw new IllegalArgumentException("No executor service is needed as we'll use single thread to merge");
         }
@@ -93,7 +111,8 @@ public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
             flatVectorsFormat,
             flatVectorsFormat.fieldsWriter(state),
             this.numMergeWorkers,
-            this.mergeExec
+            this.mergeExec,
+            this.tinySegmentsThreshold
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KnnVectorsFormatContext.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KnnVectorsFormatContext.java
@@ -43,4 +43,16 @@ public class KnnVectorsFormatContext {
      * Default beam width if not specified in params.
      */
     int defaultBeamWidth;
+
+    /**
+     * The value of {@code index.knn.advanced.approximate_threshold} for the index. Format factories
+     * should convert this to a {@code tinySegmentsThreshold} to control whether the HNSW graph is
+     * built for a given segment:
+     * <ul>
+     *   <li>{@code 0} (default): always build the graph.</li>
+     *   <li>{@code N > 0}: skip the graph when {@code docCount < N}.</li>
+     *   <li>{@code -1}: never build the graph.</li>
+     * </ul>
+     */
+    int approximateThreshold;
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.opensearch.index.IndexSettings;
+import org.opensearch.common.Nullable;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNN1040Codec.Faiss1040ScalarQuantizedKnnVectorsFormat;
@@ -16,7 +16,6 @@ import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * {@link CodecFormatResolver} implementation for native engines (FAISS, NMSLIB).
@@ -28,11 +27,12 @@ import java.util.Optional;
  */
 public class FaissCodecFormatResolver implements CodecFormatResolver {
 
-    private final Optional<MapperService> mapperService;
+    @Nullable
+    private final MapperService mapperService;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
 
     public FaissCodecFormatResolver(
-        Optional<MapperService> mapperService,
+        @Nullable MapperService mapperService,
         NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
         this.mapperService = mapperService;
@@ -59,20 +59,8 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
 
     @Override
     public KnnVectorsFormat resolve() {
-        final int approximateThreshold = getApproximateThresholdValue();
+        final int approximateThreshold = KNNSettings.getApproximateThresholdValue(mapperService);
         return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory);
-    }
-
-    /**
-     * Retrieves the approximate threshold value from index settings.
-     * Falls back to the default value when the setting is not explicitly configured.
-     */
-    private int getApproximateThresholdValue() {
-        final IndexSettings indexSettings = mapperService.get().getIndexSettings();
-        final Integer approximateThresholdValue = indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
-        return approximateThresholdValue != null
-            ? approximateThresholdValue
-            : KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 
     private static boolean isSQOneBitEncoder(Map<String, Object> params) {

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -7,6 +7,9 @@ package org.opensearch.knn.index.engine.lucene;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KnnVectorsFormatContext;
 import org.opensearch.knn.index.codec.LuceneVectorsFormatType;
 import org.opensearch.knn.index.codec.params.KNNScalarQuantizedVectorsFormatParams;
@@ -14,6 +17,7 @@ import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.opensearch.knn.common.KNNConstants.BEAM_WIDTH;
@@ -35,9 +39,22 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 public class LuceneCodecFormatResolver implements CodecFormatResolver {
 
     private final Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers;
+    private final Optional<MapperService> mapperService;
 
-    public LuceneCodecFormatResolver(Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers) {
+    public LuceneCodecFormatResolver(
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers,
+        Optional<MapperService> mapperService
+    ) {
         this.formatResolvers = formatResolvers;
+        this.mapperService = mapperService;
+    }
+
+    /**
+     * Backward-compatible constructor that does not wire in the {@code approximate_threshold} setting.
+     * The resolver will fall back to the default threshold value.
+     */
+    public LuceneCodecFormatResolver(Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers) {
+        this(formatResolvers, Optional.empty());
     }
 
     @Override
@@ -60,7 +77,26 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
         if (factory == null) {
             throw new IllegalStateException(String.format("No Lucene vectors format registered for type [%s]", formatType));
         }
-        return factory.apply(new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth));
+        final int approximateThreshold = getApproximateThresholdValue();
+        return factory.apply(
+            new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth, approximateThreshold)
+        );
+    }
+
+    /**
+     * Retrieves the approximate threshold value from index settings.
+     * Falls back to the default value when the mapper service is unavailable or the setting is not
+     * explicitly configured.
+     */
+    private int getApproximateThresholdValue() {
+        if (mapperService.isEmpty()) {
+            return KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
+        }
+        final IndexSettings indexSettings = mapperService.get().getIndexSettings();
+        final Integer approximateThresholdValue = indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
+        return approximateThresholdValue != null
+            ? approximateThresholdValue
+            : KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.engine.lucene;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.common.Nullable;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
@@ -17,7 +18,6 @@ import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.opensearch.knn.common.KNNConstants.BEAM_WIDTH;
@@ -39,22 +39,15 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 public class LuceneCodecFormatResolver implements CodecFormatResolver {
 
     private final Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers;
-    private final Optional<MapperService> mapperService;
+    @Nullable
+    private final MapperService mapperService;
 
     public LuceneCodecFormatResolver(
         Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers,
-        Optional<MapperService> mapperService
+        @Nullable MapperService mapperService
     ) {
         this.formatResolvers = formatResolvers;
         this.mapperService = mapperService;
-    }
-
-    /**
-     * Backward-compatible constructor that does not wire in the {@code approximate_threshold} setting.
-     * The resolver will fall back to the default threshold value.
-     */
-    public LuceneCodecFormatResolver(Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> formatResolvers) {
-        this(formatResolvers, Optional.empty());
     }
 
     @Override
@@ -85,14 +78,13 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
 
     /**
      * Retrieves the approximate threshold value from index settings.
-     * Falls back to the default value when the mapper service is unavailable or the setting is not
-     * explicitly configured.
+     * Falls back to the default value when the mapper service is null or the setting is not explicitly configured.
      */
     private int getApproximateThresholdValue() {
-        if (mapperService.isEmpty()) {
+        if (mapperService == null) {
             return KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
         }
-        final IndexSettings indexSettings = mapperService.get().getIndexSettings();
+        final IndexSettings indexSettings = mapperService.getIndexSettings();
         final Integer approximateThresholdValue = indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
         return approximateThresholdValue != null
             ? approximateThresholdValue

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.engine.lucene;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.opensearch.common.Nullable;
-import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KnnVectorsFormatContext;
@@ -70,25 +69,10 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
         if (factory == null) {
             throw new IllegalStateException(String.format("No Lucene vectors format registered for type [%s]", formatType));
         }
-        final int approximateThreshold = getApproximateThresholdValue();
+        final int approximateThreshold = KNNSettings.getApproximateThresholdValue(mapperService);
         return factory.apply(
             new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth, approximateThreshold)
         );
-    }
-
-    /**
-     * Retrieves the approximate threshold value from index settings.
-     * Falls back to the default value when the mapper service is null or the setting is not explicitly configured.
-     */
-    private int getApproximateThresholdValue() {
-        if (mapperService == null) {
-            return KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
-        }
-        final IndexSettings indexSettings = mapperService.getIndexSettings();
-        final Integer approximateThresholdValue = indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
-        return approximateThresholdValue != null
-            ? approximateThresholdValue
-            : KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -1367,4 +1367,66 @@ public class LuceneEngineIT extends KNNCompressionRestTestCase {
         List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
         assertEquals(k, results.size());
     }
+
+    public void testKNNIndex_whenApproximateThresholdSetForLucene_thenBuildGraphBasedOnSetting() throws Exception {
+        final String fieldName = FIELD_NAME;
+        final int dimension = DIMENSION;
+
+        // Create index with threshold = -1 (never build graph)
+        final Settings knnIndexSettings = buildKNNIndexSettings(-1);
+
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(INDEX_NAME, knnIndexSettings, builder.toString());
+
+        // Index one vector
+        addKnnDoc(INDEX_NAME, "1", fieldName, TEST_INDEX_VECTORS[0]);
+        refreshAllIndices();
+        assertEquals(1, getDocCount(INDEX_NAME));
+
+        // Add a duplicate vector with a different doc id
+        addKnnDoc(INDEX_NAME, "2", fieldName, TEST_INDEX_VECTORS[0]);
+        refreshAllIndices();
+        assertEquals(2, getDocCount(INDEX_NAME));
+
+        // Search: both docs should be returned with identical scores (exact search, no HNSW graph)
+        final int k = 2;
+        Response response = searchKNNIndex(
+            INDEX_NAME,
+            KNNQueryBuilder.builder().fieldName(fieldName).vector(TEST_QUERY_VECTORS[0]).k(k).build(),
+            k
+        );
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, fieldName);
+        assertEquals(k, results.size());
+        List<Float> scores = parseSearchResponseScore(responseBody, fieldName);
+        assertEquals("Both duplicate vectors should have identical scores (exact search)", scores.get(0), scores.get(1), 0.001);
+
+        // Update setting to 0 (always build graph) and force merge to trigger graph construction
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0));
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        // Search should still work (now with HNSW graph built)
+        response = searchKNNIndex(INDEX_NAME, KNNQueryBuilder.builder().fieldName(fieldName).vector(TEST_QUERY_VECTORS[0]).k(k).build(), k);
+        responseBody = EntityUtils.toString(response.getEntity());
+        results = parseSearchResponse(responseBody, fieldName);
+        assertEquals(k, results.size());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
@@ -75,7 +75,7 @@ public class BasePerFieldKnnVectorsFormatTests extends KNNTestCase {
                 DEFAULT_BEAM_WIDTH,
                 () -> DEFAULT_FORMAT,
                 new LuceneCodecFormatResolver(resolvers, mapperService.orElse(null)),
-                new FaissCodecFormatResolver(mapperService, new NativeIndexBuildStrategyFactory()),
+                new FaissCodecFormatResolver(mapperService.orElse(null), new NativeIndexBuildStrategyFactory()),
                 new NativeIndexBuildStrategyFactory()
             );
         }

--- a/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
@@ -74,7 +74,7 @@ public class BasePerFieldKnnVectorsFormatTests extends KNNTestCase {
                 DEFAULT_MAX_CONN,
                 DEFAULT_BEAM_WIDTH,
                 () -> DEFAULT_FORMAT,
-                new LuceneCodecFormatResolver(resolvers),
+                new LuceneCodecFormatResolver(resolvers, mapperService.orElse(null)),
                 new FaissCodecFormatResolver(mapperService, new NativeIndexBuildStrategyFactory()),
                 new NativeIndexBuildStrategyFactory()
             );

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormatTests.java
@@ -74,4 +74,43 @@ public class KNN1040HnswScalarQuantizedVectorsFormatTests extends KNNTestCase {
             assertTrue(format.toString().contains(encoding.name()));
         }
     }
+
+    public void testConstructor_whenCustomTinySegmentsThreshold_thenSucceeds() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE,
+            16,
+            100,
+            1,
+            null,
+            500
+        );
+        assertNotNull(format);
+        assertEquals("KNN1040HnswScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    public void testConstructor_whenMaxValueTinySegmentsThreshold_thenSucceeds() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE,
+            16,
+            100,
+            1,
+            null,
+            Integer.MAX_VALUE
+        );
+        assertNotNull(format);
+        assertEquals("KNN1040HnswScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    public void testConstructor_whenZeroTinySegmentsThreshold_thenSucceeds() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE,
+            16,
+            100,
+            1,
+            null,
+            0
+        );
+        assertNotNull(format);
+        assertEquals("KNN1040HnswScalarQuantizedVectorsFormat", format.getName());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormatTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.opensearch.knn.KNNTestCase;
+
+public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
+
+    public void testToTinySegmentsThreshold_whenNegativeOne_thenReturnsIntegerMaxValue() {
+        assertEquals(Integer.MAX_VALUE, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(-1));
+    }
+
+    public void testToTinySegmentsThreshold_whenZero_thenReturnsZero() {
+        // 0 → 0 → docCount < 0 is never true → always build the graph (matches Faiss semantics).
+        assertEquals(0, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(0));
+    }
+
+    public void testToTinySegmentsThreshold_whenPositive_thenReturnsSameValue() {
+        assertEquals(500, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(500));
+        assertEquals(100, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(100));
+        assertEquals(1, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(1));
+    }
+
+    public void testToTinySegmentsThreshold_whenLargeNegative_thenReturnsIntegerMaxValue() {
+        assertEquals(Integer.MAX_VALUE, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(Integer.MIN_VALUE));
+    }
+
+    public void testToTinySegmentsThreshold_whenIntegerMaxValue_thenReturnsSameValue() {
+        assertEquals(Integer.MAX_VALUE, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(Integer.MAX_VALUE));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormatTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.concurrent.Executors;
+
+public class KNN9120HnswBinaryVectorsFormatTests extends KNNTestCase {
+
+    public void testConstructor_whenDefault_thenSucceeds() {
+        KNN9120HnswBinaryVectorsFormat format = new KNN9120HnswBinaryVectorsFormat();
+        assertNotNull(format);
+    }
+
+    public void testConstructor_whenMaxConnAndBeamWidthProvided_thenSucceeds() {
+        KNN9120HnswBinaryVectorsFormat format = new KNN9120HnswBinaryVectorsFormat(16, 100);
+        assertNotNull(format);
+        String str = format.toString();
+        assertTrue(str.contains("maxConn"));
+        assertTrue(str.contains("beamWidth"));
+    }
+
+    public void testConstructor_whenMergeWorkerAndNoExecutor_thenSucceeds() {
+        KNN9120HnswBinaryVectorsFormat format = new KNN9120HnswBinaryVectorsFormat(16, 100, 1, null);
+        assertNotNull(format);
+    }
+
+    public void testConstructor_whenCustomTinySegmentsThreshold_thenSucceeds() {
+        KNN9120HnswBinaryVectorsFormat format = new KNN9120HnswBinaryVectorsFormat(16, 100, 1, null, 500);
+        assertNotNull(format);
+    }
+
+    public void testConstructor_whenMaxValueTinySegmentsThreshold_thenSucceeds() {
+        KNN9120HnswBinaryVectorsFormat format = new KNN9120HnswBinaryVectorsFormat(16, 100, 1, null, Integer.MAX_VALUE);
+        assertNotNull(format);
+    }
+
+    public void testConstructor_whenZeroTinySegmentsThreshold_thenSucceeds() {
+        KNN9120HnswBinaryVectorsFormat format = new KNN9120HnswBinaryVectorsFormat(16, 100, 1, null, 0);
+        assertNotNull(format);
+    }
+
+    public void testConstructor_whenInvalidMaxConn_thenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new KNN9120HnswBinaryVectorsFormat(0, 100, 1, null, 0));
+    }
+
+    public void testConstructor_whenInvalidBeamWidth_thenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new KNN9120HnswBinaryVectorsFormat(16, 0, 1, null, 0));
+    }
+
+    public void testConstructor_whenSingleWorkerWithExecutor_thenThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KNN9120HnswBinaryVectorsFormat(16, 100, 1, Executors.newFixedThreadPool(1), 0)
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
@@ -16,7 +16,6 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.engine.MethodComponentContext;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
@@ -46,7 +45,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
 
         NativeIndexBuildStrategyFactory factory = mock(NativeIndexBuildStrategyFactory.class);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(Optional.of(mapperService), factory);
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, factory);
         KnnVectorsFormat result = resolver.resolve();
 
         assertTrue(
@@ -67,7 +66,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
 
         NativeIndexBuildStrategyFactory factory = mock(NativeIndexBuildStrategyFactory.class);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(Optional.of(mapperService), factory);
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, factory);
         KnnVectorsFormat result = resolver.resolve();
 
         assertTrue(
@@ -89,7 +88,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
 
         NativeIndexBuildStrategyFactory factory = new NativeIndexBuildStrategyFactory();
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(Optional.of(mapperService), factory);
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, factory);
         KnnVectorsFormat result = resolver.resolve();
 
         assertTrue(
@@ -104,10 +103,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(
-            Optional.of(mapperService),
-            mock(NativeIndexBuildStrategyFactory.class)
-        );
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, mock(NativeIndexBuildStrategyFactory.class));
 
         MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1));
         Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);
@@ -125,10 +121,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(
-            Optional.of(mapperService),
-            mock(NativeIndexBuildStrategyFactory.class)
-        );
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, mock(NativeIndexBuildStrategyFactory.class));
 
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertTrue(
@@ -143,10 +136,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(
-            Optional.of(mapperService),
-            mock(NativeIndexBuildStrategyFactory.class)
-        );
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, mock(NativeIndexBuildStrategyFactory.class));
 
         MethodComponentContext encoderContext = new MethodComponentContext("sq", Map.of());
         Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);
@@ -164,10 +154,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(
-            Optional.of(mapperService),
-            mock(NativeIndexBuildStrategyFactory.class)
-        );
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, mock(NativeIndexBuildStrategyFactory.class));
         // Null params should fall back to default native format
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, null, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertTrue(
@@ -182,10 +169,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
         when(mapperService.getIndexSettings()).thenReturn(indexSettings);
 
-        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(
-            Optional.of(mapperService),
-            mock(NativeIndexBuildStrategyFactory.class)
-        );
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, mock(NativeIndexBuildStrategyFactory.class));
 
         MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
         Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
@@ -6,7 +6,10 @@
 package org.opensearch.knn.index.engine.lucene;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.KnnVectorsFormatContext;
 import org.opensearch.knn.index.codec.LuceneVectorsFormatType;
@@ -17,9 +20,11 @@ import org.opensearch.knn.index.engine.MethodComponentContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
@@ -234,5 +239,121 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         Object encoder = capturedContext[0].getParams().get(METHOD_ENCODER_PARAMETER);
         assertTrue(encoder instanceof MethodComponentContext);
         assertEquals(1, ((MethodComponentContext) encoder).getParameters().get(LUCENE_SQ_BITS));
+    }
+
+    public void testResolve_whenMapperServiceEmpty_thenContextGetsDefaultApproximateThreshold() {
+        KNNMethodContext hnswContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_PARAMETER_M, 16, METHOD_PARAMETER_EF_CONSTRUCTION, 100))
+        );
+
+        final KnnVectorsFormatContext[] captured = new KnnVectorsFormatContext[1];
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.HNSW,
+            ctx -> {
+                captured[0] = ctx;
+                return HNSW_FORMAT;
+            }
+        );
+
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.empty());
+        resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+
+        assertNotNull(captured[0]);
+        assertEquals(
+            "Expected default approximate threshold when mapperService is empty",
+            (int) KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
+            captured[0].getApproximateThreshold()
+        );
+    }
+
+    public void testResolve_whenSettingUnset_thenContextGetsDefaultApproximateThreshold() {
+        MapperService mapperService = mock(MapperService.class);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        KNNMethodContext hnswContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_PARAMETER_M, 16, METHOD_PARAMETER_EF_CONSTRUCTION, 100))
+        );
+
+        final KnnVectorsFormatContext[] captured = new KnnVectorsFormatContext[1];
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.HNSW,
+            ctx -> {
+                captured[0] = ctx;
+                return HNSW_FORMAT;
+            }
+        );
+
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.of(mapperService));
+        resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+
+        assertNotNull(captured[0]);
+        assertEquals(
+            "Expected default approximate threshold when setting is null",
+            (int) KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
+            captured[0].getApproximateThreshold()
+        );
+    }
+
+    public void testResolve_whenSettingHasCustomValue_thenContextGetsCustomApproximateThreshold() {
+        int customThreshold = 500;
+        MapperService mapperService = mock(MapperService.class);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(customThreshold);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        KNNMethodContext hnswContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_PARAMETER_M, 16, METHOD_PARAMETER_EF_CONSTRUCTION, 100))
+        );
+
+        final KnnVectorsFormatContext[] captured = new KnnVectorsFormatContext[1];
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.HNSW,
+            ctx -> {
+                captured[0] = ctx;
+                return HNSW_FORMAT;
+            }
+        );
+
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.of(mapperService));
+        resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+
+        assertNotNull(captured[0]);
+        assertEquals(customThreshold, captured[0].getApproximateThreshold());
+    }
+
+    public void testResolve_whenSettingIsNegativeOne_thenContextGetsNegativeOne() {
+        MapperService mapperService = mock(MapperService.class);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(-1);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        KNNMethodContext hnswContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_PARAMETER_M, 16, METHOD_PARAMETER_EF_CONSTRUCTION, 100))
+        );
+
+        final KnnVectorsFormatContext[] captured = new KnnVectorsFormatContext[1];
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.HNSW,
+            ctx -> {
+                captured[0] = ctx;
+                return HNSW_FORMAT;
+            }
+        );
+
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.of(mapperService));
+        resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+
+        assertNotNull(captured[0]);
+        assertEquals(-1, captured[0].getApproximateThreshold());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
@@ -20,7 +20,6 @@ import org.opensearch.knn.index.engine.MethodComponentContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.mockito.Mockito.mock;
@@ -48,6 +47,17 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
     private static final KnnVectorsFormat SQ_FORMAT = mock(KnnVectorsFormat.class);
     private static final KnnVectorsFormat FLAT_FORMAT = mock(KnnVectorsFormat.class);
 
+    /**
+     * Creates a mock MapperService with default threshold settings (returns null for threshold → uses default).
+     */
+    private static MapperService createMockMapperService() {
+        MapperService mapperService = mock(MapperService.class);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+        return mapperService;
+    }
+
     public void testResolve_whenFlatMethod_thenReturnFlatFormat() {
         KNNMethodContext flatContext = new KNNMethodContext(
             KNNEngine.LUCENE,
@@ -62,7 +72,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, flatContext, Collections.emptyMap(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertSame(FLAT_FORMAT, result);
     }
@@ -85,7 +95,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertSame(SQ_FORMAT, result);
     }
@@ -102,7 +112,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         Map<String, Object> params = Map.of(METHOD_PARAMETER_M, 32, METHOD_PARAMETER_EF_CONSTRUCTION, 256);
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, hnswContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertSame(HNSW_FORMAT, result);
@@ -121,7 +131,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         IllegalStateException ex = expectThrows(
             IllegalStateException.class,
             () -> resolver.resolve(TEST_FIELD, flatContext, Collections.emptyMap(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH)
@@ -151,7 +161,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             }
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         resolver.resolve(TEST_FIELD, methodContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
 
         assertNotNull(capturedContext[0]);
@@ -174,13 +184,13 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, hnswContext, null, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertSame(HNSW_FORMAT, result);
     }
 
     public void testResolve_whenNoArgCalled_thenThrowUnsupportedOperationException() {
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(Map.of());
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(Map.of(), createMockMapperService());
         expectThrows(UnsupportedOperationException.class, resolver::resolve);
     }
 
@@ -203,7 +213,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
         assertSame("SQ with bits=1 should route to SCALAR_QUANTIZED resolver", SQ_FORMAT, result);
     }
@@ -231,7 +241,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             ctx -> HNSW_FORMAT
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
 
         assertNotNull(capturedContext[0]);
@@ -257,7 +267,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             }
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.empty());
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, createMockMapperService());
         resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
 
         assertNotNull(captured[0]);
@@ -289,7 +299,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             }
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.of(mapperService));
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, mapperService);
         resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
 
         assertNotNull(captured[0]);
@@ -322,7 +332,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             }
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.of(mapperService));
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, mapperService);
         resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
 
         assertNotNull(captured[0]);
@@ -350,7 +360,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
             }
         );
 
-        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, Optional.of(mapperService));
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers, mapperService);
         resolver.resolve(TEST_FIELD, hnswContext, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
 
         assertNotNull(captured[0]);


### PR DESCRIPTION
### Description
Wires `index.knn.advanced.approximate_threshold` setting into the Lucene engine codec path. After this change, Lucene respects the threshold: -1 = never build graph, 0 = always build, N > 0 = controls whether HNSW graphs are built for small segments (Lucene uses a cost-based heuristic internally, so the exact cutoff may differ slightly from Faiss's strict docCount < N comparison)

**Note:** existing Lucene indices that never set this threshold previously used Lucene's hardcoded `HNSW_GRAPH_THRESHOLD` (100) which skipped graphs for very small segments. With this change the default (0) means always build, so those tiny segments will now get HNSW graphs so this breaks the current default behaviour for Lucene.

### Benchmarks

All benchmarks run on `sift-1m` (1M vectors, 128 dimensions).

#### `approximate_threshold = -1` (never build graph)

Confirms the setting now takes effect for Lucene. Before this change, the setting was ignored and ANN (graph-based) search was always used. After this change, setting `-1` correctly disables graph construction and forces exact search.
  
  | Metric | Before (setting ignored, ANN search) | After (setting respected, exact search) |
  |--------|-------------------------------------|-----------------------------------|
  | Median Throughput | 184.84 ops/s | 7.82 ops/s |
  | Mean Throughput | 173.89 ops/s | 7.78 ops/s |
  | Max Throughput | 199.47 ops/s | 7.83 ops/s |
  | P50 latency | 3.94 ms | 126.87 ms |
  | P90 latency | 4.59 ms | 129.30 ms |
  | P99 latency | 6.35 ms | 132.54 ms |
  | P100 latency | 1238.54 ms | 1198.20 ms |
  | recall@k | 0.99 | 1.00 |
  | recall@1 | 0.99 | 0.99 |
  | Index time | 21.92 min | 1.49 min |
  | Merge time | 0.30 min | 0.08 min |
  | Store size | 0.54 GB | 0.49 GB |

The throughput drop and latency increase are expected - exact search is O(n) brute-force vs O(log n) graph traversal. The recall@k improvement to 1.00 confirms exact search is being used (perfect recall).

#### `approximate_threshold = 10000` (skip graph for segments < 10K docs)

Shows that with threshold=10K, small segments skip graph construction during indexing (47% faster indexing), while the final merged segment still builds the graph for ANN search.

| Metric | Lucene Before (setting ignored) | Lucene After (setting respected) | Faiss |
|---|---|---|---|
| Median Throughput | 198.13 ops/s | 198.23 ops/s | 206.11 ops/s |
| P50 latency | 3.67 ms | 3.67 ms | 3.28 ms |
| P90 latency | 4.20 ms | 4.21 ms | 3.96 ms |
| P99 latency | 5.65 ms | 6.40 ms | 5.99 ms |
| P100 latency | 1311.50 ms | 1134.20 ms | 1077.29 ms |
| recall@k | 0.99 | 0.99 | 0.94 |
| recall@1 | 0.99 | 0.99 | 0.99 |
| Index time | 22.28 min | 11.79 min | 2.26 min |
| Merge time | 13.41 min | 13.72 min | 0.14 min |
| Store size | 0.55 GB | 0.55 GB | 1.11 GB |

With threshold=10K, indexing time drops from 22.28 min to 11.79 min (47% improvement) because small segments skip unnecessary graph construction. Search performance is unchanged. The final merged segment (1M docs > 10K) still builds the HNSW graph.


### Related Issues
Resolves #3450

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
