### PR TITLE
[SQ PR-5] Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
 * Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4} [#3432](https://github.com/opensearch-project/k-NN/pull/3432)
+* Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4} [#3459](https://github.com/opensearch-project/k-NN/pull/3459)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
+* Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4} [#3432](https://github.com/opensearch-project/k-NN/pull/3432)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -105,6 +105,19 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         final QuantizedByteVectorValues quantizedByteVectorValues,
         final float[] target
     ) throws IOException {
+        // Native bulk-SIMD scoring is implemented for 1-bit documents only. Multi-bit docs
+        // (B=2, B=4) share the same .veq layout but need width-specific kernels that are not
+        // yet in the native SIMD path — route them to Lucene's pure-Java reference scorer,
+        // which scores the same codes correctly.
+        final ScalarEncoding scalarEncoding = quantizedByteVectorValues.getScalarEncoding();
+        if (ScalarEncodingResolver.docBits(scalarEncoding) != 1) {
+            return (RandomVectorScorer.AbstractRandomVectorScorer) super.getRandomVectorScorer(
+                similarityFunction,
+                quantizedByteVectorValues,
+                target
+            );
+        }
+
         final IndexInput indexInput = quantizedByteVectorValues.getSlice();
         final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(indexInput, 0, indexInput.length());
         if (addressAndSize != null) {

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -328,9 +328,10 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
 
     private static String determineVectorDataType(final VectorDataType dataType, final Map<String, Object> parameters) {
         if (dataType == VectorDataType.FLOAT) {
-            // SQ 1-bit sends fp32 vectors. Once support is added for building 1 bit SQ graphs
-            // in the Remote Vector Index Builder, then this can be modified to send 1 bit SQ vectors.
-            if (FaissHNSWMethod.isSQOneBitIndex(dataType, parameters)) {
+            // SQ memory-optimized-search (bits ∈ {1, 2, 4}) sends fp32 vectors. The remote builder
+            // constructs an HNSW graph over fp32 neighbors — quantization happens locally on the
+            // data node, and the graph is stitched with the locally-quantized .veq at search time.
+            if (FaissHNSWMethod.isSQMosIndex(dataType, parameters)) {
                 return dataType.getValue();
             }
             if (FaissHNSWMethod.isFloat16Index(dataType, parameters)) {
@@ -347,7 +348,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
      * flat vectors at search time via {@link org.opensearch.knn.memoryoptsearch.faiss.FaissFlatIndexFactory}.
      */
     private static boolean shouldSkipStoredVectors(final VectorDataType vectorDataType, final Map<String, Object> parameters) {
-        return FaissHNSWMethod.isSQOneBitIndex(vectorDataType, parameters);
+        return FaissHNSWMethod.isSQMosIndex(vectorDataType, parameters);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.KNN1040Codec.ScalarEncodingResolver;
 import org.opensearch.knn.index.engine.AbstractKNNMethod;
 import org.opensearch.knn.index.engine.DefaultHnswSearchContext;
 import org.opensearch.knn.index.engine.Encoder;
@@ -200,7 +201,7 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
             final VectorDataType vectorDataType = extractVectorDataType(parameters);
             final Map<String, Object> encoderMap = extractEncoderMap(parameters);
 
-            if (isSQOneBitIndex(vectorDataType, parameters)) {
+            if (isSQMosIndex(vectorDataType, parameters)) {
                 return true;
             }
 
@@ -325,17 +326,20 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
     }
 
     /**
-     * Checks whether the given parameters represent an SQ 1-bit index (encoder: sq, bits: 1).
+     * Checks whether the given parameters represent an SQ memory-optimized-search (MOS) index —
+     * i.e. an sq encoder with a supported MOS bit width ({@code bits ∈ {1, 2, 4}}).
      *
-     * TODO: Consolidate the logic in this function with {@link FaissSQEncoder#isSQOneBit} into one function,
-     * so that there is a single source of truth. Currently, this is not possible because
-     * {@link FaissSQEncoder#isSQOneBit} assumes the encoder object is a {@link MethodComponentContext}.
+     * <p>The remote index build path shares the same wire behavior across all three widths: the data
+     * node uploads fp32 vectors, the remote builder constructs an HNSW graph over fp32 neighbors,
+     * and the data node stitches that graph with its locally-quantized {@code .veq} at search time
+     * via {@link org.opensearch.knn.memoryoptsearch.faiss.FaissFlatIndexFactory}. So a single
+     * predicate identifies "an SQ index the remote builder can produce a valid graph for."
      *
      * @param vectorDataType The data type for the vector field
      * @param parameters KNN library indexing parameters
-     * @return true if SQ 1 bit, false otherwise
+     * @return true if the encoder is sq with bits in {1, 2, 4}, false otherwise
      */
-    public static boolean isSQOneBitIndex(final VectorDataType vectorDataType, final Map<String, Object> parameters) {
+    public static boolean isSQMosIndex(final VectorDataType vectorDataType, final Map<String, Object> parameters) {
         try {
             if (vectorDataType != VectorDataType.FLOAT) {
                 return false;
@@ -346,9 +350,13 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
                 return false;
             }
             Object bits = encoderMap.get(SQ_BITS);
-            return bits instanceof Integer && (Integer) bits == FaissSQEncoder.Bits.ONE.getValue();
+            return bits instanceof Integer && FaissSQEncoder.isSQCodedBits((Integer) bits);
         } catch (final Exception e) {
-            log.error("Failed to check if method parameters contain an sq encoder with bits=1", e);
+            log.error(
+                "Failed to check if method parameters contain an sq encoder with bits in {}",
+                ScalarEncodingResolver.supportedDocBitsString(),
+                e
+            );
             // Ignore
             return false;
         }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -29,12 +29,13 @@ public class FaissFlatIndexFactory {
      * indices where flat storage was skipped (IO_FLAG_SKIP_STORAGE). Returns {@code null} if the field
      * does not require externally-provided flat storage.
      *
-     * <p>Currently supports SQ 1-bit. To add support for other flat storage types (e.g., fp32 flat),
-     * add new conditions here.
+     * <p>Supports the SQ memory-optimized-search path for bits in {1, 2, 4} — for all of these the
+     * .faiss file holds only the HNSW graph and the quantized codes live in Lucene's flat .veq file.
+     * To add support for other flat storage types (e.g., fp32 flat), add new conditions here.
      */
     static FaissIndex createFlatIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
         if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
         }
         return null;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
@@ -59,6 +59,61 @@ public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
         }
     }
 
+    /**
+     * For multi-bit encodings (B=2, B=4) the scorer must route to Lucene's reference scorer without
+     * touching {@code MemorySegmentAddressExtractorUtil} — native bulk SIMD is not wired for
+     * multi-bit yet. Parameterizing over {@link ScalarEncoding#DIBIT_QUERY_NIBBLE} and
+     * {@link ScalarEncoding#PACKED_NIBBLE} verifies the gate for both widths.
+     */
+    @SneakyThrows
+    private void assertMultiBitFallback(final ScalarEncoding encoding) {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040ScalarQuantizedVectorScorer scorer = new KNN1040ScalarQuantizedVectorScorer(mockDelegate);
+
+        final int dimension = 8;
+        final QuantizedByteVectorValues mockQuantizedValues = mock(QuantizedByteVectorValues.class);
+        when(mockQuantizedValues.dimension()).thenReturn(dimension);
+        when(mockQuantizedValues.getScalarEncoding()).thenReturn(encoding);
+
+        // Parent Lucene104ScalarQuantizedVectorScorer's reference path also runs a quantization —
+        // supply the same mocks the null-address test uses so it can complete without NPEs.
+        final OptimizedScalarQuantizer mockQuantizer = mock(OptimizedScalarQuantizer.class);
+        when(mockQuantizedValues.getQuantizer()).thenReturn(mockQuantizer);
+        when(mockQuantizedValues.getCentroid()).thenReturn(new float[dimension]);
+        final OptimizedScalarQuantizer.QuantizationResult quantizationResult = new OptimizedScalarQuantizer.QuantizationResult(
+            0.0f,
+            1.0f,
+            0.0f,
+            0
+        );
+        when(mockQuantizer.scalarQuantize(any(float[].class), any(byte[].class), anyByte(), any(float[].class))).thenReturn(
+            quantizationResult
+        );
+
+        final StubVectorValues stub = new StubVectorValues();
+        final java.lang.reflect.Field field = StubVectorValues.class.getDeclaredField("quantizedVectorValues");
+        field.setAccessible(true);
+        field.set(stub, mockQuantizedValues);
+
+        try (MockedStatic<MemorySegmentAddressExtractorUtil> mockedStatic = Mockito.mockStatic(MemorySegmentAddressExtractorUtil.class)) {
+            final RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, stub, new float[dimension]);
+
+            assertNotNull(result);
+            // The multi-bit gate must fire before we even ask about the address — no interaction.
+            mockedStatic.verifyNoInteractions();
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_whenTwoBitEncoding_thenRoutesToLuceneScorerWithoutAddressExtraction() {
+        assertMultiBitFallback(ScalarEncoding.DIBIT_QUERY_NIBBLE);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_whenFourBitEncoding_thenRoutesToLuceneScorerWithoutAddressExtraction() {
+        assertMultiBitFallback(ScalarEncoding.PACKED_NIBBLE);
+    }
+
     @SneakyThrows
     public void testGetRandomVectorScorer_whenAddressExtractionReturnsNull_thenFallsBackToLuceneScorer() {
         // Arrange: set up the mock delegate scorer
@@ -74,9 +129,11 @@ public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
         when(mockQuantizedValues.getSlice()).thenReturn(mockIndexInput);
         when(mockIndexInput.length()).thenReturn(1024L);
 
-        // Set up quantization mocks needed by the parent Lucene104ScalarQuantizedVectorScorer
+        // Set up quantization mocks needed by the parent Lucene104ScalarQuantizedVectorScorer.
+        // Encoding is SINGLE_BIT_QUERY_NIBBLE (docBits == 1) so the multi-bit fallback gate does
+        // not fire — this test exercises the address-extractor null fallback specifically.
         when(mockQuantizedValues.dimension()).thenReturn(dimension);
-        when(mockQuantizedValues.getScalarEncoding()).thenReturn(ScalarEncoding.UNSIGNED_BYTE);
+        when(mockQuantizedValues.getScalarEncoding()).thenReturn(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
 
         final OptimizedScalarQuantizer mockQuantizer = mock(OptimizedScalarQuantizer.class);
         when(mockQuantizedValues.getQuantizer()).thenReturn(mockQuantizer);

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -212,6 +212,73 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
         assertTrue(request.isSkipStoredVectors());
     }
 
+    public void testBuildRequestSQTwoBit() throws IOException {
+        // Same wire contract as SQ 1-bit: fp32 vectors uploaded, RVIB builds the HNSW graph over
+        // fp32 neighbors, data node stitches with locally-quantized .veq (2-bit) at search time.
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQParameterMap(2)
+        );
+        assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
+        assertTrue(request.isSkipStoredVectors());
+    }
+
+    public void testBuildRequestSQFourBit() throws IOException {
+        // Same wire contract as SQ 1-bit/2-bit — the data node quantizes to 4-bit codes locally
+        // and uploads fp32 to RVIB, which produces an HNSW graph over the fp32 neighbors.
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQParameterMap(4)
+        );
+        assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
+        assertTrue(request.isSkipStoredVectors());
+    }
+
+    public void testBuildRequestSQFP16_thenNoSkipStoredVectors() throws IOException {
+        // Sanity: fp16 is not the MOS path, so skipStoredVectors must remain false — RVIB writes
+        // its own flat storage in this case.
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQParameterMap(16)
+        );
+        assertFalse(request.isSkipStoredVectors());
+    }
+
+    private Map<String, Object> getMockSQParameterMap(int bits) {
+        Map<String, Object> encoderParams = Map.of(NAME, ENCODER_SQ, SQ_BITS, bits);
+        Map<String, Object> innerParams = Map.of(
+            METHOD_PARAMETER_EF_SEARCH,
+            24,
+            METHOD_PARAMETER_EF_CONSTRUCTION,
+            28,
+            METHOD_PARAMETER_M,
+            12,
+            METHOD_ENCODER_PARAMETER,
+            encoderParams
+        );
+        return Map.of(
+            INDEX_DESCRIPTION_PARAMETER,
+            "HNSW12,Flat",
+            SPACE_TYPE,
+            INNER_PRODUCT.getValue(),
+            NAME,
+            METHOD_HNSW,
+            VECTOR_DATA_TYPE_FIELD,
+            VectorDataType.FLOAT.getValue(),
+            PARAMETERS,
+            innerParams
+        );
+    }
+
     public void testBuildRequestFP16() throws IOException {
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethodTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethodTests.java
@@ -65,28 +65,36 @@ public class FaissHNSWMethodTests extends KNNTestCase {
         assertEquals(CompressionLevel.x2, sqEncoder.calculateCompressionLevel(mcc, null));
     }
 
-    public void testIsSQOneBitIndex_whenSQWithBits1Float_thenTrue() {
-        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 1), true);
+    public void testIsSQMosIndex_whenSQWithBits1Float_thenTrue() {
+        assertSQMosIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 1), true);
     }
 
-    public void testIsSQOneBitIndex_whenSQWithBits16Float_thenFalse() {
-        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 16), false);
+    public void testIsSQMosIndex_whenSQWithBits2Float_thenTrue() {
+        assertSQMosIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 2), true);
     }
 
-    public void testIsSQOneBitIndex_whenFlatEncoderFloat_thenFalse() {
-        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_FLAT, Map.of(), false);
+    public void testIsSQMosIndex_whenSQWithBits4Float_thenTrue() {
+        assertSQMosIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 4), true);
     }
 
