### PR TITLE
[SQ PR-6] Set default oversample factor for SQ 2-bit/4-bit to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
-* Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4} [#3432](https://github.com/opensearch-project/k-NN/pull/3432)
 * Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4} [#3459](https://github.com/opensearch-project/k-NN/pull/3459)
+* Set default oversample factor to 1 for SQ 2-bit and 4-bit encoders (x16 / x8 compression) [#3463](https://github.com/opensearch-project/k-NN/pull/3463)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)
 
 ### Bug Fixes
+* 
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.common;
 
+import org.opensearch.Version;
 import org.opensearch.knn.index.VectorDataType;
 
 import java.util.List;
@@ -220,4 +221,10 @@ public class KNNConstants {
     public static final int BYTE_ALIGNMENT_MASK = 7; // Used for rounding up to nearest byte (Byte.SIZE - 1)
     // Define here: https://github.com/opensearch-project/remote-vector-index-builder/blob/main/API.md#index-parameters
     public static final int MIN_DOCS_FOR_REMOTE_INDEX_BUILD = 4;
+
+    // Version gate for flipping the default oversample factor to 1.0 for SQ 2-bit / SQ 4-bit
+    // indices at x16 / x8 compression. Indices created before this version keep the legacy
+    // dimension-based oversample defaults.
+    // TODO: bump this to Version.V_3_9_0 once it is defined in OpenSearch core.
+    public static final Version SQ_MULTI_BIT_X16_X8_DEFAULTS_FLIP_VERSION = Version.V_3_8_0;
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
+import static org.opensearch.knn.common.KNNConstants.SQ_MULTI_BIT_X16_X8_DEFAULTS_FLIP_VERSION;
+
 /**
  * Enum representing the compression level for float vectors. Compression in this sense refers to compressing a
  * full precision value into a smaller number of bits. For instance. "16x" compression would mean that 2 bits would
@@ -127,8 +129,8 @@ public enum CompressionLevel {
         return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, false, engine);
     }
 
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod, boolean isSQOneBit) {
-        return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, isSQOneBit, null);
+    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod, boolean isSQMultiBit) {
+        return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, isSQMultiBit, null);
     }
 
     @VisibleForTesting
@@ -141,11 +143,22 @@ public enum CompressionLevel {
         int dimension,
         Version version,
         boolean isFlatMethod,
-        boolean isSQOneBit,
+        boolean isSQMultiBit,
         VectorSearchEngine engine
     ) {
-        // For sq(bits=1) encoder, use fixed oversample factor.
-        if (isSQOneBit) {
+        // For multi-bit SQ encoders (bits ∈ {1, 2, 4}), use a fixed oversample factor and disallow
+        // overrides. On indices created on/after the flip version, x16 (bits=2) and x8 (bits=4)
+        // default to oversample=1 since higher-bit codes recover most recall on their own; older
+        // indices and x32 (bits=1) keep the existing Faiss SQ factor.
+        // TODO: bump the x16/x8 gate to Version.V_3_9_0 once it is defined in OpenSearch core.
+        if (isSQMultiBit) {
+            if ((this == x16 || this == x8) && version.onOrAfter(SQ_MULTI_BIT_X16_X8_DEFAULTS_FLIP_VERSION)) {
+                return RescoreContext.builder()
+                    .oversampleFactor(RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR)
+                    .allowOverrideOversampleFactor(false)
+                    .userProvided(false)
+                    .build();
+            }
             return RescoreContext.builder()
                 .oversampleFactor(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR)
                 .allowOverrideOversampleFactor(false)
@@ -158,7 +171,7 @@ public enum CompressionLevel {
         }
         if (modesForRescore.contains(mode)) {
             if (engine != null) {
-                final RescoreContext rescoreContext = engine.getRescoreContext(this, mode, dimension, version, isFlatMethod, isSQOneBit);
+                final RescoreContext rescoreContext = engine.getRescoreContext(this, mode, dimension, version, isFlatMethod, isSQMultiBit);
                 if (rescoreContext != null) {
                     return rescoreContext;
                 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -184,7 +184,7 @@ public class KNNVectorFieldType extends MappedFieldType {
         final Optional<KNNMethodContext> methodContext = knnMappingConfig.getKnnMethodContext();
         final boolean isFlatMethod = methodContext.isPresent()
             && METHOD_FLAT.equals(methodContext.get().getMethodComponentContext().getName());
-        final boolean isSQOneBit = methodContext.map(mc -> FaissSQEncoder.isSQOneBit(mc.getMethodComponentContext().getParameters()))
+        final boolean isSQMultiBit = methodContext.map(mc -> FaissSQEncoder.isSQMultiBit(mc.getMethodComponentContext().getParameters()))
             .orElse(false);
         final int dimension = knnMappingConfig.getDimension();
         final CompressionLevel compressionLevel = knnMappingConfig.getCompressionLevel();
@@ -198,7 +198,7 @@ public class KNNVectorFieldType extends MappedFieldType {
             dimension,
             knnMappingConfig.getIndexCreatedVersion(),
             isFlatMethod,
-            isSQOneBit,
+            isSQMultiBit,
             engine
         );
     }

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -26,6 +26,7 @@ public final class RescoreContext {
 
     public static final float OVERSAMPLE_FACTOR_DEFAULT_FOR_LUCENE_SCALAR_QUANTIZER_AFTER_V360 = 2.0f;
     public static final float OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD = 5.0f;
+    public static final float SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR = 1.0f;
 
     // Dimension thresholds for adjusting oversample factor
     public static final int DIMENSION_THRESHOLD_1000 = 1000;

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -217,6 +217,44 @@ public class CompressionLevelTests extends KNNTestCase {
         assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
     }
 
+    public void testGetDefaultRescoreContext_whenSQMultiBitAtX16_thenOversampleOne() {
+        // sq(bits=2) at x16 on indices created at/after the flip version should return oversample=1
+        // (2-bit codes recover most recall on their own), with override disallowed.
+        // TODO: bump the gate to Version.V_3_9_0 once it is defined in OpenSearch core.
+        for (int dimension : new int[] { 500, 1500 }) {
+            RescoreContext rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(
+                Mode.ON_DISK,
+                dimension,
+                Version.V_3_8_0,
+                false,
+                true
+            );
+            assertNotNull("dim=" + dimension, rescoreContext);
+            assertEquals("dim=" + dimension, 1.0f, rescoreContext.getOversampleFactor(), 0.0f);
+            assertFalse("dim=" + dimension, rescoreContext.isUserProvided());
+            assertFalse("dim=" + dimension, rescoreContext.isAllowOverrideOversampleFactor());
+        }
+    }
+
+    public void testGetDefaultRescoreContext_whenSQMultiBitAtX8_thenOversampleOne() {
+        // sq(bits=4) at x8 on indices created at/after the flip version should return oversample=1
+        // (4-bit codes are near-lossless), with override disallowed.
+        // TODO: bump the gate to Version.V_3_9_0 once it is defined in OpenSearch core.
+        for (int dimension : new int[] { 500, 1500 }) {
+            RescoreContext rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(
+                Mode.ON_DISK,
+                dimension,
+                Version.V_3_8_0,
+                false,
+                true
+            );
+            assertNotNull("dim=" + dimension, rescoreContext);
+            assertEquals("dim=" + dimension, 1.0f, rescoreContext.getOversampleFactor(), 0.0f);
+            assertFalse("dim=" + dimension, rescoreContext.isUserProvided());
+            assertFalse("dim=" + dimension, rescoreContext.isAllowOverrideOversampleFactor());
+        }
+    }
+
     public void testX32MapsToOneBitQuantization() {
         assertEquals(1, CompressionLevel.x32.numBitsForFloat32());
 


### PR DESCRIPTION
### Description
Set the default oversample factor to 1 for both SQ 2-bit/4-bit (override disallowed). Existing x32 (SQ 1-bit) behavior is unchanged. Version-gated so the flip only affects indices created on/after 3.9(for now set to 3.8, will change to 3.9 later).

### Related Issues
#3427 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
