### PR TITLE
Bump up timeout for parameterized tests

### DIFF
--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -12,14 +12,12 @@
 package org.opensearch.knn.index;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.VectorUtil;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
@@ -88,7 +86,6 @@ import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class FaissIT extends KNNCompressionRestTestCase {
 
     public FaissIT(CompressionTestConfig compressionConfig) {

--- a/src/testFixtures/java/org/opensearch/knn/KNNCompressionRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNCompressionRestTestCase.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import org.apache.lucene.tests.util.TimeUnits;
 import lombok.SneakyThrows;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -36,6 +38,7 @@ import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
  * Provides parameterization infrastructure, helper methods for index creation with compression,
  * and assertion helpers that adapt to compression-specific thresholds.
  */
+@TimeoutSuite(millis = 90 * TimeUnits.MINUTE)
 public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
 
     private static final int DEFAULT_HNSW_M = 16;


### PR DESCRIPTION
### Description
- Increase timeout for parameterized tests due to timeout based test failures
- https://ci.opensearch.org/ci/dbc/integ-test/3.8.0/12115/linux/arm64/deb/test-results/11484/integ-test/k-NN/without-security/stdout.txt

### Related Issues
Resolves #3475 

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
