### PR TITLE
[SQ PR-7] Support method=flat with SQ 2-bit / 4-bit (x16 / x8) and make it engine-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
 * Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4} [#3459](https://github.com/opensearch-project/k-NN/pull/3459)
 * Set default oversample factor to 1 for SQ 2-bit and 4-bit encoders (x16 / x8 compression) [#3463](https://github.com/opensearch-project/k-NN/pull/3463)
+* Support flat with x8 and x16 compression and make `method=flat` engine-agnostic [#3471](https://github.com/opensearch-project/k-NN/pull/3471)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)
 
 ### Bug Fixes
-* 
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class LuceneFlatBWCIT extends AbstractRestartUpgradeTestCase {
+
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 8;
+    private static final int NUM_DOCS = 10;
+    private static final int K = 5;
+
+    /**
+     * Old cluster creates a flat mapping WITH engine=lucene explicitly set (legal on the old cluster).
+     * After upgrade to a version that enforces engine-agnostic flat, the persisted mapping — which
+     * still carries engine=lucene — must continue to load, be searchable, and accept new docs.
+     */
+    public void testFlatWithExplicitLuceneEngine_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        // Only meaningful when the old cluster still accepts engine on method=flat.
+        // Once the old cluster is on the engine-agnostic gate version or later, it rejects the
+        // mapping itself and there is no pre-gate → post-gate transition to exercise.
+        if (isFlatMethodEnginePermittedOnOldCluster(getBWCVersion()) == false) {
+            logger.info("Skipping test — flat + explicit engine not accepted by old cluster in version: {}", getBWCVersion());
+            return;
+        }
+
+        if (isRunningAgainstOldCluster()) {
+            XContentBuilder mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(TEST_FIELD)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(NAME, METHOD_FLAT)
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping.toString());
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+            forceMergeKnnIndex(testIndex);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+            deleteKNNIndex(testIndex);
+        }
+    }
+}

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class LuceneFlatBWCIT extends AbstractRollingUpgradeTestCase {
+
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 8;
+    private static final int NUM_DOCS = 10;
+    private static final int K = 5;
+
+    /**
+     * Rolling upgrade variant of the flat + explicit engine BWC check. The old cluster creates a
+     * flat mapping with engine=lucene explicitly set. As nodes roll to the new version that
+     * enforces engine-agnostic flat, the mapping (which still carries engine=lucene) must
+     * continue to load, be searchable in mixed and upgraded phases.
+     */
+    public void testRollingUpgrade_flatWithExplicitLuceneEngine() throws Exception {
+        // Only meaningful when the old cluster still accepts engine on method=flat.
+        // Once the old cluster is on the engine-agnostic gate version or later, it rejects the
+        // mapping itself and there is no pre-gate → post-gate transition to exercise.
+        if (isFlatMethodEnginePermittedOnOldCluster(getBWCVersion()) == false) {
+            logger.info("Skipping test — flat + explicit engine not accepted by old cluster in version: {}", getBWCVersion());
+            return;
+        }
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        switch (getClusterType()) {
+            case OLD:
+                XContentBuilder mapping = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(TEST_FIELD)
+                    .field("type", "knn_vector")
+                    .field("dimension", DIMENSION)
+                    .startObject(KNN_METHOD)
+                    .field(NAME, METHOD_FLAT)
+                    .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                    .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping.toString());
+                addKNNDocs(testIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+                flush(testIndex, true);
+                break;
+
+            case MIXED:
+                validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+                break;
+
+            case UPGRADED:
+                validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+                addKNNDocs(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+                forceMergeKnnIndex(testIndex);
+                validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+                deleteKNNIndex(testIndex);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -227,4 +227,10 @@ public class KNNConstants {
     // dimension-based oversample defaults.
     // TODO: bump this to Version.V_3_9_0 once it is defined in OpenSearch core.
     public static final Version SQ_MULTI_BIT_X16_X8_DEFAULTS_FLIP_VERSION = Version.V_3_8_0;
+
+    // Version gate for rejecting user-supplied engine on method=flat mappings. Indices created
+    // before this version may have engine=lucene persisted in their flat mapping — they must
+    // continue to load without error. New indices reject any engine setting on flat.
+    // TODO: bump this to Version.V_3_9_0 once it is defined in OpenSearch core.
+    public static final Version FLAT_METHOD_ENGINE_AGNOSTIC_VERSION = Version.V_3_8_0;
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040BasePerFieldKnnVectorsFormat.java
@@ -92,7 +92,14 @@ public abstract class KNN1040BasePerFieldKnnVectorsFormat extends PerFieldKnnVec
         final Map<String, Object> params = knnMethodContext.getMethodComponentContext().getParameters();
 
         if (engine == KNNEngine.LUCENE) {
-            return luceneFormatResolver.resolve(field, knnMethodContext, params, defaultMaxConnections, defaultBeamWidth);
+            return luceneFormatResolver.resolve(
+                field,
+                knnMethodContext,
+                params,
+                defaultMaxConnections,
+                defaultBeamWidth,
+                knnMappingConfig.getCompressionLevel()
+            );
         }
 
         // Native engines — pass params so the resolver can detect SQ encoder

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -26,6 +26,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.faiss.FaissCodecFormatResolver;
 import org.opensearch.knn.index.engine.lucene.LuceneCodecFormatResolver;
 import org.opensearch.knn.index.engine.lucene.LuceneSQEncoder;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 import java.util.Optional;
@@ -101,7 +102,10 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 p.getConfidenceInterval(),
                 merge.v2()
             );
-        }, LuceneVectorsFormatType.FLAT, ctx -> new KNN1040ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE));
+        },
+            LuceneVectorsFormatType.FLAT,
+            ctx -> new KNN1040ScalarQuantizedVectorsFormat(resolveFlatScalarEncoding(ctx.getCompressionLevel()))
+        );
     }
 
     @Override
