### PR TITLE
Fix _source bloat on merge for derived source with _source.exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix corrupt index file when remote build falls back to local build [#3448](https://github.com/opensearch-project/k-NN/pull/3448)
 * Fix radial search max_distance threshold conversion for inner product with memory-optimized search [#3369](https://github.com/opensearch-project/k-NN/pull/3369)
 * Fix inner-hits returning mask value for top level source excludes [#3446](https://github.com/opensearch-project/k-NN/pull/3446)
+* Fix _source bloat on merge for derived source indices with _source.exclude [#3465](https://github.com/opensearch-project/k-NN/pull/3465)
 
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -160,10 +160,26 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
      * @return wrapped stored fields reader
      */
     public static StoredFieldsReader wrapForMerge(StoredFieldsReader storedFieldsReader) {
-        if (storedFieldsReader instanceof KNN10010DerivedSourceStoredFieldsReader) {
+        if (optimizedForMerge(storedFieldsReader)) {
             return ((KNN10010DerivedSourceStoredFieldsReader) storedFieldsReader).cloneForMerge();
         }
         return storedFieldsReader;
+    }
+
+    /**
+     * Whether the given reader can take the optimized (block-copy) merge path. This is the single
+     * source of truth for recognizing a reader whose stored _source is already masked: only a bare
+     * {@link KNN10010DerivedSourceStoredFieldsReader} qualifies. Any other reader - for example the
+     * {@code RecoverySourcePruningStoredFieldsReader} that OpenSearch wraps ours in when a
+     * {@code _source.exclude} is configured - hides our reader, so the merge must fall back to the
+     * generic path. Both {@link #wrapForMerge(StoredFieldsReader)} and the writer's merge-path
+     * decision use this check so they stay in sync.
+     *
+     * @param storedFieldsReader reader for a source segment being merged
+     * @return true if the reader is a bare {@link KNN10010DerivedSourceStoredFieldsReader}
+     */
+    static boolean optimizedForMerge(StoredFieldsReader storedFieldsReader) {
+        return storedFieldsReader instanceof KNN10010DerivedSourceStoredFieldsReader;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -33,6 +33,7 @@ import org.opensearch.knn.index.util.IndexUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -169,7 +170,16 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
      */
     @Override
     public int merge(MergeState mergeState) throws IOException {
+        // Legacy segments are merged by the legacy codec, so fall through to the generic merge.
         if (KNN9120DerivedSourceStoredFieldsReader.doesMergeContainLegacySegments(mergeState)) {
+            return super.merge(mergeState);
+        }
+
+        // If any source reader is not our own reader (e.g. wrapped by RecoverySourcePruneMergePolicy
+        // when _source.exclude is set), we cannot guarantee its stored _source is masked, so use the
+        // generic super.merge() which re-applies the mask via writeField() instead of block-copying.
+        if (requiresFallbackMerge(mergeState.storedFieldsReaders)) {
+            maybeWrapReadersForMerge(mergeState);
             return super.merge(mergeState);
         }
 
@@ -190,9 +200,7 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
             }
         }
 
-        for (int i = 0; i < mergeState.storedFieldsReaders.length; i++) {
-            mergeState.storedFieldsReaders[i] = KNN10010DerivedSourceStoredFieldsReader.wrapForMerge(mergeState.storedFieldsReaders[i]);
-        }
+        maybeWrapReadersForMerge(mergeState);
 
         int result = delegate.merge(mergeState);
 
@@ -207,6 +215,39 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
         mergeState.segmentInfo.putAttribute(KNN10010DerivedSourceStoredFieldsFormat.KNN_DELEGATE_CODEC_NAME, name);
 
         return result;
+    }
+
+    /**
+     * Determines whether the merge must take the full, field-by-field {@code super.merge()} path
+     * instead of the optimized {@code delegate.merge()} block copy.
+     * <p>
+     * The optimized path only preserves the vector mask when every source segment's stored fields
+     * reader is our own {@link KNN10010DerivedSourceStoredFieldsReader} (so its stored _source is
+     * already masked and the reader can be made non-injecting via {@code wrapForMerge()}). If any
+     * reader is something else - most notably OpenSearch's
+     * {@code RecoverySourcePruningStoredFieldsReader}, which wraps our reader when a
+     * {@code _source.exclude} is configured - we cannot see through it to guarantee the _source is
+     * masked, so we fall back to the full merge.
+     *
+     * @param storedFieldsReaders the source segment stored-fields readers for the merge
+     * @return true if any source reader is not a bare {@link KNN10010DerivedSourceStoredFieldsReader}
+     */
+    private static boolean requiresFallbackMerge(StoredFieldsReader[] storedFieldsReaders) {
+        return Arrays.stream(storedFieldsReaders).anyMatch(reader -> !KNN10010DerivedSourceStoredFieldsReader.optimizedForMerge(reader));
+    }
+
+    /**
+     * Replaces each source reader with a non-injecting clone via
+     * {@link KNN10010DerivedSourceStoredFieldsReader#wrapForMerge(StoredFieldsReader)} so the merge
+     * does not re-inject vectors into the stored _source. Readers that are not our own k-NN reader
+     * (e.g. a recovery wrapper) are passed through unchanged.
+     *
+     * @param mergeState state for the merge in progress
+     */
+    private static void maybeWrapReadersForMerge(MergeState mergeState) {
+        for (int i = 0; i < mergeState.storedFieldsReaders.length; i++) {
+            mergeState.storedFieldsReaders[i] = KNN10010DerivedSourceStoredFieldsReader.wrapForMerge(mergeState.storedFieldsReaders[i]);
+        }
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -6,10 +6,14 @@
 package org.opensearch.knn.index.codec.KNN10010Codec;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.InfoStream;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -31,6 +35,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -132,5 +137,71 @@ public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
 
         assertEquals(List.of(fieldName), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false));
         verify(delegate).finish(1);
+    }
+
+    @SneakyThrows
+    public void testMerge_whenNonKnnReaderPresent_thenFallsBackToGenericMerge() {
+        // When a source reader is not our own reader (e.g. the recovery wrapper introduced by
+        // _source.exclude), merge() must NOT take the optimized delegate.merge() block-copy path -
+        // it falls back to the generic super.merge(), which re-applies the vector mask per document.
+        StoredFieldsWriter delegate = mock(StoredFieldsWriter.class);
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fieldTypes()).thenReturn(Collections.emptyList());
+
+        KNN10010DerivedSourceStoredFieldsWriter writer = new KNN10010DerivedSourceStoredFieldsWriter(
+            "mock-codec",
+            delegate,
+            segmentInfo,
+            mapperService
+        );
+
+        // A single non-k-NN reader with no documents (maxDoc = 0), so super.merge() has no work to do.
+        StoredFieldsReader nonKnnReader = mock(StoredFieldsReader.class);
+        MergeState mergeState = mergeStateWithReaders(nonKnnReader);
+
+        int docCount = writer.merge(mergeState);
+
+        assertEquals(0, docCount);
+        // Fallback path: the delegate's optimized merge must never be invoked.
+        verify(delegate, never()).merge(any());
+        // The reader is left in place (not wrapped) because it is not our k-NN reader.
+        assertSame(nonKnnReader, mergeState.storedFieldsReaders[0]);
+    }
+
+    /**
+     * Builds a minimal {@link MergeState} that only populates the fields merge() and the generic
+     * super.merge() touch for empty (maxDoc = 0) segments: the readers, per-reader field infos, doc
+     * maps, and maxDocs. Everything else is left null.
+     */
+    private static MergeState mergeStateWithReaders(StoredFieldsReader... readers) {
+        int n = readers.length;
+        MergeState.DocMap[] docMaps = new MergeState.DocMap[n];
+        FieldInfos[] fieldInfos = new FieldInfos[n];
+        int[] maxDocs = new int[n];
+        for (int i = 0; i < n; i++) {
+            docMaps[i] = docId -> docId;
+            fieldInfos[i] = new FieldInfos(new FieldInfo[0]);
+            maxDocs[i] = 0;
+        }
+        return new MergeState(
+            docMaps,
+            null,
+            new FieldInfos(new FieldInfo[0]),
+            readers,
+            null,
+            null,
+            null,
+            fieldInfos,
+            null,
+            null,
+            null,
+            null,
+            maxDocs,
+            InfoStream.NO_OUTPUT,
+            Runnable::run,
+            false,
+            null
+        );
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReaderTests.java
@@ -5,12 +5,22 @@
 
 package org.opensearch.knn.index.codec.KNN10010Codec;
 
+import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.opensearch.index.fieldvisitor.FieldsVisitor;
 import org.opensearch.knn.KNNTestCase;
 
+import static org.mockito.Mockito.mock;
+
 public class KNN10010DerivedSourceStoredFieldsReaderTests extends KNNTestCase {
+
+    public void testOptimizedForMerge() {
+        // Only our own reader is recognized as already-masked and mergeable via the optimized path;
+        // any other reader (e.g. a recovery wrapper) forces the generic merge fallback.
+        assertTrue(KNN10010DerivedSourceStoredFieldsReader.optimizedForMerge(mock(KNN10010DerivedSourceStoredFieldsReader.class)));
+        assertFalse(KNN10010DerivedSourceStoredFieldsReader.optimizedForMerge(mock(StoredFieldsReader.class)));
+    }
 
     public void testResolveExcludes_usesCodecExcludesNotResponseExcludes() {
         // Response-level excludes strip the vector from the top-level _source, but codec excludes omit it

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.integ;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Before;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -843,6 +844,215 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             indexWithWildcardExcludes,
             new String[] { VECTOR_FIELD_1, TEXT_FIELD },
             new String[] { VECTOR_FIELD_2 }
+        );
+    }
+
+    /**
+     * Regression test for https://github.com/opensearch-project/k-NN/issues/3316.
+     *
+     * When derived source is enabled AND the mapping filters _source (e.g. _source.excludes on an
+     * unrelated field), a segment merge used to re-inject the vector back into the stored _source,
+     * durably bloating the merged segment. This verifies that after a force-merge:
+     *   - a derived-source index that excludes an unrelated keyword field stays roughly the size of
+     *     the equivalent derived-source index with no exclude (i.e. the vector is NOT re-injected), and
+     *   - it is meaningfully smaller than the same index with derived source disabled (where the full
+     *     vector really is stored in _source), and
+     *   - search still returns the full reconstructed vector and omits the excluded field.
+     */
+    @SneakyThrows
+    public void testDerivedSource_withSourceExclude_doesNotAddVectorsInSourceOnMerge() {
+        String vectorField = "test_vector";
+        String excludedKeywordField = "label";
+        int dimension = 128;
+        int docCount = 500;
+
+        String derivedExclude = getIndexName("source-exclude-merge", "derived-exclude", false);
+        String nonDerivedExclude = getIndexName("source-exclude-merge", "nonderived-exclude", false);
+        String derivedNoExclude = getIndexName("source-exclude-merge", "derived-noexclude", false);
+
+        createSourceExcludeIndex(derivedExclude, vectorField, excludedKeywordField, dimension, true, true);
+        createSourceExcludeIndex(nonDerivedExclude, vectorField, excludedKeywordField, dimension, false, true);
+        createSourceExcludeIndex(derivedNoExclude, vectorField, excludedKeywordField, dimension, true, false);
+
+        // Index the same docs into each index, refreshing in batches so multiple segments are created.
+        Random random = new Random(1234);
+        for (int i = 1; i <= docCount; i++) {
+            float[] vector = new float[dimension];
+            for (int d = 0; d < dimension; d++) {
+                vector[d] = random.nextFloat();
+            }
+            String docId = String.valueOf(i);
+            String doc = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(vectorField, vector)
+                .field(excludedKeywordField, "label-" + i)
+                .endObject()
+                .toString();
+            addKnnDoc(derivedExclude, docId, doc);
+            addKnnDoc(nonDerivedExclude, docId, doc);
+            addKnnDoc(derivedNoExclude, docId, doc);
+            if (i % 100 == 0) {
+                refreshIndex(derivedExclude);
+                refreshIndex(nonDerivedExclude);
+                refreshIndex(derivedNoExclude);
+            }
+        }
+
+        forceMergeKnnIndex(derivedExclude, 1);
+        forceMergeKnnIndex(nonDerivedExclude, 1);
+        forceMergeKnnIndex(derivedNoExclude, 1);
+
+        // Correctness (the #2472 guard): a search fetching 10+ adjacent documents still reconstructs
+        // the full vector into _source, and the excluded field is absent.
+        assertVectorPresentAndFieldExcluded(derivedExclude, vectorField, excludedKeywordField, dimension, 20);
+
+        // kNN search must return identical top-k results across all three indices - the fix must not
+        // change what the vector index returns, only what is stored in _source.
+        float[] queryVector = new float[dimension];
+        Random queryRandom = new Random(4321);
+        for (int d = 0; d < dimension; d++) {
+            queryVector[d] = queryRandom.nextFloat();
+        }
+        int k = 10;
+        List<String> derivedExcludeIds = knnSearchDocIds(derivedExclude, vectorField, queryVector, k);
+        List<String> nonDerivedExcludeIds = knnSearchDocIds(nonDerivedExclude, vectorField, queryVector, k);
+        List<String> derivedNoExcludeIds = knnSearchDocIds(derivedNoExclude, vectorField, queryVector, k);
+
+        assertEquals("Expected k results from derived+exclude index", k, derivedExcludeIds.size());
+        assertEquals(
+            "derived+exclude and non-derived+exclude indices should return the same top-k docs",
+            nonDerivedExcludeIds,
+            derivedExcludeIds
+        );
+        assertEquals(
+            "derived+exclude and derived+no-exclude indices should return the same top-k docs",
+            derivedNoExcludeIds,
+            derivedExcludeIds
+        );
+
+        // Size assertions are only meaningful in exhaustive mode; mirror the existing size checks.
+        if (isExhaustive()) {
+            int derivedExcludeSize = indexSizeInBytes(derivedExclude);
+            int nonDerivedExcludeSize = indexSizeInBytes(nonDerivedExclude);
+            int derivedNoExcludeSize = indexSizeInBytes(derivedNoExclude);
+
+            // The bug's signature: with the fix, the derived+exclude index must stay well below the
+            // non-derived index (which really stores the full vector in _source).
+            assertTrue(
+                String.format(
+                    Locale.ROOT,
+                    "derived+exclude index (%d bytes) should be smaller than non-derived+exclude index (%d bytes)",
+                    derivedExcludeSize,
+                    nonDerivedExcludeSize
+                ),
+                derivedExcludeSize < nonDerivedExcludeSize
+            );
+
+            // Excluding an unrelated field should not inflate the derived index relative to the
+            // no-exclude baseline. Allow modest overhead (recovery source is out of scope here) but
+            // it must be far below the full-vector size.
+            assertTrue(
+                String.format(
+                    Locale.ROOT,
+                    "derived+exclude index (%d bytes) should stay close to derived+no-exclude baseline (%d bytes),"
+                        + " not bloat toward the non-derived size (%d bytes)",
+                    derivedExcludeSize,
+                    derivedNoExcludeSize,
+                    nonDerivedExcludeSize
+                ),
+                derivedExcludeSize < derivedNoExcludeSize + (nonDerivedExcludeSize - derivedNoExcludeSize) / 2
+            );
+        }
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private void assertVectorPresentAndFieldExcluded(String indexName, String vectorField, String excludedField, int dimension, int size) {
+        XContentBuilder searchBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("size", size)
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Request searchRequest = new Request("POST", "/" + indexName + "/_search");
+        searchRequest.setJsonEntity(searchBuilder.toString());
+        Response response = client().performRequest(searchRequest);
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        Map<String, Object> hits = (Map<String, Object>) responseMap.get("hits");
+        List<Map<String, Object>> hitsList = (List<Map<String, Object>>) hits.get("hits");
+
+        assertTrue("Expected at least 10 hits to exercise the sequential fetch path", hitsList.size() >= 10);
+        for (Map<String, Object> hit : hitsList) {
+            Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+            assertTrue(
+                String.format(Locale.ROOT, "Vector field '%s' should be reconstructed into _source", vectorField),
+                source.containsKey(vectorField)
+            );
+            assertEquals(
+                String.format(Locale.ROOT, "Reconstructed vector '%s' should have full dimension", vectorField),
+                dimension,
+                ((List<Object>) source.get(vectorField)).size()
+            );
+            assertFalse(
+                String.format(Locale.ROOT, "Excluded field '%s' should be absent from _source", excludedField),
+                source.containsKey(excludedField)
+            );
+        }
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private List<String> knnSearchDocIds(String indexName, String vectorField, float[] queryVector, int k) {
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(vectorField)
+            .field("vector", queryVector)
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = searchKNNIndex(indexName, queryBuilder, k);
+        List<Object> hits = parseSearchResponseHits(EntityUtils.toString(response.getEntity()));
+
+        List<String> docIds = new ArrayList<>();
+        for (Object hit : hits) {
+            docIds.add((String) ((Map<String, Object>) hit).get("_id"));
+        }
+        return docIds;
+    }
+
+    @SneakyThrows
+    private void createSourceExcludeIndex(
+        String indexName,
+        String vectorField,
+        String excludedKeywordField,
+        int dimension,
+        boolean derivedSourceEnabled,
+        boolean withExclude
+    ) {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject();
+        if (withExclude) {
+            mapping.startObject("_source").array("excludes", excludedKeywordField).endObject();
+        }
+        mapping.startObject(KNNConstants.PROPERTIES)
+            .startObject(vectorField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mapping);
+        mapping.endObject().startObject(excludedKeywordField).field(KNNConstants.TYPE, "keyword").endObject().endObject().endObject();
+
+        createKnnIndex(
+            indexName,
+            Settings.builder().put("index.knn", true).put("index.knn.derived_source.enabled", derivedSourceEnabled).build(),
+            mapping.toString()
         );
     }
 


### PR DESCRIPTION
### Description
When k-NN derived source is enabled and the mapping filters _source (via _source.excludes/includes), OpenSearch writes a _recovery_source marker on every document. That marker causes RecoverySourcePruneMergePolicy to wrap the k-NN stored-fields reader in a RecoverySourcePruningStoredFieldsReader during merge. The wrapper hides our reader from the instanceof checks in KNN10010DerivedSourceStoredFieldsWriter.merge(), so wrapForMerge() never makes the reader non-injecting. The optimized delegate.merge() block-copy then reconstructs the vector back into the stored _source, durably bloating the merged segment 

This change makes merge() fall back to the generic super.merge() whenever any source reader is not a bare KNN10010DerivedSourceStoredFieldsReader (e.g. a recovery wrapper). super.merge() routes each document through this writer's writeField(), which re-applies the vector mask, so the vector never lands in the merged _source. The common case (no _source.exclude) is unchanged and keeps the optimized delegate.merge() path. Bare k-NN readers on the fallback path are still made non-injecting so they skip the reconstruct-then-strip round trip. Legacy segments continue to fall through to super.merge() directly.

KNN10010DerivedSourceStoredFieldsReader.optimizedForMerge() is the single source of truth for recognizing a bare k-NN reader; both wrapForMerge() and the writer's merge-path decision use it so they stay in sync.

Tests:
- Unit (DerivedSourceStoredFieldsWriterTests): merge() falls back to the generic
  super.merge() (delegate.merge() is never called) when a non-k-NN reader is
  present, and leaves that reader unwrapped.
- Unit (KNN10010DerivedSourceStoredFieldsReaderTests): optimizedForMerge() is
  true only for a bare k-NN reader.
- Integ (DerivedSourceIT.testDerivedSource_withSourceExclude_doesNotAddVectorsInSourceOnMerge):
  force-merges three indices with the same 500 docs (derived+exclude,
  non-derived+exclude, derived+no-exclude) and asserts (a) a 10+ doc fetch on
  the derived+exclude index still reconstructs the full vector into _source with
  the excluded field absent, (b) kNN search with k=10 returns identical top-k
  docs across all three indices, and (c) in exhaustive mode the derived+exclude
  index stays near the no-exclude baseline and well below the non-derived size.

### Related Issues
#3316 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
