### PR TITLE
Fix dimension-based oversampling not applying for 32x BQ compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Re-enable flaky BWC test testKNNWarmupCustomLegacyFieldMapping and restore legacy index settings in BWC test fixtures [#2415](https://github.com/opensearch-project/k-NN/issues/2415)
 
 ### Bug Fixes
+* Fix dimension-based oversampling not applying for 32x compression [#3455](https://github.com/opensearch-project/k-NN/pull/3455)
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -1275,10 +1275,83 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
     }
 
     /**
-     * Test segment with knn_vector field mapping but no docs containing the vector field.
-     * Creates a doc with both vector and text fields, then updates it to remove the vector field.
-     * Validates k-NN search functionality works without errors after upgrade with ON_DISK mode and compression.
+     * Test BWC for 32x compression (BQ) with dimension-based oversampling after upgrade.
+     * Indices created before 3.6.0 use BQ (binary quantization) for 32x compression.
+     * After upgrade, the dimension-based oversampling logic in getFirstPassK should apply
+     * regardless of the shard-level rescoring setting.
      */
+    public void testCompression32xDimensionBasedOversamplingRestartUpgrade() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        if (isModeAndCompressionSupported(getBWCVersion()) == false) {
+            return;
+        }
+
+        int dimension = 128;
+        int k = 10;
+
+        if (isRunningAgainstOldCluster()) {
+            String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES)
+                .startObject(TEST_FIELD)
+                .field(VECTOR_TYPE, KNN_VECTOR)
+                .field(DIMENSION, dimension)
+                .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x32.getName())
+                .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .startObject(KNN_METHOD)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(NAME, METHOD_HNSW)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .toString();
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping);
+            bulkIngestRandomVectors(testIndex, TEST_FIELD, 500, dimension);
+            flush(testIndex, true);
+        } else {
+            float[] queryVector = new float[dimension];
+            java.util.Arrays.fill(queryVector, 1.0f);
+
+            // Search with explain to verify dimension-based oversampling applies
+            String query = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(TEST_FIELD)
+                .field("vector", queryVector)
+                .field("k", k)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .toString();
+
+            Response response = performSearch(testIndex, query, "explain=true");
+            String responseBody = EntityUtils.toString(response.getEntity());
+
+            // For dim=128 (< 768), dimension-based oversampling should use 3x factor
+            // firstPassK = max(MIN_FIRST_PASS_RESULTS, ceil(k * 3.0)) = max(100, 30) = 100
+            assertTrue(
+                "Expected dimension-based oversampling to apply for 32x BQ index after upgrade",
+                responseBody.contains("the first pass k was 100")
+            );
+
+            // Verify same behavior with shard-level rescoring disabled
+            updateIndexSettings(testIndex, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            response = performSearch(testIndex, query, "explain=true");
+            responseBody = EntityUtils.toString(response.getEntity());
+            assertTrue(
+                "Expected dimension-based oversampling to apply with shard-level rescoring disabled",
+                responseBody.contains("the first pass k was 100")
+            );
+
+            deleteKNNIndex(testIndex);
+        }
+    }
+
     public void testVectorFieldRemovalByUpdateCompressionRestartUpgrade() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         if (isRunningAgainstOldCluster()) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -132,7 +132,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
         boolean needsRescore = shouldRescore(rescoreContext);
         if (needsRescore) {
             // Will always do shard level rescoring whenever rescore is required.
-            overSampledK = rescoreContext.getFirstPassK(k, false, getDimension(vector, byteVector));
+            overSampledK = rescoreContext.getFirstPassK(k, getDimension(vector, byteVector));
         }
 
         int luceneK = Math.max(overSampledK, IndexHyperParametersUtil.getHNSWEFSearchValue(methodParameters, indexName));

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -245,7 +245,7 @@ public abstract class KNNWeight extends Weight {
             isShardLevelRescoringDisabled = true;
         }
         int dimension = knnQuery.getQueryVector().length;