@@ -115,5 +119,23 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
         }
         return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
+    }
+
+    /**
+     * Picks the {@link ScalarEncoding} for the FLAT format from the field's compression level.
+     * x32 → 1-bit ({@code SINGLE_BIT_QUERY_NIBBLE}), x16 → 2-bit ({@code DIBIT_QUERY_NIBBLE}),
+     * x8 → 4-bit ({@code PACKED_NIBBLE}). Any other value (including {@code NOT_CONFIGURED},
+     * which the resolver maps to x32) falls back to 1-bit. {@link LuceneFlatMethodResolver}
+     * rejects unsupported compression levels at mapping time so an unexpected value here would
+     * indicate an upstream invariant violation.
+     */
+    private static ScalarEncoding resolveFlatScalarEncoding(final CompressionLevel compressionLevel) {
+        if (compressionLevel == CompressionLevel.x8) {
+            return ScalarEncodingResolver.forDocBits(4);
+        }
+        if (compressionLevel == CompressionLevel.x16) {
+            return ScalarEncodingResolver.forDocBits(2);
+        }
+        return ScalarEncodingResolver.forDocBits(1);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KnnVectorsFormatContext.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KnnVectorsFormatContext.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec;
 
 import lombok.Value;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 
@@ -43,4 +44,10 @@ public class KnnVectorsFormatContext {
      * Default beam width if not specified in params.
      */
     int defaultBeamWidth;
+
+    /**
+     * Resolved compression level for the field (may be {@link CompressionLevel#NOT_CONFIGURED}).
+     * Used by the FLAT format factory to pick the correct scalar-quantization encoding.
+     */
+    CompressionLevel compressionLevel;
 }

--- a/src/main/java/org/opensearch/knn/index/engine/CodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/CodecFormatResolver.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.engine;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 
@@ -32,6 +33,24 @@ public interface CodecFormatResolver {
         int defaultMaxConnections,
         int defaultBeamWidth
     );
+
+    /**
+     * Overload that additionally threads the resolved {@link CompressionLevel} through. Needed by
+     * the Lucene FLAT format factory to pick the correct scalar-quantization encoding when the
+     * user selects {@code method=flat} with x8 / x16 / x32 compression. Default implementation
+     * delegates to {@link #resolve(String, KNNMethodContext, Map, int, int)} so engines that do
+     * not consume the compression level (e.g., Faiss) don't need to override.
+     */
+    default KnnVectorsFormat resolve(
+        String field,
+        KNNMethodContext methodContext,
+        Map<String, Object> params,
+        int defaultMaxConnections,
+        int defaultBeamWidth,
+        CompressionLevel compressionLevel
+    ) {
+        return resolve(field, methodContext, params, defaultMaxConnections, defaultBeamWidth);
+    }
 
     KnnVectorsFormat resolve();
 }

