### PR TITLE
Refactor field creation to Optional-based override pattern

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -163,36 +163,14 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
 
     @Override
     protected List<Field> getFieldsForFloatVector(final float[] array, boolean isDerivedSourceEnabled) {
-        List<Field> fields = fieldStrategy.createFloatFields(
-            name(),
-            array,
-            fieldType,
-            vectorFieldType,
-            stored,
-            hasDocValues,
-            isDerivedSourceEnabled
-        );
-        if (fields != null) {
-            return fields;
-        }
-        return super.getFieldsForFloatVector(array, isDerivedSourceEnabled);
+        return fieldStrategy.getFloatFieldOverrides(name(), array, fieldType, vectorFieldType, stored, hasDocValues, isDerivedSourceEnabled)
+            .orElseGet(() -> super.getFieldsForFloatVector(array, isDerivedSourceEnabled));
     }
 
     @Override
     protected List<Field> getFieldsForByteVector(final byte[] array, boolean isDerivedSourceEnabled) {
-        List<Field> fields = fieldStrategy.createByteFields(
-            name(),
-            array,
-            fieldType,
-            vectorFieldType,
-            stored,
-            hasDocValues,
-            isDerivedSourceEnabled
-        );
-        if (fields != null) {
-            return fields;
-        }
-        return super.getFieldsForByteVector(array, isDerivedSourceEnabled);
+        return fieldStrategy.getByteFieldOverrides(name(), array, fieldType, vectorFieldType, stored, hasDocValues, isDerivedSourceEnabled)
+            .orElseGet(() -> super.getFieldsForByteVector(array, isDerivedSourceEnabled));
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldStrategy.java
@@ -13,11 +13,14 @@ import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
- * Strategy interface for engine-specific field construction and vector field creation.
- * Each KNN engine provides its own implementation to handle field type building,
- * vector field creation, and attribute formatting.
+ * Strategy interface for engine-specific field type construction. Each KNN engine provides its
+ * own implementation to handle field type building and attribute formatting. Engines that require
+ * custom vector field creation override {@link #getFloatFieldOverrides} and
+ * {@link #getByteFieldOverrides}; otherwise the default field creation path owned by
+ * {@link KNNVectorFieldMapper} is used.
  */
 public interface EngineFieldStrategy {
 
@@ -42,10 +45,8 @@ public interface EngineFieldStrategy {
     );
 
     /**
-     * Creates the list of fields for indexing a float vector.
-     * <p>
-     * Returns null to signal the caller should use the parent class default field creation path.
-     * Override only when the engine requires custom field construction (e.g. Lucene doc-values fields).
+     * Returns engine-specific fields for indexing a float vector, or {@link Optional#empty()} to
+     * use the default field creation path owned by {@link KNNVectorFieldMapper}.
      *
      * @param name the field name
      * @param array the float vector
@@ -54,9 +55,9 @@ public interface EngineFieldStrategy {
      * @param stored whether the field is stored
      * @param hasDocValues whether the field has doc values
      * @param isDerivedSourceEnabled whether derived source is enabled
-     * @return list of fields to add to the document, or null to use the default field creation path
+     * @return optional list of fields to add to the document
      */
-    default List<Field> createFloatFields(
+    default Optional<List<Field>> getFloatFieldOverrides(
         String name,
         float[] array,
         FieldType fieldType,
@@ -65,14 +66,12 @@ public interface EngineFieldStrategy {
         boolean hasDocValues,
         boolean isDerivedSourceEnabled
     ) {
-        return null;
+        return Optional.empty();
     }
 
     /**
-     * Creates the list of fields for indexing a byte vector.
-     * <p>
-     * Returns null to signal the caller should use the parent class default field creation path.
-     * Override only when the engine requires custom field construction (e.g. Lucene doc-values fields).
+     * Returns engine-specific fields for indexing a byte vector, or {@link Optional#empty()} to
+     * use the default field creation path owned by {@link KNNVectorFieldMapper}.
      *
      * @param name the field name
      * @param array the byte vector
@@ -81,9 +80,9 @@ public interface EngineFieldStrategy {
      * @param stored whether the field is stored
      * @param hasDocValues whether the field has doc values
      * @param isDerivedSourceEnabled whether derived source is enabled
-     * @return list of fields to add to the document, or null to use the default field creation path
+     * @return optional list of fields to add to the document
      */
-    default List<Field> createByteFields(
+    default Optional<List<Field>> getByteFieldOverrides(
         String name,
         byte[] array,
         FieldType fieldType,
@@ -92,6 +91,6 @@ public interface EngineFieldStrategy {
         boolean hasDocValues,
         boolean isDerivedSourceEnabled
     ) {
-        return null;
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
@@ -37,7 +37,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 /**
  * Faiss (and NMSLIB) engine implementation of {@link EngineFieldStrategy}.
  * Handles field type construction for non-Lucene KNN engines. Vector field creation uses the
- * {@link EngineFieldStrategy} interface defaults, signaling the caller to use its default path.
+ * default path owned by {@link KNNVectorFieldMapper}.
  */
 @Log4j2
 public final class FaissFieldStrategy implements EngineFieldStrategy {

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -938,11 +938,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         if (fieldType().getKnnMappingConfig().getModelId().isPresent()) {
             knnMethodConfigContext = null;
         } else {
-            // compression_level may never have been specified by the user, in which case it is null
-            String userCompressionLevelName = originalMappingParameters.getCompressionLevel();
-            CompressionLevel userConfiguredCompressionLevel = userCompressionLevelName == null
-                ? CompressionLevel.NOT_CONFIGURED
-                : CompressionLevel.fromName(userCompressionLevelName);
             knnMethodConfigContext = KNNMethodConfigContext.builder()
                 .vectorDataType(vectorDataType)
                 .versionCreated(indexCreatedVersion)
@@ -950,7 +945,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 .compressionLevel(fieldType().getKnnMappingConfig().getCompressionLevel())
                 // The mapping config carries the resolved compression, which may have been derived from the
                 // encoder. Preserve what the user originally configured so mode derivation stays correct on merge.
-                .userConfiguredCompressionLevel(userConfiguredCompressionLevel)
+                .userConfiguredCompressionLevel(CompressionLevel.fromName(originalMappingParameters.getCompressionLevel()))
                 .mode(fieldType().getKnnMappingConfig().getMode())
                 .build();
         }

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldStrategy.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForByteVector;
@@ -25,7 +26,8 @@ import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createSto
 
 /**
  * Lucene engine implementation of {@link EngineFieldStrategy}.
- * Handles field type construction and vector field creation for the Lucene KNN engine.
+ * Handles field type construction and custom vector field creation (doc-values based)
+ * for the Lucene KNN engine.
  */
 public final class LuceneFieldStrategy implements EngineFieldStrategy {
 
@@ -57,7 +59,7 @@ public final class LuceneFieldStrategy implements EngineFieldStrategy {
     }
 
     @Override
-    public List<Field> createFloatFields(
+    public Optional<List<Field>> getFloatFieldOverrides(
         String name,
         float[] array,
         FieldType fieldType,
@@ -74,11 +76,11 @@ public final class LuceneFieldStrategy implements EngineFieldStrategy {
         if (stored) {
             fields.add(createStoredFieldForFloatVector(name, array));
         }
-        return fields;
+        return Optional.of(fields);
     }
 
     @Override
-    public List<Field> createByteFields(
+    public Optional<List<Field>> getByteFieldOverrides(
         String name,
         byte[] array,
         FieldType fieldType,
@@ -95,6 +97,6 @@ public final class LuceneFieldStrategy implements EngineFieldStrategy {
         if (stored) {
             fields.add(createStoredFieldForByteVector(name, array));
         }
-        return fields;
+        return Optional.of(fields);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/FaissFieldStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/FaissFieldStrategyTests.java
@@ -20,7 +20,6 @@ import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 import java.util.Collections;
-import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
@@ -123,30 +122,12 @@ public class FaissFieldStrategyTests extends KNNTestCase {
         assertNull(fieldType.getAttributes().get(SQ_CONFIG));
     }
 
-    public void testCreateFloatFieldsReturnsNull() {
-        List<?> result = FaissFieldStrategy.INSTANCE.createFloatFields(
-            "test_field",
-            new float[] { 1.0f, 2.0f },
-            mock(FieldType.class),
-            null,
-            true,
-            true,
-            false
+    public void testFaissFieldStrategyDoesNotProvideFieldOverrides() {
+        EngineFieldStrategy strategy = FaissFieldStrategy.INSTANCE;
+        assertTrue(
+            strategy.getFloatFieldOverrides("test_field", new float[] { 1.0f, 2.0f, 3.0f }, null, null, false, false, false).isEmpty()
         );
-        assertNull(result);
-    }
-
-    public void testCreateByteFieldsReturnsNull() {
-        List<?> result = FaissFieldStrategy.INSTANCE.createByteFields(
-            "test_field",
-            new byte[] { 1, 2 },
-            mock(FieldType.class),
-            null,
-            true,
-            true,
-            false
-        );
-        assertNull(result);
+        assertTrue(strategy.getByteFieldOverrides("test_field", new byte[] { 1, 2, 3 }, null, null, false, false, false).isEmpty());
     }
 
     public void testBuildFieldTypeConfigForFaissWithBQEncoder() {

--- a/src/test/java/org/opensearch/knn/index/mapper/LuceneFieldStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/LuceneFieldStrategyTests.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -76,7 +77,7 @@ public class LuceneFieldStrategyTests extends KNNTestCase {
         assertNull(config.getVectorFieldType());
     }
 
-    public void testCreateFloatFieldsWithDocValuesAndStored() {
+    public void testGetFloatFieldOverridesWithDocValuesAndStored() {
         int dimension = 3;
         FieldType fieldType = KnnFloatVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
         FieldType vectorFieldType = new FieldType();
@@ -85,7 +86,7 @@ public class LuceneFieldStrategyTests extends KNNTestCase {
 
         float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
 
-        List<Field> fields = LuceneFieldStrategy.INSTANCE.createFloatFields(
+        Optional<List<Field>> fields = LuceneFieldStrategy.INSTANCE.getFloatFieldOverrides(
             "test_field",
             vector,
             fieldType,
@@ -95,21 +96,31 @@ public class LuceneFieldStrategyTests extends KNNTestCase {
             false
         );
 
-        assertEquals(3, fields.size());
+        assertTrue(fields.isPresent());
+        assertEquals(3, fields.get().size());
     }
 
-    public void testCreateFloatFieldsWithoutDocValuesOrStored() {
+    public void testGetFloatFieldOverridesWithoutDocValuesOrStored() {
         int dimension = 3;
         FieldType fieldType = KnnFloatVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
 
         float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
 
-        List<Field> fields = LuceneFieldStrategy.INSTANCE.createFloatFields("test_field", vector, fieldType, null, false, false, false);
+        Optional<List<Field>> fields = LuceneFieldStrategy.INSTANCE.getFloatFieldOverrides(
+            "test_field",
+            vector,
+            fieldType,
+            null,
+            false,
+            false,
+            false
+        );
 
-        assertEquals(1, fields.size());
+        assertTrue(fields.isPresent());
+        assertEquals(1, fields.get().size());
     }
 
-    public void testCreateByteFieldsWithDocValuesAndStored() {
+    public void testGetByteFieldOverridesWithDocValuesAndStored() {
         int dimension = 3;
         FieldType fieldType = KnnByteVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
         FieldType vectorFieldType = new FieldType();
@@ -118,7 +129,7 @@ public class LuceneFieldStrategyTests extends KNNTestCase {
 
         byte[] vector = new byte[] { 1, 2, 3 };
 
-        List<Field> fields = LuceneFieldStrategy.INSTANCE.createByteFields(
+        Optional<List<Field>> fields = LuceneFieldStrategy.INSTANCE.getByteFieldOverrides(
             "test_field",
             vector,
             fieldType,
@@ -128,39 +139,67 @@ public class LuceneFieldStrategyTests extends KNNTestCase {
             false
         );
 
-        assertEquals(3, fields.size());
+        assertTrue(fields.isPresent());
+        assertEquals(3, fields.get().size());
     }
 
-    public void testCreateByteFieldsWithoutDocValuesOrStored() {
+    public void testGetByteFieldOverridesWithoutDocValuesOrStored() {
         int dimension = 3;
         FieldType fieldType = KnnByteVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
 
         byte[] vector = new byte[] { 1, 2, 3 };
 
-        List<Field> fields = LuceneFieldStrategy.INSTANCE.createByteFields("test_field", vector, fieldType, null, false, false, false);
+        Optional<List<Field>> fields = LuceneFieldStrategy.INSTANCE.getByteFieldOverrides(
+            "test_field",
+            vector,
+            fieldType,
+            null,
+            false,
+            false,
+            false
+        );
 
-        assertEquals(1, fields.size());
+        assertTrue(fields.isPresent());
+        assertEquals(1, fields.get().size());
     }
 
-    public void testCreateFloatFieldsWithDocValuesButNullVectorFieldType() {
+    public void testGetFloatFieldOverridesWithDocValuesButNullVectorFieldType() {
         int dimension = 3;
         FieldType fieldType = KnnFloatVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
 
         float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
 
-        List<Field> fields = LuceneFieldStrategy.INSTANCE.createFloatFields("test_field", vector, fieldType, null, false, true, false);
+        Optional<List<Field>> fields = LuceneFieldStrategy.INSTANCE.getFloatFieldOverrides(
+            "test_field",
+            vector,
+            fieldType,
+            null,
+            false,
+            true,
+            false
+        );
 
-        assertEquals(1, fields.size());
+        assertTrue(fields.isPresent());
+        assertEquals(1, fields.get().size());
     }
 
-    public void testCreateByteFieldsWithDocValuesButNullVectorFieldType() {
+    public void testGetByteFieldOverridesWithDocValuesButNullVectorFieldType() {
         int dimension = 3;
         FieldType fieldType = KnnByteVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
 
         byte[] vector = new byte[] { 1, 2, 3 };
 
-        List<Field> fields = LuceneFieldStrategy.INSTANCE.createByteFields("test_field", vector, fieldType, null, false, true, false);
+        Optional<List<Field>> fields = LuceneFieldStrategy.INSTANCE.getByteFieldOverrides(
+            "test_field",
+            vector,
+            fieldType,
+            null,
+            false,
+            true,
+            false
+        );
 
-        assertEquals(1, fields.size());
+        assertTrue(fields.isPresent());
+        assertEquals(1, fields.get().size());
     }
 }


### PR DESCRIPTION
### Description
Replaces the null-return delegation and DefaultFieldStrategy duplication with an Optional-based override pattern on EngineFieldStrategy. 

### Related Issues
Resolves #2745

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
