### PR TITLE
Move document vector conversion out of the query-vector loop in lateInteractionScore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
 
 ### Enhancements
+* Convert document vectors to primitive arrays once per document in lateInteractionScore, instead of once per query-vector/document-vector pair [#TBD](https://github.com/opensearch-project/k-NN/pull/TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,4 +33,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
 
 ### Enhancements
-* Convert document vectors to primitive arrays once per document in lateInteractionScore, instead of once per query-vector/document-vector pair [#TBD](https://github.com/opensearch-project/k-NN/pull/TBD)
+* Convert document vectors to primitive arrays once per document in lateInteractionScore, instead of once per query-vector/document-vector pair [#3453](https://github.com/opensearch-project/k-NN/pull/3453)

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
@@ -74,6 +74,24 @@ public class KNNPainlessScriptUtils {
             throw new IllegalArgumentException("Space type " + spaceType + " does not support vector similarity function");
         }
 
+        // Convert document vectors to primitive arrays once, outside the query-vector loop.
+        // Previously this conversion ran once per (query vector, document vector) pair, so a
+        // document with D vectors scored against Q query vectors paid Q*D float[] allocations
+        // and Q*D*dim Number unboxing calls, which dominates latency for large multi-vector
+        // fields (e.g. ~1M allocations per scored document at Q=D=1024).
+        float[][] convertedDocVectors = new float[docVectors.size()][];
+        int numValidDocVectors = 0;
+        for (List<Number> docVector : docVectors) {
+            if (docVector == null || docVector.isEmpty()) {
+                continue;
+            }
+            float[] dVec = new float[docVector.size()];
+            for (int i = 0; i < docVector.size(); i++) {
+                dVec[i] = docVector.get(i).floatValue();
+            }
+            convertedDocVectors[numValidDocVectors++] = dVec;
+        }
+
         float totalScore = 0.0f;
 
         for (List<Number> queryVector : queryVectors) {
@@ -86,19 +104,15 @@ public class KNNPainlessScriptUtils {
                 qVec[i] = queryVector.get(i).floatValue();
             }
 
-            float bestRawScore = (float) docVectors.stream()
-                .filter(docVector -> docVector != null && !docVector.isEmpty())
-                .mapToDouble(docVector -> {
-                    float[] dVec = new float[docVector.size()];
-                    for (int i = 0; i < docVector.size(); i++) {
-                        dVec[i] = docVector.get(i).floatValue();
-                    }
-                    return similarityFunction.compare(qVec, dVec);
-                })
-                .max()
-                .orElse(Double.NEGATIVE_INFINITY);
+            float bestRawScore = Float.NEGATIVE_INFINITY;
+            for (int i = 0; i < numValidDocVectors; i++) {
+                float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
+                if (score > bestRawScore) {
+                    bestRawScore = score;
+                }
+            }
 
-            if (bestRawScore != Double.NEGATIVE_INFINITY) {
+            if (bestRawScore != Float.NEGATIVE_INFINITY) {
                 totalScore += bestRawScore;
             }
         }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
@@ -105,10 +105,10 @@ public class KNNPainlessScriptUtils {
             }
 
             float bestRawScore = Float.NEGATIVE_INFINITY;
-for (int i = 0; i < numValidDocVectors; i++) {
-   float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
-    bestRawScore = Math.max(bestRawScore, score);
-}
+            for (int i = 0; i < numValidDocVectors; i++) {
+            float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
+                bestRawScore = Math.max(bestRawScore, score);
+            }
 
             if (bestRawScore != Float.NEGATIVE_INFINITY) {
                 totalScore += bestRawScore;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
@@ -105,12 +105,10 @@ public class KNNPainlessScriptUtils {
             }
 
             float bestRawScore = Float.NEGATIVE_INFINITY;
-            for (int i = 0; i < numValidDocVectors; i++) {
-                float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
-                if (score > bestRawScore) {
-                    bestRawScore = score;
-                }
-            }
+for (int i = 0; i < numValidDocVectors; i++) {
+   float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
+    bestRawScore = Math.max(bestRawScore, score);
+}
 
             if (bestRawScore != Float.NEGATIVE_INFINITY) {
                 totalScore += bestRawScore;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNPainlessScriptUtils.java
@@ -106,7 +106,7 @@ public class KNNPainlessScriptUtils {
 
             float bestRawScore = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numValidDocVectors; i++) {
-            float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
+                float score = similarityFunction.compare(qVec, convertedDocVectors[i]);
                 bestRawScore = Math.max(bestRawScore, score);
             }
 


### PR DESCRIPTION
# PR: Move document vector conversion out of the query-vector loop in `lateInteractionScore`

**Target repo**: `opensearch-project/k-NN` (base branch: `main`)
**Branch name**: `fix-late-interaction-doc-vector-conversion`
**Patch file**: `0001-Hoist-document-vector-conversion-out-of-the-query-ve.patch` (same directory; `git am` it onto a fresh fork of `main`)
---

### Description

`KNNPainlessScriptUtils.lateInteractionScore` converts each document vector from
`List<Number>` to `float[]` **inside** the per-query-vector loop — once per
*(query vector, document vector)* pair:

```java
for (List<Number> queryVector : queryVectors) {          // × Q
    ...
    float bestRawScore = (float) docVectors.stream()     // × D — re-run for every query vector
        .mapToDouble(docVector -> {
            float[] dVec = new float[docVector.size()];  // fresh allocation per (Q,D) pair
            for (int i = 0; i < docVector.size(); i++) {
                dVec[i] = docVector.get(i).floatValue(); // unbox per (Q,D) pair
            }
            return similarityFunction.compare(qVec, dVec);
        })
        ...
}
```

For ColBERT-style late-interaction workloads with large multi-vector fields this dominates
end-to-end latency. At Q = D = 1024, dim = 128 (a realistic ColBERT document), scoring **one**
document performs ~1M `float[128]` allocations and ~134M `Number.floatValue()` calls, while the
actual similarity comparison is comparatively cheap.

This change converts the document vectors to primitive `float[][]` **once per call**, before the
query-vector loop, and replaces the per-query-vector stream with a plain loop over the converted
arrays. Query-vector conversion (already once per query vector) is unchanged. Null/empty document
vectors are skipped exactly as the previous `.filter(...)` did; a query vector that matches no
valid document vector contributes nothing to the total, as before.

**Measured impact** (OpenSearch 3.5, `script_score` rescore via the Painless allowlisted function,
`window_size=20`, 1 shard, server-side `took`, N=5, request cache off): per-candidate cost is
linear in *both* the query-vector count and the document-vector count with the same
~0.29µs-per-pair slope — i.e. the pair loop, not the similarity math, is the dominant term:

| Variant (QNV = query vectors, D = doc vectors) | took p50 |
|---|---|
| rescore with constant script (machinery baseline) | 387ms |
| + touch `_source` field, no scoring (parse only) | 1,176ms |
| full fn, QNV=1024, D=128 | 1,714ms |
| full fn, QNV=1024, D=256 | 2,481ms |
| full fn, QNV=1024, D=512 | 3,931ms |
| full fn, QNV=1024, D=1024 | 7,032ms |
| full fn, QNV=128, D=1024 | 1,927ms |
| full fn, QNV=256, D=1024 | 2,686ms |
| full fn, QNV=512, D=1024 | 4,225ms |

With conversion hoisted, the redundant work drops from `Q × D` conversions to `D` conversions per
document; the remaining per-pair work is the SIMD `compare` itself. For the Q = D = 1024 case above
this removes the large majority of the ~290ms-per-candidate conversion overhead (the same scoring
computed over primitive arrays externally takes ~3ms/candidate).

No API or behavior change: same inputs, same score, same exceptions for null/empty inputs.

**A/B verification on containerized OpenSearch 3.5.0** (two identical single-node containers from
the official 3.5.0 image, the patched one differing only by this change recompiled into the
bundled `opensearch-knn-3.5.0.0.jar`; 50 docs × 1024×128-dim multivectors, k=20, window_size=20,
request cache off, N=3 + warmup; harness: `local-verify/` beside this file):

- **Correctness**: identical ranking, and per-hit rescore scores **bitwise identical** between
  stock and patched (max |Δ| = 0.0); both match an independent numpy MaxSim implementation within
  float32 epsilon (max |Δ| = 1.6e-06).
- **Performance** (server-side `took` p50, same container resources, benchmarked sequentially):

| Query vectors (QNV) | stock | patched | speedup |
|---|---|---|---|
| 128 | 738ms | 442ms | 1.7× |
| 512 | 1,710ms | 526ms | 3.3× |
| 1024 | 2,913ms | 675ms | **4.3×** |

The patched engine's `took` is nearly flat in QNV (remaining growth is the SIMD compares and
per-query-vector conversion), while stock grows linearly — consistent with the removed
`Q × D` conversion term.

### Related Issues

None filed; found while profiling late-interaction rescoring on OpenSearch 3.5.

### Check List
- [x] New functionality includes testing. *(No new functionality — existing
  `KNNPainlessScriptUtilsTests` cover the null/empty-vector and scoring behavior, which is
  unchanged.)*
- [ ] New functionality has been documented. *(N/A — no API/behavior change.)*
- [ ] API changes companion pull request created. *(N/A)*
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created. *(N/A)*

By submitting this pull request, I confirm that my contribution is made under the terms of the
Apache 2.0 license.