--- a/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
@@ -17,6 +17,8 @@ import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.Locale;
 
+import static org.opensearch.knn.common.KNNConstants.FLAT_METHOD_ENGINE_AGNOSTIC_VERSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.index.engine.KNNEngine.DEPRECATED_ENGINES;
 
@@ -80,6 +82,13 @@ public final class EngineResolver {
         boolean requiresTraining,
         Version version
     ) {
+        // Flat method is engine-agnostic from the user's perspective: it always resolves to
+        // Lucene internally. Reject ANY user-provided engine (method-level or top-level, even if
+        // it happens to be Lucene) — but only for indices created on/after the gate version.
+        // Pre-gate indices may have engine=lucene persisted in their flat mapping and must
+        // continue to load without error.
+        rejectEngineForMethodFlat(knnMethodContext, topLevelEngineString, version);
+
         KNNEngine userConfiguredEngine = resolveAndValidateUserConfiguredEngine(
             knnMethodContext,
             topLevelEngineString,
@@ -118,6 +127,26 @@ public final class EngineResolver {
             return resolveEngineForX1OrNoCompression(mode, version);
         }
         return KNNEngine.FAISS;
+    }
+
+    private void rejectEngineForMethodFlat(KNNMethodContext knnMethodContext, String topLevelEngineString, Version version) {
+        final boolean isFlatMethod = knnMethodContext != null
+            && METHOD_FLAT.equalsIgnoreCase(knnMethodContext.getMethodComponentContext().getName());
+        if (isFlatMethod == false) {
+            return;
+        }
+        // Skip the reject for pre-gate indices so existing flat mappings with engine=lucene
+        // persisted from earlier versions keep loading.
+        if (version != null && version.before(FLAT_METHOD_ENGINE_AGNOSTIC_VERSION)) {
+            return;
+        }
+        // Flat is engine-agnostic — do not accept any user-provided engine, even if it happens
+        // to match the internally-resolved one.
+        if (hasUserConfiguredMethodEngine(knnMethodContext) || hasUserConfiguredTopLevelEngine(topLevelEngineString)) {
+            throw new MapperParsingException(
+                String.format(Locale.ROOT, "[%s] method does not support [%s] parameter", METHOD_FLAT, KNN_ENGINE)
+            );
+        }
     }
 
     private boolean hasUserConfiguredMethodEngine(KNNMethodContext knnMethodContext) {

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
@@ -227,7 +228,11 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(KNN_ENGINE, knnEngine.getName());
+        // Flat is engine-agnostic; do not serialize a resolved engine — the round-trip parse
+        // would otherwise be flagged as a user-supplied engine and rejected.
+        if (METHOD_FLAT.equalsIgnoreCase(methodComponentContext.getName()) == false) {
+            builder.field(KNN_ENGINE, knnEngine.getName());
+        }
         builder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
         builder = methodComponentContext.toXContent(builder, params);
         return builder;

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -12,6 +12,7 @@ import org.opensearch.knn.index.codec.LuceneVectorsFormatType;
 import org.opensearch.knn.index.codec.params.KNNScalarQuantizedVectorsFormatParams;
 import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -55,12 +56,26 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
         int defaultMaxConnections,
         int defaultBeamWidth
     ) {
+        return resolve(field, methodContext, params, defaultMaxConnections, defaultBeamWidth, CompressionLevel.NOT_CONFIGURED);
+    }
+
+    @Override
+    public KnnVectorsFormat resolve(
+        String field,
+        KNNMethodContext methodContext,
+        Map<String, Object> params,
+        int defaultMaxConnections,
+        int defaultBeamWidth,
+        CompressionLevel compressionLevel
+    ) {
         LuceneVectorsFormatType formatType = determineFormatType(field, methodContext, params, defaultMaxConnections, defaultBeamWidth);
         Function<KnnVectorsFormatContext, KnnVectorsFormat> factory = formatResolvers.get(formatType);
         if (factory == null) {
             throw new IllegalStateException(String.format("No Lucene vectors format registered for type [%s]", formatType));
         }
-        return factory.apply(new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth));
+        return factory.apply(
+            new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth, compressionLevel)
+        );
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolver.java
@@ -24,13 +24,20 @@ import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 import static org.opensearch.knn.index.engine.lucene.LuceneFlatMethod.FLAT_METHOD_COMPONENT;
 
 /**
- * Resolves method configuration for the Lucene flat method. The flat method uses SQ (1-bit quantization)
- * without an HNSW graph, supporting only {@link org.opensearch.knn.index.mapper.CompressionLevel#x32} compression
- * and does not support {@link org.opensearch.knn.index.mapper.Mode}.
+ * Resolves method configuration for the Lucene flat method. The flat method uses scalar quantization
+ * without an HNSW graph (brute-force scan). Supported compression levels are
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel#x32} (SQ 1-bit),
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel#x16} (SQ 2-bit), and
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel#x8} (SQ 4-bit).
+ * {@link org.opensearch.knn.index.mapper.Mode} is not supported.
  */
 public class LuceneFlatMethodResolver extends AbstractMethodResolver {
 
-    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS = Set.of(CompressionLevel.x32);
+    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS = Set.of(
+        CompressionLevel.x32,
+        CompressionLevel.x16,
+        CompressionLevel.x8
+    );
     static final CompressionLevel DEFAULT_COMPRESSION = CompressionLevel.x32;
 
     @Override
@@ -92,7 +99,12 @@ public class LuceneFlatMethodResolver extends AbstractMethodResolver {
             if (!SUPPORTED_COMPRESSION_LEVELS.contains(compressionLevel)) {
                 ValidationException validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format(Locale.ROOT, "\"%s\" method only supports \"%s\" compression", METHOD_FLAT, DEFAULT_COMPRESSION.getName())
+                    String.format(
+                        Locale.ROOT,
+                        "[%s] method only supports these compression levels: [%s] ",
+                        METHOD_FLAT,
+                        SUPPORTED_COMPRESSION_LEVELS.stream().map(CompressionLevel::getName).sorted().toList()
+                    )
                 );
                 throw validationException;
             }

--- a/src/test/java/org/opensearch/knn/index/LuceneSQFlatIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneSQFlatIT.java
@@ -116,22 +116,29 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testFlatMethod_withFaissEngine_thenFail() {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject(PROPERTIES_FIELD)
-            .startObject(FIELD_NAME)
-            .field(TYPE_FIELD, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, METHOD_FLAT)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
-        expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, builder.toString()));
+    public void testFlatMethod_withExplicitEngine_thenFail() {
+        // Flat method is engine-agnostic — any user-supplied engine (even lucene) must be rejected.
+        for (KNNEngine engine : new KNNEngine[] { KNNEngine.LUCENE, KNNEngine.FAISS }) {
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(FIELD_NAME)
+                .field(TYPE_FIELD, KNN_VECTOR_TYPE)
+                .field(DIMENSION_FIELD, DIMENSION)
+                .startObject(KNNConstants.KNN_METHOD)
+                .field(KNNConstants.NAME, METHOD_FLAT)
+                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .field(KNNConstants.KNN_ENGINE, engine.getName())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            expectThrows(
+                ResponseException.class,
+                String.format(Locale.ROOT, "Expected failure for engine %s with flat method", engine.getName()),
+                () -> createKnnIndex(INDEX_NAME, builder.toString())
+            );
+        }
     }
 
     @SneakyThrows
