### PR TITLE
Fix knn query against a field alias returning zero hits silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix inner-hits returning mask value for top level source excludes [#3446](https://github.com/opensearch-project/k-NN/pull/3446)
 * Fix _source bloat on merge for derived source indices with _source.exclude [#3465](https://github.com/opensearch-project/k-NN/pull/3465)
 * Disable radial search on quantized indices due to poor recall from quantization error [#3448](https://github.com/opensearch-project/k-NN/pull/3448)
+* Fix knn query against a field alias returning zero hits silently [#3485](https://github.com/opensearch-project/k-NN/pull/3485)
 
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -436,6 +436,12 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not knn_vector type.", this.fieldName));
         }
         KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldType) mappedFieldType;
+        // A field alias is mapping-only metadata and never appears in Lucene's FieldInfos, which is what the
+        // segment-level lookup in KNNWeight consults. MappedFieldType#name() is the concrete field name after alias
+        // resolution, so use it for everything that reaches the segment; a query built on the alias name would
+        // otherwise find no field info and return no hits at all. Error messages deliberately keep this.fieldName so
+        // they still name the field the user actually typed. The null fallback mirrors core's CommonTermsQueryBuilder.
+        final String resolvedFieldName = mappedFieldType.name() != null ? mappedFieldType.name() : this.fieldName;
         KNNMappingConfig knnMappingConfig = knnVectorFieldType.getKnnMappingConfig();
         QueryConfigFromMapping queryConfigFromMapping = getQueryConfig(knnMappingConfig, knnVectorFieldType);
 
@@ -545,7 +551,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             KNNQueryFactory.CreateQueryRequest createQueryRequest = KNNQueryFactory.CreateQueryRequest.builder()
                 .knnEngine(knnEngine)
                 .indexName(indexName)
-                .fieldName(this.fieldName)
+                .fieldName(resolvedFieldName)
                 .vector(getFloatVectorForCreatingQueryRequest(transformedQueryVector, vectorDataType, knnEngine))
                 .originalVector(vector)
                 .byteVector(getByteVectorForCreatingQueryRequest(vectorDataType, byteVector))
@@ -564,7 +570,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             RNNQueryFactory.CreateQueryRequest createQueryRequest = RNNQueryFactory.CreateQueryRequest.builder()
                 .knnEngine(knnEngine)
                 .indexName(indexName)
-                .fieldName(this.fieldName)
+                .fieldName(resolvedFieldName)
                 .vector(getFloatVectorForCreatingQueryRequest(transformedQueryVector, vectorDataType, knnEngine))
                 .originalVector(vector)
                 .byteVector(getByteVectorForCreatingQueryRequest(vectorDataType, byteVector))

--- a/src/test/java/org/opensearch/knn/index/KNNFieldAliasQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNFieldAliasQueryTests.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.knn.KNNSingleNodeTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.test.hamcrest.OpenSearchAssertions;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Tests that a {@code knn} query issued against a field <em>alias</em> whose {@code path} points at a
+ * {@code knn_vector} field behaves identically to the same query issued against the concrete field.
+ *
+ * <p>Regression coverage for the silent-zero-hits bug: a field alias exists only as mapping metadata and
+ * never appears in Lucene's {@code FieldInfos}. {@code KNNQueryBuilder#doToQuery} resolved the mapping
+ * through the alias correctly (so dimension / space type / engine were right) but then carried the
+ * <em>alias</em> name into the {@code KNNQuery}. At the segment level {@code KNNWeight} looks the field name
+ * up directly in {@code FieldInfos}, missed, and -- because a miss is not an error -- logged at DEBUG and
+ * returned {@code EMPTY_TOPDOCS}. The user saw zero hits, no error, and nothing in the log.
+ */
+public class KNNFieldAliasQueryTests extends KNNSingleNodeTestCase {
+
+    private static final String INDEX_NAME = "test-alias-index";
+    private static final String CONCRETE_FIELD = "embedding_a";
+    private static final String ALIAS_FIELD = "embedding";
+    private static final int DIMENSION = 2;
+
+    private static final Float[] VECTOR_1 = new Float[] { 1.0f, 1.0f };
+    private static final Float[] VECTOR_2 = new Float[] { 2.0f, 2.0f };
+    private static final Float[] VECTOR_3 = new Float[] { 3.0f, 3.0f };
+    private static final float[] QUERY_VECTOR = new float[] { 1.0f, 1.0f };
+
+    /**
+     * Creates a mapping with a concrete knn_vector field plus an alias pointing at it.
+     */
+    private void createKnnMappingWithAlias(final String indexName, final KNNEngine engine) throws IOException {
+        final PutMappingRequest request = new PutMappingRequest(indexName);
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(CONCRETE_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject("method")
+            .field("name", "hnsw")
+            .field("engine", engine.getName())
+            .field("space_type", SpaceType.L2.getValue())
+            .endObject()
+            .endObject()
+            .startObject(ALIAS_FIELD)
+            .field("type", "alias")
+            .field("path", CONCRETE_FIELD)
+            .endObject()
+            .endObject()
+            .endObject();
+        request.source(builder);
+        OpenSearchAssertions.assertAcked(client().admin().indices().putMapping(request).actionGet());
+    }
+
+    private void setUpIndex(final KNNEngine engine) throws IOException, InterruptedException, ExecutionException {
+        createKNNIndex(INDEX_NAME);
+        createKnnMappingWithAlias(INDEX_NAME, engine);
+        addKnnDoc(INDEX_NAME, "1", CONCRETE_FIELD, VECTOR_1);
+        addKnnDoc(INDEX_NAME, "2", CONCRETE_FIELD, VECTOR_2);
+        addKnnDoc(INDEX_NAME, "3", CONCRETE_FIELD, VECTOR_3);
+    }
+
+    private long hits(final QueryBuilder query) {
+        final SearchResponse response = client().prepareSearch(INDEX_NAME).setQuery(query).setSize(10).get();
+        assertEquals(RestStatus.OK, response.status());
+        return response.getHits().getTotalHits().value();
+    }
+
+    /**
+     * Baseline: proves the alias itself is valid and resolves through the mapping. A non-vector query over
+     * the alias must find all three docs. If this fails, the test setup is wrong rather than k-NN.
+     */
+    public void testExistsQueryOnAlias_thenResolves() throws IOException, InterruptedException, ExecutionException {
+        setUpIndex(KNNEngine.FAISS);
+        assertEquals(3L, hits(QueryBuilders.existsQuery(ALIAS_FIELD)));
+    }
+
+    /**
+     * The core bug: an approximate k-NN query over the alias must return the same hits as over the concrete
+     * field. Before the fix the alias variant silently returned zero hits.
+     */
+    public void testKnnQueryOnAlias_faiss_thenReturnsSameHitsAsConcreteField() throws IOException, InterruptedException,
+        ExecutionException {
+        setUpIndex(KNNEngine.FAISS);
+
+        final long concreteHits = hits(new KNNQueryBuilder(CONCRETE_FIELD, QUERY_VECTOR, 3));
+        assertEquals("sanity: concrete field must return all 3 docs", 3L, concreteHits);
+
+        final long aliasHits = hits(new KNNQueryBuilder(ALIAS_FIELD, QUERY_VECTOR, 3));
+        assertEquals("knn query over a field alias must return the same hits as the concrete field", concreteHits, aliasHits);
+    }
+
+    /**
+     * Same as above for the Lucene engine, which takes a completely different code path
+     * ({@code OSKnnFloatVectorQuery} rather than {@code KNNQuery}/{@code KNNWeight}).
+     */
+    public void testKnnQueryOnAlias_lucene_thenReturnsSameHitsAsConcreteField() throws IOException, InterruptedException,
+        ExecutionException {
+        setUpIndex(KNNEngine.LUCENE);
+
+        final long concreteHits = hits(new KNNQueryBuilder(CONCRETE_FIELD, QUERY_VECTOR, 3));
+        assertEquals("sanity: concrete field must return all 3 docs", 3L, concreteHits);
+
+        final long aliasHits = hits(new KNNQueryBuilder(ALIAS_FIELD, QUERY_VECTOR, 3));
+        assertEquals("lucene-engine knn query over a field alias must match the concrete field", concreteHits, aliasHits);
+    }
+
+    /**
+     * Filtered k-NN over an alias. The filter is applied via a {@code FieldExistsQuery} on the query's field
+     * name in {@code KNNQuery#getFilterWeight}, which is a second place an unresolved alias name would break.
+     */
+    public void testFilteredKnnQueryOnAlias_thenReturnsSameHitsAsConcreteField() throws IOException, InterruptedException,
+        ExecutionException {
+        setUpIndex(KNNEngine.FAISS);
+
+        final long concreteHits = hits(new KNNQueryBuilder(CONCRETE_FIELD, QUERY_VECTOR, 3, QueryBuilders.existsQuery(CONCRETE_FIELD)));
+        assertEquals("sanity: filtered concrete query must return all 3 docs", 3L, concreteHits);
+
+        final KNNQueryBuilder alias = new KNNQueryBuilder(ALIAS_FIELD, QUERY_VECTOR, 3, QueryBuilders.existsQuery(CONCRETE_FIELD));
+        assertEquals("filtered knn query over a field alias must match the concrete field", concreteHits, hits(alias));
+    }
+
+    /**
+     * Radial search by {@code min_score} over an alias. This goes through {@code RNNQueryFactory} rather than
+     * {@code KNNQueryFactory}, so it is a distinct field-name flow that needed fixing separately.
+     */
+    public void testRadialMinScoreQueryOnAlias_thenReturnsSameHitsAsConcreteField() throws IOException, InterruptedException,
+        ExecutionException {
+        setUpIndex(KNNEngine.FAISS);
+
+        final KNNQueryBuilder concrete = KNNQueryBuilder.builder().fieldName(CONCRETE_FIELD).vector(QUERY_VECTOR).minScore(0.1f).build();
+        final long concreteHits = hits(concrete);
+        assertTrue("sanity: min_score radial query must match at least one doc", concreteHits > 0);
+
+        final KNNQueryBuilder alias = KNNQueryBuilder.builder().fieldName(ALIAS_FIELD).vector(QUERY_VECTOR).minScore(0.1f).build();
+        assertEquals("min_score radial query over a field alias must match the concrete field", concreteHits, hits(alias));
+    }
+
+    /**
+     * Radial search by {@code max_distance} over an alias.
+     */
+    public void testRadialMaxDistanceQueryOnAlias_thenReturnsSameHitsAsConcreteField() throws IOException, InterruptedException,
+        ExecutionException {
+        setUpIndex(KNNEngine.FAISS);
+
+        final KNNQueryBuilder concrete = KNNQueryBuilder.builder()
+            .fieldName(CONCRETE_FIELD)
+            .vector(QUERY_VECTOR)
+            .maxDistance(100.0f)
+            .build();
+        final long concreteHits = hits(concrete);
+        assertTrue("sanity: max_distance radial query must match at least one doc", concreteHits > 0);
+
+        final KNNQueryBuilder alias = KNNQueryBuilder.builder().fieldName(ALIAS_FIELD).vector(QUERY_VECTOR).maxDistance(100.0f).build();
+        assertEquals("max_distance radial query over a field alias must match the concrete field", concreteHits, hits(alias));
+    }
+
+    /**
+     * {@code explain} over an alias must produce a populated explanation, not an empty/no-match one.
+     */
+    public void testExplainKnnQueryOnAlias_thenExplanationIsNotEmpty() throws IOException, InterruptedException, ExecutionException {
+        setUpIndex(KNNEngine.FAISS);
+
+        final SearchResponse response = client().prepareSearch(INDEX_NAME)
+            .setQuery(new KNNQueryBuilder(ALIAS_FIELD, QUERY_VECTOR, 3))
+            .setExplain(true)
+            .setSize(10)
+            .get();
+        assertEquals(RestStatus.OK, response.status());
+        assertTrue("explain over a field alias must return hits", response.getHits().getHits().length > 0);
+        assertNotNull("explanation must be present for an alias query", response.getHits().getHits()[0].getExplanation());
+    }
+}


### PR DESCRIPTION
### Description
**Root cause.** `KNNQueryBuilder#doToQuery` resolves the *mapping* through the alias
correctly — `context.fieldMapper(fieldName)` goes through `FieldTypeLookup`, which applies
`aliasToConcreteName`, so dimension, space type and engine all resolve properly. But it then
carries the **alias name** into the query object rather than the concrete name:

```java
KNNQueryFactory.CreateQueryRequest.builder()
    .fieldName(this.fieldName)   // <-- the alias, as the user typed it
```

At the segment level, `KNNWeight` looks that name up directly in Lucene's `FieldInfos`:

```java
FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, knnQuery.getField());
if (fieldInfo == null) {
    log.debug("[KNN] Field info not found for {}:{}", knnQuery.getField(), reader.getSegmentName());
    return EMPTY_TOPDOCS;
}
```

**A field alias does not exist in `FieldInfos`** — it is mapping-only metadata, so the lookup
misses. The miss is not treated as an error: it logs at `DEBUG` and returns `EMPTY_TOPDOCS`.

The unresolved name reaches several other consumers for the same reason (exact search,
memory-optimized search, and the `FieldExistsQuery` used by the filtered path), which is why
every query variant is affected rather than just one.

**Fix** Use `MappedFieldType#name()` — the concrete name after alias resolution —
for the value that reaches the segment. This is the pattern OpenSearch core already uses for
alias-safe queries (`CommonTermsQueryBuilder`, `FieldMaskingSpanQueryBuilder`,
`GeoPolygonQueryBuilder`). Two call sites in `doToQuery` cover every downstream consumer,
because they all take the field name off `KNNQuery`:

```java
final String resolvedFieldName = mappedFieldType.name() != null ? mappedFieldType.name() : this.fieldName;
```


### Related Issues
Resolves #3484 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