-        int firstPassK = knnQuery.getRescoreContext().getFirstPassK(knnQuery.getK(), isShardLevelRescoringDisabled, dimension);
+        int firstPassK = knnQuery.getRescoreContext().getFirstPassK(knnQuery.getK(), dimension);
         sb.append(" and the first pass k was ")
             .append(firstPassK)
             .append(" with vector dimension of ")

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -205,7 +205,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         if (rescoreContext != null && rescoreContext.isRescoreEnabled()) {
             // We need 2-phase search where using expanded `k` for the first stage search.
             final int dimension = knnQuery.getQueryVector().length;
-            return rescoreContext.getFirstPassK(knnQuery.getK(), isShardLevelRescoringDisabled, dimension);
+            return rescoreContext.getFirstPassK(knnQuery.getK(), dimension);
         }
 
         // We don't need 2-phase, hence there's no first pass k.

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -80,22 +80,19 @@ public final class RescoreContext {
 
     /**
      * Calculates the number of results to return for the first pass of rescoring (firstPassK).
-     * This method considers whether shard-level rescoring is enabled and adjusts the oversample factor
-     * based on the vector dimension if shard-level rescoring is disabled.
+     * Adjusts the oversample factor based on vector dimension when the factor was not explicitly
+     * provided by the user and the encoder allows override. Higher dimensions need less oversampling
+     * because quantization error is relatively smaller per-dimension.
      *
      * @param finalK The final number of results to return for the entire shard.
-     * @param isShardLevelRescoringDisabled A boolean flag indicating whether shard-level rescoring is disabled.
-     *                                     If false, the dimension-based oversampling logic is bypassed.
-     * @param dimension The dimension of the vector. This is used to determine the oversampling factor when
-     *                  shard-level rescoring is disabled.
+     * @param dimension The dimension of the vector. Used to determine the appropriate oversampling factor.
      * @return The number of results to return for the first pass of rescoring, adjusted by the oversample factor.
      */
-    public int getFirstPassK(int finalK, boolean isShardLevelRescoringDisabled, int dimension) {
-        // Only apply default dimension-based oversampling logic when:
-        // 1. Shard-level rescoring is disabled
-        // 2. The oversample factor was not provided by the user
-        if (isShardLevelRescoringDisabled && !userProvided && allowOverrideOversampleFactor) {
-            // Apply new dimension-based oversampling logic when shard-level rescoring is disabled
+    public int getFirstPassK(int finalK, int dimension) {
+        // Apply dimension-based oversampling when the oversample factor was not user-provided
+        // and the encoder allows override. This ensures high-dimensional vectors (which have
+        // lower relative quantization error) don't over-fetch candidates unnecessarily.
+        if (!userProvided && allowOverrideOversampleFactor) {
             if (dimension >= DIMENSION_THRESHOLD_1000) {
                 oversampleFactor = OVERSAMPLE_FACTOR_1000;  // No oversampling for dimensions >= 1000
             } else if (dimension >= DIMENSION_THRESHOLD_768) {
@@ -104,8 +101,17 @@ public final class RescoreContext {
                 oversampleFactor = OVERSAMPLE_FACTOR_BELOW_768;  // 3x oversampling for dimensions < 768
             }
         }
-        // The calculation for firstPassK remains the same, applying the oversample factor
         return Math.min(MAX_FIRST_PASS_RESULTS, Math.max(MIN_FIRST_PASS_RESULTS, (int) Math.ceil(finalK * oversampleFactor)));
+    }
+
+    /**
+     * @deprecated Use {@link #getFirstPassK(int, int)} instead. The {@code isShardLevelRescoringDisabled} parameter
+     * is no longer used — dimension-based oversampling now applies unconditionally when the oversample factor is not
+     * user-provided. This method will be removed in the next major version.
+     */
+    @Deprecated
+    public int getFirstPassK(int finalK, boolean isShardLevelRescoringDisabled, int dimension) {
+        return getFirstPassK(finalK, dimension);
     }
 
 }

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -212,7 +212,7 @@ public class ExplainTests extends KNNWeightTestCase {
             Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
             String[] expectedTopDescription = new String[] {
                 KNNConstants.DISK_BASED_SEARCH,
-                "the first pass k was " + rescoreContext.getFirstPassK(k, false, QUERY_VECTOR.length),
+                "the first pass k was " + rescoreContext.getFirstPassK(k, QUERY_VECTOR.length),
                 "over sampling factor of " + rescoreContext.getOversampleFactor(),
                 "with vector dimension of " + QUERY_VECTOR.length,
                 "shard level rescoring enabled" };
@@ -283,7 +283,7 @@ public class ExplainTests extends KNNWeightTestCase {
             Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
             String[] expectedTopDescription = new String[] {
                 KNNConstants.DISK_BASED_SEARCH,
-                "the first pass k was " + rescoreContext.getFirstPassK(0, true, queryVector.length),
+                "the first pass k was " + rescoreContext.getFirstPassK(0, queryVector.length),
                 "over sampling factor of " + rescoreContext.getOversampleFactor(),
                 "with vector dimension of " + queryVector.length,
                 "shard level rescoring disabled" };

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -330,7 +330,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         Map<Integer, Float> rescoredLeaf2Results = new HashMap<>(Map.of(0, 21f));
 
         RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(1.5f).build();
-        int firstPassK = rescoreContext.getFirstPassK(k, true, 1);
+        int firstPassK = rescoreContext.getFirstPassK(k, 1);
         when(knnQuery.getRescoreContext()).thenReturn(RescoreContext.builder().oversampleFactor(1.5f).build());
         when(knnQuery.getK()).thenReturn(k);
         when(knnWeight.getQuery()).thenReturn(knnQuery);
@@ -741,7 +741,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
             if (rescoreEnabled) {
                 RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(oversampleFactor).build();
                 when(knnQuery.getRescoreContext()).thenReturn(rescoreContext);
-                firstPassK = rescoreContext.getFirstPassK(k, isShardLevelRescoringDisabled, dimension);
+                firstPassK = rescoreContext.getFirstPassK(k, dimension);
             } else {
                 firstPassK = k;
             }
@@ -923,7 +923,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
                 when(knnQuery.getRescoreContext()).thenReturn(RescoreContext.getDefault());
             }
 
-            final int expectedExpandedK = RescoreContext.getDefault().getFirstPassK(k, isShardLevelRescoringDisabled, dimension);
+            final int expectedExpandedK = RescoreContext.getDefault().getFirstPassK(k, dimension);
             final MemoryOptimizedKNNWeight weight = mock(MemoryOptimizedKNNWeight.class);
             doAnswer(invocation -> {
                 // This will be invoked for reentrant search.

--- a/src/test/java/org/opensearch/knn/index/query/rescore/RescoreContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/rescore/RescoreContextTests.java
@@ -12,107 +12,113 @@ import static org.opensearch.knn.index.query.rescore.RescoreContext.MIN_FIRST_PA
 
 public class RescoreContextTests extends KNNTestCase {
 
-    public void testGetFirstPassK() {
+    public void testGetFirstPassK_userProvidedOversample_notOverriddenByDimension() {
         float oversample = 2.6f;
         RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(oversample).userProvided(true).build();
         int finalK = 100;
-        boolean isShardLevelRescoringDisabled = false;
+
+        assertEquals(260, rescoreContext.getFirstPassK(finalK, 500));
+        assertEquals(260, rescoreContext.getFirstPassK(finalK, 1200));
+    }
+
+    public void testGetFirstPassK_boundsCheck_minAndMax() {
+        float oversample = 2.6f;
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(oversample).userProvided(true).build();
+
+        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(1, 500));
+        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(0, 500));
+        assertEquals(MAX_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(MAX_FIRST_PASS_RESULTS, 500));
+    }
+
+    public void testGetFirstPassK_dimensionAbove1000_oversampleIs1x() {
+        int finalK = 100;
+        int dimension = 1024;
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(3.0f).userProvided(false).build();
+
+        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, dimension));
+    }
+
+    public void testGetFirstPassK_dimension768to999_oversampleIs2x() {
+        int finalK = 100;
+        int dimension = 800;
+        // Regardless of initial oversampleFactor, dimension-based logic sets it to 2.0
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(3.0f).userProvided(false).build();
+
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, dimension));
+    }
+
+    public void testGetFirstPassK_dimensionBelow768_oversampleIs3x() {
+        int finalK = 100;
         int dimension = 500;
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(1.0f).userProvided(false).build();
 
-        // Case 1: Test with standard oversample factor when shard-level rescoring is enabled
-        assertEquals(260, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
-
-        // Case 2: Test with a very small finalK that should result in a value less than MIN_FIRST_PASS_RESULTS
-        finalK = 1;
-        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
-
-        // Case 3: Test with finalK = 0, should return MIN_FIRST_PASS_RESULTS
-        finalK = 0;
-        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
-
-        // Case 4: Test with finalK = MAX_FIRST_PASS_RESULTS, should cap at MAX_FIRST_PASS_RESULTS
-        finalK = MAX_FIRST_PASS_RESULTS;
-        assertEquals(MAX_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
+        assertEquals(300, rescoreContext.getFirstPassK(finalK, dimension));
     }
 
-    public void testGetFirstPassKWithDimensionBasedOversampling() {
+    public void testGetFirstPassK_dimensionExactly768_oversampleIs2x() {
         int finalK = 100;
-        int dimension;
+        int dimension = 768;
+        RescoreContext rescoreContext = RescoreContext.builder().userProvided(false).build();
 
-        // Case 1: Test no oversampling for dimensions >= 1000 when shard-level rescoring is disabled
-        dimension = 1000;
-        RescoreContext rescoreContext = RescoreContext.builder().userProvided(false).build();  // Ensuring dimension-based logic applies
-        assertEquals(100, rescoreContext.getFirstPassK(finalK, true, dimension));  // No oversampling
-
-        // Case 2: Test 2x oversampling for dimensions >= 768 but < 1000 when shard-level rescoring is disabled
-        dimension = 800;
-        rescoreContext = RescoreContext.builder().userProvided(false).build();  // Ensure previous values don't carry over
-        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, dimension));  // 2x oversampling
-
-        // Case 3: Test 3x oversampling for dimensions < 768 when shard-level rescoring is disabled
-        dimension = 700;
-        rescoreContext = RescoreContext.builder().userProvided(false).build();  // Ensure previous values don't carry over
-        assertEquals(300, rescoreContext.getFirstPassK(finalK, true, dimension));  // 3x oversampling
-
-        // Case 4: Shard-level rescoring enabled, oversample factor should be used as provided by the user (ignore dimension)
-        rescoreContext = RescoreContext.builder().oversampleFactor(5.0f).userProvided(true).build();  // Provided by user
-        dimension = 500;
-        assertEquals(500, rescoreContext.getFirstPassK(finalK, false, dimension));  // User-defined oversample factor should be used
-
-        // Case 5: Test finalK where oversampling factor results in a value less than MIN_FIRST_PASS_RESULTS
-        finalK = 10;
-        dimension = 700;
-        rescoreContext = RescoreContext.builder().userProvided(false).build();  // Ensure dimension-based logic applies
-        assertEquals(100, rescoreContext.getFirstPassK(finalK, true, dimension));  // 3x oversampling results in 30
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, dimension));
     }
 
-    public void testGetFirstPassKWithMinPassK() {
-        float oversample = 0.5f;
-        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(oversample).userProvided(true).build();  // User provided
-        boolean isShardLevelRescoringDisabled = true;
+    public void testGetFirstPassK_dimensionExactly1000_oversampleIs1x() {
+        int finalK = 100;
+        int dimension = 1000;
+        RescoreContext rescoreContext = RescoreContext.builder().userProvided(false).build();
 
-        // Case 1: Test where finalK * oversample is smaller than MIN_FIRST_PASS_RESULTS
-        int finalK = 10;
-        int dimension = 700;
-        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
-
-        // Case 2: Test where finalK * oversample results in exactly MIN_FIRST_PASS_RESULTS
-        finalK = 100;
-        oversample = 1.0f;  // This will result in exactly 100 (MIN_FIRST_PASS_RESULTS)
-        rescoreContext = RescoreContext.builder().oversampleFactor(oversample).userProvided(true).build();  // User provided
-        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
+        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, dimension));
     }
 