-    public void testIsSQOneBitIndex_whenSQWithBits1Binary_thenFalse() {
-        assertSQOneBitIndex(VectorDataType.BINARY, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    public void testIsSQMosIndex_whenSQWithBits16Float_thenFalse() {
+        assertSQMosIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 16), false);
     }
 
-    public void testIsSQOneBitIndex_whenSQWithBits1Byte_thenFalse() {
-        assertSQOneBitIndex(VectorDataType.BYTE, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    public void testIsSQMosIndex_whenFlatEncoderFloat_thenFalse() {
+        assertSQMosIndex(VectorDataType.FLOAT, ENCODER_FLAT, Map.of(), false);
     }
 
-    public void testIsSQOneBitIndex_whenNoBitsParam_thenFalse() {
-        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(), false);
+    public void testIsSQMosIndex_whenSQWithBits1Binary_thenFalse() {
+        assertSQMosIndex(VectorDataType.BINARY, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    }
+
+    public void testIsSQMosIndex_whenSQWithBits1Byte_thenFalse() {
+        assertSQMosIndex(VectorDataType.BYTE, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    }
+
+    public void testIsSQMosIndex_whenNoBitsParam_thenFalse() {
+        assertSQMosIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(), false);
     }
 
     public void testIsFloat16Index_whenSQWithBits16Float_thenTrue() {
@@ -213,9 +221,9 @@ public class FaissHNSWMethodTests extends KNNTestCase {
         assertEquals(ENCODER_FLAT, encoderParams.get(NAME));
     }
 
-    private void assertSQOneBitIndex(VectorDataType dataType, String encoderName, Map<String, Object> encoderParams, boolean expected) {
+    private void assertSQMosIndex(VectorDataType dataType, String encoderName, Map<String, Object> encoderParams, boolean expected) {
         Map<String, Object> params = buildLibraryParametersMap(dataType, encoderName, encoderParams);
-        assertEquals(expected, FaissHNSWMethod.isSQOneBitIndex(dataType, params));
+        assertEquals(expected, FaissHNSWMethod.isSQMosIndex(dataType, params));
     }
 
     private void assertIsFloat16Index(VectorDataType dataType, String encoderName, Map<String, Object> encoderParams, boolean expected) {

--- a/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
@@ -72,6 +72,20 @@ public class FaissSQMappingIT extends KNNRestTestCase {
         deleteKNNIndex(indexName);
     }
 
+    /**
+     * Validates a multi-bit SQ ({@code bits ∈ {2, 4}}) index end-to-end: mapping is applied,
+     * documents index without error, and search returns the requested top-k. Correctness of
+     * ranking is a recall concern owned by benchmark tests; this smoke test only asserts the
+     * search path does not crash and returns k hits.
+     */
+    private void validateMultiBitIndex(String indexName, String mapping, Integer expectedBits) throws Exception {
+        createKnnIndex(indexName, mapping);
+        validateMapping(indexName, expectedBits, null, null);
+        addKNNDocs(indexName, FIELD_NAME, TEST_DIMENSION, 0, NUM_DOCS);
+        validateKNNSearch(indexName, FIELD_NAME, TEST_DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
     @SuppressWarnings("unchecked")
     private void validateMapping(String indexName, Integer expectedBits, String expectedType, Boolean expectedClip) throws Exception {
         Map<String, Object> actualMapping = getIndexMappingAsMap(indexName);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
@@ -12,12 +12,17 @@ import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
 /**
- * This is testing Faiss SQ 32x for all possible combinations.
+ * This is testing Faiss SQ for all supported memory-optimized-search widths
+ * (bits ∈ {1, 2, 4}, corresponding to compression x32, x16, x8).
  */
 public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     // These tests validate MOS off-heap behavior which is specific to the SQ code path.
     private static final String SQ_ENCODER_PARAMS = """
         {"encoder": {"name": "sq", "parameters": {"bits": 1}}}""";
+    private static final String SQ_TWO_BIT_ENCODER_PARAMS = """
+        {"encoder": {"name": "sq", "parameters": {"bits": 2}}}""";
+    private static final String SQ_FOUR_BIT_ENCODER_PARAMS = """
+        {"encoder": {"name": "sq", "parameters": {"bits": 4}}}""";
 
     @ExpectRemoteBuildValidation
     public void testNonNestedDiskBasedIndexWithIP() {
@@ -134,5 +139,153 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
         );
 
         // We don't support radial search for nested index
+    }
+
+    // --- SQ 2-bit (x16 compression) ---
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithIP_SQTwoBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithIP_SQTwoBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithL2_SQTwoBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithL2_SQTwoBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithCosine_SQTwoBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithCosine_SQTwoBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    // --- SQ 4-bit (x8 compression) ---
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithIP_SQFourBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithIP_SQFourBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithL2_SQFourBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithL2_SQFourBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithCosine_SQFourBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithCosine_SQFourBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
@@ -34,6 +34,39 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testCreate_whenSQTwoBitField_thenReturnsFaissScalarQuantizedFlatIndex() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=2").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNotNull(result);
+        assertTrue(result instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenSQFourBitField_thenReturnsFaissScalarQuantizedFlatIndex() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=4").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNotNull(result);
+        assertTrue(result instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenSQFP16Field_thenReturnsNull() {
+        // bits=16 is fp16 (not an MOS width); the flat proxy should not be wired.
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=16").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNull(result);
+    }
+
+    @SneakyThrows
     public void testCreate_whenNonSQField_thenReturnsNull() {
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
         FlatVectorsReader mockReader = mock(FlatVectorsReader.class);


### PR DESCRIPTION
### Description
  Enable the remote index build (RVIB) path for SQ multi-bit — bits ∈ {2, 4} — which previously only handled SQ 1-bit. The wire contract is identical across all three widths: the data node uploads fp32 vectors and RVIB constructs an HNSW graph over fp32 neighbors; quantization runs locally on the data node and the graph is stitched with the locally-quantized `.veq` at search time via `FaissFlatIndexFactory`.

### Related Issues
#3427 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