@@ -145,7 +152,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .startObject(KNNConstants.PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, 16)
             .endObject()
@@ -158,7 +164,7 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testFlatMethod_withUnsupportedCompression_thenFail() {
-        String[] unsupportedCompressions = { "1x", "2x", "4x", "8x", "16x", "64x" };
+        String[] unsupportedCompressions = { "1x", "2x", "4x", "64x" };
         for (String compression : unsupportedCompressions) {
             XContentBuilder builder = XContentFactory.jsonBuilder()
                 .startObject()
@@ -170,7 +176,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, METHOD_FLAT)
                 .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-                .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .endObject()
                 .endObject()
                 .endObject()
@@ -197,7 +202,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, METHOD_FLAT)
                 .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-                .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .endObject()
                 .endObject()
                 .endObject()
@@ -259,7 +263,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .startObject(COLOR_FIELD_NAME)
@@ -319,7 +322,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -367,7 +369,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -394,7 +395,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .endObject()

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -300,6 +300,70 @@ public class EngineResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveEngine_whenFlatMethodWithExplicitLuceneEngine_thenThrow() {
+        // Flat is engine-agnostic — passing engine=lucene explicitly is rejected too.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            true
+        );
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, null, false)
+        );
+        assertTrue(ex.getMessage().contains(METHOD_FLAT));
+        assertTrue(ex.getMessage().toLowerCase(java.util.Locale.ROOT).contains("engine"));
+    }
+
+    public void testResolveEngine_whenFlatMethodWithNonLuceneMethodEngine_thenThrow() {
+        // Flat method + engine=faiss → mapping-time error.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            true
+        );
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, null, false)
+        );
+        assertTrue(ex.getMessage().contains(METHOD_FLAT));
+        assertTrue(ex.getMessage().toLowerCase(java.util.Locale.ROOT).contains("engine"));
+    }
+
+    public void testResolveEngine_whenFlatMethodWithTopLevelEngine_thenThrow() {
+        // Flat method + any top-level engine (Lucene or not) → mapping-time error.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.UNDEFINED,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            false
+        );
+        for (KNNEngine topLevel : new KNNEngine[] { KNNEngine.LUCENE, KNNEngine.FAISS }) {
+            MapperParsingException ex = expectThrows(
+                MapperParsingException.class,
+                () -> ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, topLevel.getName(), false)
+            );
+            assertTrue("topLevel=" + topLevel, ex.getMessage().contains(METHOD_FLAT));
+            assertTrue("topLevel=" + topLevel, ex.getMessage().toLowerCase(java.util.Locale.ROOT).contains("engine"));
+        }
+    }
+
+    public void testResolveEngine_whenFlatMethodWithPreGateVersion_thenLucene() {
+        // Pre-gate flat mappings that had engine=lucene persisted must still resolve without throwing.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            true
+        );
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, null, false, Version.V_3_7_0)
+        );
+    }
+
     public void testResolveEngine_whenOnDiskWith32xCompression_thenFaiss() {
         assertEquals(
             KNNEngine.FAISS,

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolverTests.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 
@@ -64,9 +65,50 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
         assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
     }
 
+    public void testResolveMethod_whenFlatMethodWithX16Compression_thenResolve() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of())
+        );
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            flatMethodContext,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x16)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(METHOD_FLAT, resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getName());
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenFlatMethodWithX8Compression_thenResolve() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.INNER_PRODUCT,
+            new MethodComponentContext(METHOD_FLAT, Map.of())
+        );
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            flatMethodContext,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x8)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        assertEquals(METHOD_FLAT, resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getName());
+        assertEquals(CompressionLevel.x8, resolvedMethodContext.getCompressionLevel());
+    }
+
     public void testResolveMethod_whenFlatMethodWithUnsupportedCompression_thenThrow() {
+        final Set<CompressionLevel> supported = Set.of(CompressionLevel.x8, CompressionLevel.x16, CompressionLevel.x32);
         for (CompressionLevel level : CompressionLevel.values()) {
-            if (level == CompressionLevel.x32 || level == CompressionLevel.NOT_CONFIGURED) {
+            if (supported.contains(level) || level == CompressionLevel.NOT_CONFIGURED) {
                 continue;
             }
             KNNMethodContext flatMethodContext = new KNNMethodContext(
@@ -74,7 +116,7 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
                 SpaceType.L2,
                 new MethodComponentContext(METHOD_FLAT, Map.of())
             );
-            expectThrows(
+            ValidationException ex = expectThrows(
                 ValidationException.class,
                 () -> TEST_RESOLVER.resolveMethod(
                     flatMethodContext,
@@ -87,6 +129,13 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
                     SpaceType.L2
                 )
             );
+            final String msg = ex.getMessage();
+            assertTrue("level=" + level + " msg=" + msg, msg.contains("[" + METHOD_FLAT + "]"));
+            assertTrue("level=" + level + " msg=" + msg, msg.contains("only supports these compression levels"));
+            // The message should list the supported levels — spot-check each name is present.
+            for (CompressionLevel supportedLevel : supported) {
+                assertTrue("level=" + level + " supportedLevel=" + supportedLevel + " msg=" + msg, msg.contains(supportedLevel.getName()));
+            }
         }
     }
 

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -773,7 +773,6 @@ public class RecallTestsIT extends KNNCompressionRestTestCase {
                 .field(DIMENSION, TEST_DIMENSION)
                 .startObject(KNN_METHOD)
                 .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-                .field(KNN_ENGINE, LUCENE_NAME)
                 .field(NAME, METHOD_FLAT)
                 .endObject()
                 .endObject()

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -2844,6 +2844,25 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Returns true when the BWC old-cluster version still accepts an explicit engine on method=flat.
+     * The reject was introduced in {@link org.opensearch.knn.common.KNNConstants#FLAT_METHOD_ENGINE_AGNOSTIC_VERSION}.
+     * Tests that verify the pre-gate → post-gate BWC path must only run when the old cluster
+     * predates the gate (otherwise the old cluster itself rejects the mapping).
+     */
+    protected boolean isFlatMethodEnginePermittedOnOldCluster(final Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get();
+        if (versionString.endsWith("-SNAPSHOT")) {
+            versionString = versionString.substring(0, versionString.length() - 9);
+        }
+        final Version version = Version.fromString(versionString);
+        return version.onOrAfter(Version.V_3_6_0)
+            && version.before(org.opensearch.knn.common.KNNConstants.FLAT_METHOD_ENGINE_AGNOSTIC_VERSION);
+    }
+
+    /**
      * Generates a random lowercase string with length between MIN_CODE_UNITS and MAX_CODE_UNITS.
      * This method is used for test fixtures to generate random string values that can be used
      * as identifiers, names, or other string-based test data.


### PR DESCRIPTION
### Description
  Extends `method=flat` to support SQ 2-bit and 4-bit and makes it fully engine-agnostic for new indices.

  - `LuceneFlatMethodResolver` now accepts `x8`, `x16`, and `x32` compression (in addition to the prior `x32`-only path). Unsupported levels throw a clearer message: `[flat] method only supports these compression levels: [...]`.
  - The resolved `CompressionLevel` is threaded through `CodecFormatResolver` / `KnnVectorsFormatContext` to the FLAT format factory in `KNN1040PerFieldKnnVectorsFormat`, which picks the scalar encoding: `x32 → SINGLE_BIT_QUERY_NIBBLE`, `x16 → DIBIT_QUERY_NIBBLE`, `x8 → PACKED_NIBBLE`. Non-Lucene engines are
  unaffected via a default overload.
  - `EngineResolver` now rejects any user-supplied engine (method-level or top-level, including `engine=lucene`) when `method=flat` with a `MapperParsingException`: `[flat] method does not support [engine] parameter`. Internal resolution still routes flat → LUCENE.
  - The reject is version-gated by `FLAT_METHOD_ENGINE_AGNOSTIC_VERSION` (`V_3_8_0`, TODO to bump to `V_3_9_0` when defined). Indices created before this version — which may already have `engine: lucene` persisted in their flat mappings — continue to load, be searchable, and accept writes without error.
  - `KNNMethodContext.toXContent` no longer serializes the `engine` field for `method=flat`, keeping the mapping round-trip idempotent (the resolver stamps `LUCENE` in memory; the persisted mapping stays engine-free).

### Related Issues
#3427 

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