-    public void testGetFirstPassK_whenAllowOverrideOversampleFactorIsFalse_thenDimensionBasedOverrideIsSkipped() {
-        // Simulates SQ encoder behavior: oversampleFactor is fixed and should NOT be overridden by dimension-based logic
-        float oversample = RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR; // 2.0f
+    public void testGetFirstPassK_userProvided_neverOverriddenByDimension() {
+        int finalK = 100;
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(5.0f).userProvided(true).build();
+
+        assertEquals(500, rescoreContext.getFirstPassK(finalK, 500));
+        assertEquals(500, rescoreContext.getFirstPassK(finalK, 1200));
+    }
+
+    public void testGetFirstPassK_whenAllowOverrideIsFalse_thenDimensionBasedOverrideIsSkipped() {
+        float oversample = RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR;
         int finalK = 100;
 
-        // Even though shard-level rescoring is disabled and userProvided is false,
-        // allowOverrideOversampleFactor=false should prevent dimension-based override
         RescoreContext rescoreContext = RescoreContext.builder()
             .oversampleFactor(oversample)
             .userProvided(false)
             .allowOverrideOversampleFactor(false)
             .build();
 
-        // dimension < 768 would normally trigger 3x oversampling, but allowOverrideOversampleFactor=false keeps it at 2x
-        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, 500));
+        // dimension < 768 would normally trigger 3x, but allowOverrideOversampleFactor=false keeps it at 2x
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, 500));
 
-        // dimension >= 768 && < 1000 would normally trigger 2x, stays at 2x (same value but for different reason)
         rescoreContext = RescoreContext.builder()
             .oversampleFactor(oversample)
             .userProvided(false)
             .allowOverrideOversampleFactor(false)
             .build();
-        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, 800));
+        // dimension >= 1000 would normally trigger 1x, but stays at 2x
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, 1200));
+    }
 
-        // dimension >= 1000 would normally trigger 1x (no oversampling), but stays at 2x
-        rescoreContext = RescoreContext.builder()
-            .oversampleFactor(oversample)
-            .userProvided(false)
-            .allowOverrideOversampleFactor(false)
-            .build();
-        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, 1200));
+    public void testGetFirstPassK_smallFinalK_clampedToMin() {
+        int finalK = 10;
+        int dimension = 700;
+        RescoreContext rescoreContext = RescoreContext.builder().userProvided(false).build();
+
+        assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, dimension));
+    }
+
+    @SuppressWarnings("deprecation")
+    public void testGetFirstPassK_deprecatedMethodDelegatesToNewMethod() {
+        int finalK = 100;
+        int dimension = 500;
+        RescoreContext rescoreContext = RescoreContext.builder().userProvided(false).build();
+
+        // Deprecated 3-arg method should produce same result regardless of boolean value
+        assertEquals(rescoreContext.getFirstPassK(finalK, dimension), rescoreContext.getFirstPassK(finalK, false, dimension));
+
+        rescoreContext = RescoreContext.builder().userProvided(false).build();
+        assertEquals(rescoreContext.getFirstPassK(finalK, dimension), rescoreContext.getFirstPassK(finalK, true, dimension));
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/DimensionBasedOversamplingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DimensionBasedOversamplingIT.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+/**
+ * Integration test verifying dimension-based oversampling applies correctly for disk-based
+ * vector indices with 16x compression. Uses 16x because 32x resolves to SQ(bits=1) on 3.6+
+ * which explicitly disables dimension-based override via allowOverrideOversampleFactor=false.
+ */
+public class DimensionBasedOversamplingIT extends KNNRestTestCase {
+
+    private static final String INDEX_NAME = "dimension-oversampling-test";
+    private static final String FIELD_NAME = "test_vector";
+    private static final int NUM_DOCS = 500;
+
+    @SneakyThrows
+    public void testOversamplingFactor_whenDimAbove1000_thenFirstPassKEqualsMinPassResults() {
+        int dimension = 1024;
+        try {
+            createDiskBased16xIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplain(dimension, 10);
+            assertFirstPassK(explanation, RescoreContext.MIN_FIRST_PASS_RESULTS);
+
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            String explanationDisabled = searchWithExplain(dimension, 10);
+            assertFirstPassK(explanationDisabled, RescoreContext.MIN_FIRST_PASS_RESULTS);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    @SneakyThrows
+    public void testOversamplingFactor_whenDim768to999_thenFirstPassKUses2xFactor() {
+        int dimension = 800;
+        try {
+            createDiskBased16xIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanation, 200);
+
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            String explanationDisabled = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanationDisabled, 200);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    @SneakyThrows
+    public void testOversamplingFactor_whenDimBelow768_thenFirstPassKUses3xFactor() {
+        int dimension = 128;
+        try {
+            createDiskBased16xIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanation, 300);
+
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            String explanationDisabled = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanationDisabled, 300);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    @SneakyThrows
+    public void testOversamplingFactor_whenUserProvided_thenNotOverridden() {
+        int dimension = 1024;
+        float userOversample = 5.0f;
+        try {
+            createDiskBased16xIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplainAndOversample(dimension, 100, userOversample);
+            assertFirstPassK(explanation, 500);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    @SneakyThrows
+    public void testOversamplingFactor_32xBQ_whenDimAbove1000_thenFirstPassKEqualsMinPassResults() {
+        int dimension = 1024;
+        try {
+            createDiskBased32xBQIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplain(dimension, 10);
+            assertFirstPassK(explanation, RescoreContext.MIN_FIRST_PASS_RESULTS);
+
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            String explanationDisabled = searchWithExplain(dimension, 10);
+            assertFirstPassK(explanationDisabled, RescoreContext.MIN_FIRST_PASS_RESULTS);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    @SneakyThrows
+    public void testOversamplingFactor_32xBQ_whenDim768to999_thenFirstPassKUses2xFactor() {
+        int dimension = 800;
+        try {
+            createDiskBased32xBQIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanation, 200);
+
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            String explanationDisabled = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanationDisabled, 200);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    @SneakyThrows
+    public void testOversamplingFactor_32xBQ_whenDimBelow768_thenFirstPassKUses3xFactor() {
+        int dimension = 128;
+        try {
+            createDiskBased32xBQIndex(dimension);
+            bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME, NUM_DOCS, dimension);
+            refreshIndex(INDEX_NAME);
+
+            String explanation = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanation, 300);
+
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, true));
+            String explanationDisabled = searchWithExplain(dimension, 100);
+            assertFirstPassK(explanationDisabled, 300);
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    private void createDiskBased16xIndex(int dimension) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, "on_disk")
+            .field(COMPRESSION_LEVEL_PARAMETER, "16x")
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        Settings settings = Settings.builder().put(KNN_INDEX, true).build();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+    }
+
+    private void createDiskBased32xBQIndex(int dimension) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, "on_disk")
+            .field(COMPRESSION_LEVEL_PARAMETER, "32x")
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .startObject(PARAMETERS)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "binary")
+            .startObject(PARAMETERS)
+            .field("bits", 1)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        Settings settings = Settings.builder().put(KNN_INDEX, true).build();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+    }
+
+    private String searchWithExplain(int dimension, int k) throws IOException, ParseException {
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, 1.0f);
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = performSearch(INDEX_NAME, queryBuilder.toString(), "explain=true");
+        return EntityUtils.toString(response.getEntity());
+    }
+
+    private String searchWithExplainAndOversample(int dimension, int k, float oversample) throws IOException, ParseException {
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, 1.0f);
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field("k", k)
+            .startObject("rescore")
+            .field("oversample_factor", oversample)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = performSearch(INDEX_NAME, queryBuilder.toString(), "explain=true");
+        return EntityUtils.toString(response.getEntity());
+    }
+
+    private void assertFirstPassK(String responseBody, int expectedFirstPassK) {
+        String expectedString = "the first pass k was " + expectedFirstPassK;
+        assertTrue("Expected explain to contain '" + expectedString + "' but got: " + responseBody, responseBody.contains(expectedString));
+    }
+}

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -226,7 +226,7 @@ public class RecallTestsIT extends KNNCompressionRestTestCase {
                     .endObject()
                     .endObject();
                 createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), builder.toString());
-                assertRecall(indexName, spaceType, 0.4f);
+                assertRecall(indexName, spaceType, 0.6f);
             }
         }
     }
@@ -364,7 +364,7 @@ public class RecallTestsIT extends KNNCompressionRestTestCase {
                     .endObject()
                     .endObject();
                 createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), builder.toString());
-                assertRecall(indexName, spaceType, 0.4f);
+                assertRecall(indexName, spaceType, 0.6f);
             }
         }
     }


### PR DESCRIPTION
### Description

Fix dimension-based oversampling factor not being applied for 32x compression when shard-level rescoring is enabled (the default).

The dimension-based oversampling logic in `RescoreContext.getFirstPassK()` was gated behind `isShardLevelRescoringDisabled`, which defaults to `false`. This meant the dimension-aware code never executed under normal conditions, and the static 3x oversampling factor from the enum default was always used — regardless of vector dimension.

For high-dimensional vectors (dim >= 1000), quantization error is relatively smaller per-dimension, so oversampling provides diminishing returns. The intended behavior is:
- **dim >= 1000**: 1x (no oversampling)
- **dim 768-999**: 2x oversampling  
- **dim < 768**: 3x oversampling

**Before fix:** dim=1024, k=100 → `firstPassK = ceil(100 * 3.0) = 300` → 3x 
**After fix:** dim=1024, k=10 → `firstPassK = ceil(10 * 1.0) = 10` → correct

The fix removes the `isShardLevelRescoringDisabled` condition since dimension-based oversampling is a property of the data geometry, not the rescoring architecture. The remaining guards (`!userProvided && allowOverrideOversampleFactor`) correctly protect:
- User-provided oversample factors (never overridden)
- SQ 1-bit encoder's fixed 2x factor (`allowOverrideOversampleFactor=false`)

#### No regression for `isShardLevelRescoringDisabled = true`

When `isShardLevelRescoringDisabled = true`, the old code already entered the dimension-based block (the condition evaluated to `true && true && true`). After this fix, the same block is still entered — the only difference is that it's no longer skipped when the setting is `false`. The dimension-based factors (1x, 2x, 3x) are identical in both cases, so behavior is unchanged for users who had explicitly set `shard_level_rescoring_disabled = true`.

| Setting | Before fix | After fix |
|---------|-----------|-----------|
| `false` (default) | Dimension logic **skipped**, always 3x | Dimension logic **applies** correctly |
| `true` (explicit) | Dimension logic applies correctly | Dimension logic applies correctly (**no change**) |

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).