### PR TITLE
[BugFix] Drop HasIndexSlice from ScalarQuantizedFloatVectorValues and expose float/quantized delegates via getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix inner-hits returning mask value for top level source excludes [#3446](https://github.com/opensearch-project/k-NN/pull/3446)
 * Fix _source bloat on merge for derived source indices with _source.exclude [#3465](https://github.com/opensearch-project/k-NN/pull/3465)
 * Disable radial search on quantized indices due to poor recall from quantization error [#3448](https://github.com/opensearch-project/k-NN/pull/3448)
+* Drop HasIndexSlice from ScalarQuantizedFloatVectorValues and expose float/quantized delegates via getters [#3486](https://github.com/opensearch-project/k-NN/pull/3486)
 
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix knn query against a field alias returning zero hits silently [#3485](https://github.com/opensearch-project/k-NN/pull/3485)
 * Add prefetch for Lucene engine's fp32 and binary vector data type [#3504](https://github.com/opensearch-project/k-NN/pull/3504)
 * Fix when BQ file is not present in the segment as there is no vectors in the segment [#3511](https://github.com/opensearch-project/k-NN/pull/3511)
+* Drop HasIndexSlice from ScalarQuantizedFloatVectorValues and expose float/quantized delegates via getters [#3486](https://github.com/opensearch-project/k-NN/pull/3486)
 
 ### Refactoring
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReader.java
@@ -14,19 +14,15 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import java.io.IOException;
 
 /**
- * A {@link FlatVectorsReader} wrapper for Faiss SQ (1-bit) vector fields that ensures the
- * {@link FloatVectorValues} returned by {@link #getFloatVectorValues(String)} implement
- * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}.
+ * A {@link FlatVectorsReader} wrapper for Faiss SQ vector fields that exposes both the
+ * full-precision floats and the quantized codes on the {@link FloatVectorValues} returned by
+ * {@link #getFloatVectorValues(String)}.
  *
  * <p>Lucene's {@code Lucene104ScalarQuantizedVectorsReader} returns a {@code ScalarQuantizedVectorValues}
- * from {@link #getFloatVectorValues(String)}, which does not implement
- * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}. However, Lucene's HNSW
- * graph traversal requires all {@link FloatVectorValues} to implement {@code HasIndexSlice} so that
- * the underlying {@link org.apache.lucene.store.IndexInput} can be accessed for I/O prefetching.
- *
- * <p>This reader solves the problem by wrapping the delegate's {@link FloatVectorValues} with
- * {@link ScalarQuantizedFloatVectorValues}, which implements {@code HasIndexSlice}
- * by exposing the {@link org.apache.lucene.store.IndexInput} from the quantized byte vector values.
+ * that hides its quantized byte delegate behind a private field. Callers on the plugin side
+ * (warmup, native scoring) need both the full-precision {@code .vec} floats and the quantized
+ * {@code .veq} codes, so this reader wraps the delegate's values with
+ * {@link ScalarQuantizedFloatVectorValues}, which carries both delegates explicitly.
  *
  * <p>The resulting reader hierarchy is:
  * <pre>
@@ -65,9 +61,10 @@ public class Faiss1040ScalarQuantizedFlatVectorsReader extends FlatVectorsReader
     }
 
     /**
-     * Returns {@link FloatVectorValues} wrapped with {@link ScalarQuantizedFloatVectorValues}
-     * so that the result implements {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}.
-     * Empty values are wrapped with no quantized backing because Lucene does not expose one.
+     * Returns {@link FloatVectorValues} wrapped with {@link ScalarQuantizedFloatVectorValues},
+     * which exposes both the full-precision float delegate and the quantized byte delegate via
+     * dedicated getters. Empty values are wrapped with no quantized backing because Lucene does
+     * not expose one.
      */
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsReader;
 import org.opensearch.knn.index.codec.nativeindex.AbstractNativeEnginesKnnVectorsReader;
 import org.opensearch.knn.index.codec.util.KNNCodecUtil;
@@ -81,24 +80,26 @@ public class Faiss1040ScalarQuantizedKnnVectorsReader extends AbstractNativeEngi
     /**
      * Warms up the on-disk data for the given scalar-quantized field.
      * <p>
-     * The full-precision vectors are always warmed by reading each vector explicitly through the underlying
-     * {@link ScalarQuantizedFloatVectorValues} (they cannot be warmed through {@link WarmupUtil}, whose slice
-     * is backed by the quantized data).
+     * Warms three files: the quantized codes in {@code .veq}, the full-precision floats in
+     * {@code .vec}, and (when present) the FAISS HNSW graph in {@code .faiss}.
      * <p>
-     * When a native engine (.faiss) graph file is present, the HNSW graph and the quantized vectors are warmed
-     * via the memory-optimized searcher. When the graph was skipped by the approximate threshold there is no
-     * .faiss file - search is served by exact search over the quantized {@code .veq} codes, so those are warmed
-     * directly through the flat reader's index slice instead of loading a (non-existent) searcher.
+     * The {@code .veq} slice is warmed here via the quantized delegate — it's the one file
+     * {@link VectorSearcher#warmUp()} does not cover on its own. When a {@code .faiss} graph
+     * file is present, {@link VectorSearcher#warmUp()} bulk-reads the graph and then iterates
+     * the fp32 float values, which touches every {@code .vec} page via this wrapper's
+     * {@link ScalarQuantizedFloatVectorValues#getFloatVectorValues() fp32 delegate} — so we
+     * don't duplicate that work.
+     * <p>
+     * When the graph was skipped by the approximate threshold there is no {@code .faiss} file
+     * and no memory-optimized searcher to load. Exact search over the just-warmed {@code .veq}
+     * codes serves queries, and we additionally warm the {@code .vec} fp32 floats directly
+     * through the fp32 delegate for rescoring.
      *
      * @param fieldName the name of the vector field to warm up
      * @throws IOException if an I/O error occurs while reading the underlying data
      */
     @Override
     public void warmUp(final String fieldName) throws IOException {
-        // Warm up full-precision vectors
-        // We cannot rely on WarmupUtil, which extracts the IndexInput from vector values and reads through it.
-        // Because, the IndexInput returned by vector values is backed by quantized vectors.
-        // Therefore, to warm up full-precision vectors, we need to load them explicitly as below.
         final ScalarQuantizedFloatVectorValues vectorValues = (ScalarQuantizedFloatVectorValues) flatVectorsReader.getFloatVectorValues(
             fieldName
         );
@@ -108,30 +109,27 @@ public class Faiss1040ScalarQuantizedKnnVectorsReader extends AbstractNativeEngi
             return;
         }
 
-        for (int i = 0; i < vectorValues.size(); ++i) {
-            vectorValues.vectorValue(i);
+        // Warm up the .veq (quantized codes). This is the only file MOS's
+        // warmUp() does not cover — it handles .faiss (graph) and .vec (fp32).
+        if (vectorValues.getQuantizedVectorValues() != null) {
+            WarmupUtil.readAll(vectorValues.getQuantizedVectorValues());
         }
 
-        // When the graph was skipped by the approximate threshold there is no native engine (.faiss) file, so
-        // there is no memory-optimized searcher to load. In that case search is served by exact search over the
-        // quantized .veq codes, so warm those directly through the flat reader's index slice. Only attempt the
-        // memory-optimized searcher when a graph file is actually present; that path keeps warming the .veq codes
-        // and the graph, and still surfaces the error/warn logs for a genuine load failure.
+        // When the approximate threshold skipped the HNSW build there's no .faiss file and no
+        // memory-optimized searcher to load. Warm the .vec fp32 floats directly through the fp32
+        // delegate (its OffHeapFloatVectorValues doesn't implement HasIndexSlice, so readAll falls
+        // through to the per-ord loop) and return — exact search over the just-warmed .veq codes
+        // serves queries.
         final FieldInfo fieldInfo = fieldInfos.fieldInfo(fieldName);
         final boolean hasGraphFile = KNNCodecUtil.getNativeEngineFileFromFieldInfo(fieldInfo, segmentReadState.segmentInfo) != null;
-        if (hasGraphFile == false) {
-            // Warm the quantized .veq codes directly through the flat reader's index slice
-            // (ScalarQuantizedFloatVectorValues exposes them via HasIndexSlice#getSlice).
-            final IndexInput veqSlice = vectorValues.getSlice();
-            if (veqSlice != null) {
-                WarmupUtil.readAll(veqSlice);
-            }
+        if (!hasGraphFile) {
+            WarmupUtil.readAll(vectorValues.getFloatVectorValues());
             return;
         }
 
         final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
         if (memoryOptimizedSearcher != null) {
-            // MOS is supported, warm up search parts
+            // Warms the .faiss graph and the .vec fp32 floats.
             memoryOptimizedSearcher.warmUp();
         } else {
             log.warn("Memory optimized search is not supported for {}", fieldName);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -93,6 +93,10 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         final QuantizedByteVectorValues quantizedByteVectorValues;
         if (vectorValues instanceof QuantizedByteVectorValues) {
             quantizedByteVectorValues = (QuantizedByteVectorValues) vectorValues;
+        } else if (vectorValues instanceof ScalarQuantizedFloatVectorValues) {
+            // Our wrapper exposes the quantized delegate via a public getter, so we don't
+            // need to fall back to the reflection path used for Lucene's private inner class.
+            quantizedByteVectorValues = ((ScalarQuantizedFloatVectorValues) vectorValues).getQuantizedVectorValues();
         } else {
             // Extract QuantizedByteVectorValues from `vectorValues`.
             // This should not be null, otherwise it can't get entroid + correction factors.

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -91,6 +91,10 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         final QuantizedByteVectorValues quantizedByteVectorValues;
         if (vectorValues instanceof QuantizedByteVectorValues) {
             quantizedByteVectorValues = (QuantizedByteVectorValues) vectorValues;
+        } else if (vectorValues instanceof ScalarQuantizedFloatVectorValues) {
+            // Our wrapper exposes the quantized delegate via a public getter, so we don't
+            // need to fall back to the reflection path used for Lucene's private inner class.
+            quantizedByteVectorValues = ((ScalarQuantizedFloatVectorValues) vectorValues).getQuantizedVectorValues();
         } else {
             // Extract QuantizedByteVectorValues from `vectorValues`.
             // This should not be null, otherwise it can't get entroid + correction factors.

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValues.java
@@ -5,36 +5,42 @@
 
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.VectorScorer;
-import org.apache.lucene.store.IndexInput;
 
 import java.io.IOException;
 
 /**
- * A {@link FloatVectorValues} wrapper that implements {@link HasIndexSlice} to enable I/O prefetching
- * during HNSW graph traversal.
+ * A {@link FloatVectorValues} wrapper that holds both the full-precision float delegate (backed by
+ * the {@code .vec} file) and the underlying quantized byte delegate (backed by the {@code .veq} file).
  *
- * <p>Lucene's {@code ScalarQuantizedVectorValues} (returned by
- * {@code Lucene104ScalarQuantizedVectorsReader.getFloatVectorValues()}) does not implement
- * {@link HasIndexSlice}. Lucene's prefetch-enabled flat vector scorer
- * ({@link org.apache.lucene.codecs.hnsw.FlatVectorsScorer}) requires this interface to obtain the
- * underlying {@link IndexInput} for issuing prefetch hints ahead of scoring.
+ * <p>The wrapper exists so callers can reach either representation without reflection: the search
+ * scorer needs the quantized codes; warmup needs the full-precision bytes. Consumers pick via
+ * {@link #getFloatVectorValues()} or {@link #getQuantizedVectorValues()} rather than relying on a
+ * single ambiguous slice.
  *
- * <p>This class bridges the gap by delegating all {@link FloatVectorValues} operations to the original
- * instance, while implementing {@link HasIndexSlice#getSlice()} by returning the {@link IndexInput}
- * from the underlying {@link QuantizedByteVectorValues}. The quantized byte values hold the on-disk
- * slice that contains the quantized vector data and correction factors used during scoring. For an
- * empty vector segment, the quantized values may be {@code null}; in that case, this wrapper has no
- * index slice.
+ * <p>Historically this class implemented {@code HasIndexSlice#getSlice()}. It was removed because
+ * the delegating {@code vectorValue(ord)} reads full-precision floats from {@code .vec} while the
+ * quantized values expose the {@code .veq} slice — a generic prefetch caller trusting
+ * {@code HasIndexSlice} would warm the wrong file, defeating the fetch-phase prefetch entirely.
+ *
+ * <p>For an empty vector segment, the quantized delegate may be {@code null}.
  */
+@Getter
 @RequiredArgsConstructor
-class ScalarQuantizedFloatVectorValues extends FloatVectorValues implements HasIndexSlice {
+class ScalarQuantizedFloatVectorValues extends FloatVectorValues {
+    /**
+     * The full-precision float delegate (reads the {@code .vec} file).
+     */
     private final FloatVectorValues floatVectorValues;
+    /**
+     * The quantized byte delegate (reads the {@code .veq} file), or {@code null} for empty
+     * segments where Lucene does not expose one.
+     */
     private final QuantizedByteVectorValues quantizedVectorValues;
 
     @Override
@@ -66,18 +72,18 @@ class ScalarQuantizedFloatVectorValues extends FloatVectorValues implements HasI
     }
 
     @Override
-    public IndexInput getSlice() {
-        return quantizedVectorValues == null ? null : quantizedVectorValues.getSlice();
-    }
-
-    @Override
     public DocIndexIterator iterator() {
         return floatVectorValues.iterator();
     }
 
+    /**
+     * Returns a {@link VectorScorer} that scores the query against the quantized codes in
+     * {@code .veq}. Scoring is the quantized-vs-quantized path, not the full-precision one — the
+     * {@code .vec} floats are reserved for rescore/fetch via {@link #rescorer(float[])}.
+     */
     @Override
     public VectorScorer scorer(float[] target) throws IOException {
-        return floatVectorValues.scorer(target);
+        return quantizedVectorValues == null ? null : quantizedVectorValues.scorer(target);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/util/WarmupUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/WarmupUtil.java
@@ -36,8 +36,11 @@ public class WarmupUtil {
      */
     public static void readAll(@NonNull final FloatVectorValues floatVectorValues) throws IOException {
         if (floatVectorValues instanceof HasIndexSlice hasIndexSlice) {
-            readAll(hasIndexSlice.getSlice());
-            return;
+            final IndexInput slice = hasIndexSlice.getSlice();
+            if (slice != null) {
+                readAll(slice);
+                return;
+            }
         }
         for (int i = 0; i < floatVectorValues.size(); ++i) {
             floatVectorValues.vectorValue(i);
@@ -56,8 +59,11 @@ public class WarmupUtil {
      */
     public static void readAll(@NonNull final ByteVectorValues byteVectorValues) throws IOException {
         if (byteVectorValues instanceof HasIndexSlice hasIndexSlice) {
-            readAll(hasIndexSlice.getSlice());
-            return;
+            final IndexInput slice = hasIndexSlice.getSlice();
+            if (slice != null) {
+                readAll(slice);
+                return;
+            }
         }
         for (int i = 0; i < byteVectorValues.size(); ++i) {
             byteVectorValues.vectorValue(i);

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValues.java
@@ -84,16 +84,6 @@ public class FaissFloatVectorValues extends FloatVectorValues implements HasInde
         public SparseFloatVectorValuesImpl(final FloatVectorValues vectorValues, final DirectMonotonicReader idMappingReader) {
             super(vectorValues);
             this.idMappingReader = idMappingReader;
-            if ((vectorValues instanceof HasIndexSlice) == false) {
-                throw new IllegalArgumentException(
-                    "SparseFloatVectorValuesImpl needs an instance of "
-                        + "FloatVectorValues which implements HasIndexSlice interface. "
-                        + vectorValues.getClass().getCanonicalName()
-                        + " doesn't implement "
-                        + HasIndexSlice.class
-                        + "interface"
-                );
-            }
         }
 
         @Override
@@ -146,8 +136,13 @@ public class FaissFloatVectorValues extends FloatVectorValues implements HasInde
 
         @Override
         public IndexInput getSlice() {
-            // Since in constructor we are already validating the instance type we don't need another validation here
-            return ((HasIndexSlice) floatVectorValues).getSlice();
+            // Two-slice wrappers (e.g. ScalarQuantizedFloatVectorValues, which fronts both .vec and
+            // .veq) don't implement HasIndexSlice because no single slice honestly represents them.
+            // Return null so consumers fall through to their non-slice path.
+            if (floatVectorValues instanceof HasIndexSlice hasIndexSlice) {
+                return hasIndexSlice.getSlice();
+            }
+            return null;
         }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReaderTests.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -67,7 +66,7 @@ public class Faiss1040ScalarQuantizedFlatVectorsReaderTests extends KNNTestCase 
     }
 
     @SneakyThrows
-    public void testGetFloatVectorValues_thenReturnsWrappedValuesWithHasIndexSlice() {
+    public void testGetFloatVectorValues_thenReturnsWrappedValuesWithBothDelegates() {
         FlatVectorsReader delegate = mock(FlatVectorsReader.class);
         FloatVectorValues mockFvv = mock(FloatVectorValues.class);
         QuantizedByteVectorValues mockQbvv = mock(QuantizedByteVectorValues.class);
@@ -80,8 +79,10 @@ public class Faiss1040ScalarQuantizedFlatVectorsReaderTests extends KNNTestCase 
             Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
             FloatVectorValues result = reader.getFloatVectorValues("field");
 
-            assertTrue("Result should implement HasIndexSlice", result instanceof HasIndexSlice);
             assertTrue("Result should be ScalarQuantizedFloatVectorValues", result instanceof ScalarQuantizedFloatVectorValues);
+            ScalarQuantizedFloatVectorValues wrapper = (ScalarQuantizedFloatVectorValues) result;
+            assertSame(mockFvv, wrapper.getFloatVectorValues());
+            assertSame(mockQbvv, wrapper.getQuantizedVectorValues());
             verify(delegate).getFloatVectorValues("field");
             mockedUtils.verify(() -> KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(mockFvv));
         }
@@ -99,8 +100,9 @@ public class Faiss1040ScalarQuantizedFlatVectorsReaderTests extends KNNTestCase 
             FloatVectorValues result = reader.getFloatVectorValues("field");
 
             assertTrue(result instanceof ScalarQuantizedFloatVectorValues);
-            assertTrue(result instanceof HasIndexSlice);
-            assertNull(((HasIndexSlice) result).getSlice());
+            ScalarQuantizedFloatVectorValues wrapper = (ScalarQuantizedFloatVectorValues) result;
+            assertSame(emptyValues, wrapper.getFloatVectorValues());
+            assertNull(wrapper.getQuantizedVectorValues());
             assertEquals(0, result.size());
             verify(delegate).getFloatVectorValues("field");
             mockedUtils.verifyNoInteractions();

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
@@ -186,20 +186,22 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testWarmUp_whenGraphSkippedByThreshold_thenWarmsVeqWithoutError() {
+    public void testWarmUp_whenGraphSkippedByThreshold_thenWarmsVeqAndVecWithoutError() {
         // No native engine (.faiss) file (the approximate threshold skipped the graph). Search is served by
-        // exact search over the quantized .veq codes, so warmUp should warm those codes via the flat reader's
-        // index slice and NOT attempt to load a memory-optimized searcher, so no error/warn is logged.
+        // exact search over the quantized .veq codes, so warmUp should warm both the .veq codes (via the
+        // quantized delegate) and the .vec fp32 floats (via the fp32 delegate), and NOT attempt to load a
+        // memory-optimized searcher, so no error/warn is logged.
         final FieldInfo fi = createFieldInfo("field1", KNNEngine.FAISS, 0);
 
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
         final ScalarQuantizedFloatVectorValues mockVectorValues = mock(ScalarQuantizedFloatVectorValues.class);
+        final FloatVectorValues mockFloatDelegate = mock(FloatVectorValues.class);
+        final org.apache.lucene.util.quantization.QuantizedByteVectorValues mockQuantizedDelegate = mock(
+            org.apache.lucene.util.quantization.QuantizedByteVectorValues.class
+        );
         when(mockVectorValues.size()).thenReturn(3);
-        when(mockVectorValues.vectorValue(org.mockito.ArgumentMatchers.anyInt())).thenReturn(new float[] { 1.0f, 2.0f, 3.0f });
-        // The .veq codes are exposed through the index slice; warmUp should read through it.
-        final IndexInput veqSlice = mock(IndexInput.class);
-        when(veqSlice.length()).thenReturn(0L);
-        when(mockVectorValues.getSlice()).thenReturn(veqSlice);
+        when(mockVectorValues.getFloatVectorValues()).thenReturn(mockFloatDelegate);
+        when(mockVectorValues.getQuantizedVectorValues()).thenReturn(mockQuantizedDelegate);
         when(fvr.getFloatVectorValues("field1")).thenReturn(mockVectorValues);
 
         final List<LogEvent> logEvents = new ArrayList<>();
@@ -219,7 +221,9 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         logger.setLevel(Level.INFO);
         baseLogger.setLevel(Level.INFO);
 
-        try {
+        try (
+            MockedStatic<org.opensearch.knn.index.util.WarmupUtil> mockedWarmup = mockStatic(org.opensearch.knn.index.util.WarmupUtil.class)
+        ) {
             final Faiss1040ScalarQuantizedKnnVectorsReader reader = createReader(
                 new FieldInfos(new FieldInfo[] { fi }),
                 Collections.emptySet(),
@@ -228,8 +232,10 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
 
             reader.warmUp("field1");
 
-            // The .veq slice must be warmed (read through).
-            verify(veqSlice).seek(0);
+            // Both the .veq codes (via the quantized delegate) and the .vec fp32 floats (via the fp32 delegate)
+            // must be warmed.
+            mockedWarmup.verify(() -> org.opensearch.knn.index.util.WarmupUtil.readAll(mockQuantizedDelegate));
+            mockedWarmup.verify(() -> org.opensearch.knn.index.util.WarmupUtil.readAll(mockFloatDelegate));
             // No misleading error/warn should be logged for a legitimately graph-less segment.
             final boolean sawErrorOrWarn = logEvents.stream().anyMatch(e -> e.getLevel() == Level.ERROR || e.getLevel() == Level.WARN);
             assertFalse("Graph-less warmup must not log error/warn: " + logEvents, sawErrorOrWarn);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
@@ -188,20 +188,22 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testWarmUp_whenGraphSkippedByThreshold_thenWarmsVeqWithoutError() {
+    public void testWarmUp_whenGraphSkippedByThreshold_thenWarmsVeqAndVecWithoutError() {
         // No native engine (.faiss) file (the approximate threshold skipped the graph). Search is served by
-        // exact search over the quantized .veq codes, so warmUp should warm those codes via the flat reader's
-        // index slice and NOT attempt to load a memory-optimized searcher, so no error/warn is logged.
+        // exact search over the quantized .veq codes, so warmUp should warm both the .veq codes (via the
+        // quantized delegate) and the .vec fp32 floats (via the fp32 delegate), and NOT attempt to load a
+        // memory-optimized searcher, so no error/warn is logged.
         final FieldInfo fi = createFieldInfo("field1", KNNEngine.FAISS, 0);
 
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
         final ScalarQuantizedFloatVectorValues mockVectorValues = mock(ScalarQuantizedFloatVectorValues.class);
+        final FloatVectorValues mockFloatDelegate = mock(FloatVectorValues.class);
+        final org.apache.lucene.util.quantization.QuantizedByteVectorValues mockQuantizedDelegate = mock(
+            org.apache.lucene.util.quantization.QuantizedByteVectorValues.class
+        );
         when(mockVectorValues.size()).thenReturn(3);
-        when(mockVectorValues.vectorValue(org.mockito.ArgumentMatchers.anyInt())).thenReturn(new float[] { 1.0f, 2.0f, 3.0f });
-        // The .veq codes are exposed through the index slice; warmUp should read through it.
-        final IndexInput veqSlice = mock(IndexInput.class);
-        when(veqSlice.length()).thenReturn(0L);
-        when(mockVectorValues.getSlice()).thenReturn(veqSlice);
+        when(mockVectorValues.getFloatVectorValues()).thenReturn(mockFloatDelegate);
+        when(mockVectorValues.getQuantizedVectorValues()).thenReturn(mockQuantizedDelegate);
         when(fvr.getFloatVectorValues("field1")).thenReturn(mockVectorValues);
 
         final List<LogEvent> logEvents = new ArrayList<>();
@@ -221,7 +223,9 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         logger.setLevel(Level.INFO);
         baseLogger.setLevel(Level.INFO);
 
-        try {
+        try (
+            MockedStatic<org.opensearch.knn.index.util.WarmupUtil> mockedWarmup = mockStatic(org.opensearch.knn.index.util.WarmupUtil.class)
+        ) {
             final Faiss1040ScalarQuantizedKnnVectorsReader reader = createReader(
                 new FieldInfos(new FieldInfo[] { fi }),
                 Collections.emptySet(),
@@ -230,8 +234,10 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
 
             reader.warmUp("field1");
 
-            // The .veq slice must be warmed (read through).
-            verify(veqSlice).seek(0);
+            // Both the .veq codes (via the quantized delegate) and the .vec fp32 floats (via the fp32 delegate)
+            // must be warmed.
+            mockedWarmup.verify(() -> org.opensearch.knn.index.util.WarmupUtil.readAll(mockQuantizedDelegate));
+            mockedWarmup.verify(() -> org.opensearch.knn.index.util.WarmupUtil.readAll(mockFloatDelegate));
             // No misleading error/warn should be logged for a legitimately graph-less segment.
             final boolean sawErrorOrWarn = logEvents.stream().anyMatch(e -> e.getLevel() == Level.ERROR || e.getLevel() == Level.WARN);
             assertFalse("Graph-less warmup must not log error/warn: " + logEvents, sawErrorOrWarn);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -26,7 +26,6 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.IOFunction;
@@ -509,8 +508,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
                 assertNotNull(emptyValues);
                 assertTrue(emptyValues instanceof ScalarQuantizedFloatVectorValues);
                 assertEquals(0, emptyValues.size());
-                assertTrue(emptyValues instanceof HasIndexSlice);
-                assertNull(((HasIndexSlice) emptyValues).getSlice());
+                assertNull(((ScalarQuantizedFloatVectorValues) emptyValues).getQuantizedVectorValues());
                 ((Faiss1040ScalarQuantizedKnnVectorsReader) emptySegmentReader).warmUp(FIELD_NAME);
             }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValuesTests.java
@@ -6,12 +6,11 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
-import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.VectorScorer;
-import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.opensearch.knn.KNNTestCase;
 
 import static org.mockito.Mockito.mock;
@@ -62,6 +61,8 @@ public class ScalarQuantizedFloatVectorValuesTests extends KNNTestCase {
 
         assertNotSame(wrapper, copied);
         assertTrue(copied instanceof ScalarQuantizedFloatVectorValues);
+        assertSame(fvvCopy, ((ScalarQuantizedFloatVectorValues) copied).getFloatVectorValues());
+        assertSame(qbvvCopy, ((ScalarQuantizedFloatVectorValues) copied).getQuantizedVectorValues());
         verify(fvv).copy();
         verify(qbvv).copy();
     }
@@ -77,7 +78,7 @@ public class ScalarQuantizedFloatVectorValuesTests extends KNNTestCase {
 
         assertNotSame(wrapper, copied);
         assertTrue(copied instanceof ScalarQuantizedFloatVectorValues);
-        assertNull(((ScalarQuantizedFloatVectorValues) copied).getSlice());
+        assertNull(((ScalarQuantizedFloatVectorValues) copied).getQuantizedVectorValues());
         verify(fvv).copy();
     }
 
@@ -90,27 +91,32 @@ public class ScalarQuantizedFloatVectorValuesTests extends KNNTestCase {
         verify(fvv).getEncoding();
     }
 
-    @SneakyThrows
-    public void testGetSlice_thenReturnsSliceFromQuantizedValues() {
+    public void testGetFloatVectorValues_thenReturnsConstructorArg() {
+        FloatVectorValues fvv = mock(FloatVectorValues.class);
         QuantizedByteVectorValues qbvv = mock(QuantizedByteVectorValues.class);
-        IndexInput expectedSlice = mock(IndexInput.class);
-        when(qbvv.getSlice()).thenReturn(expectedSlice);
-
-        var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), qbvv);
-        assertSame(expectedSlice, wrapper.getSlice());
-        verify(qbvv).getSlice();
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, qbvv);
+        assertSame(fvv, wrapper.getFloatVectorValues());
     }
 
-    public void testGetSlice_whenQuantizedValuesAreNull_thenReturnsNull() {
+    public void testGetQuantizedVectorValues_thenReturnsConstructorArg() {
+        FloatVectorValues fvv = mock(FloatVectorValues.class);
+        QuantizedByteVectorValues qbvv = mock(QuantizedByteVectorValues.class);
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, qbvv);
+        assertSame(qbvv, wrapper.getQuantizedVectorValues());
+    }
+
+    public void testGetQuantizedVectorValues_whenNull_thenReturnsNull() {
         var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), null);
-
-        assertNull(wrapper.getSlice());
+        assertNull(wrapper.getQuantizedVectorValues());
     }
 
-    @SneakyThrows
-    public void testImplementsHasIndexSlice() {
+    public void testDoesNotImplementHasIndexSlice() {
         var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), mock(QuantizedByteVectorValues.class));
-        assertTrue(wrapper instanceof HasIndexSlice);
+        assertFalse(
+            "Wrapper must not implement HasIndexSlice because its vectorValue() reads .vec while the quantized slice"
+                + " points at .veq — a mismatch that misleads generic prefetch consumers.",
+            wrapper instanceof HasIndexSlice
+        );
     }
 
     @SneakyThrows
@@ -125,14 +131,20 @@ public class ScalarQuantizedFloatVectorValuesTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testScorer_thenDelegatesToFloatVectorValues() {
-        FloatVectorValues fvv = mock(FloatVectorValues.class);
+    public void testScorer_thenDelegatesToQuantizedValues() {
+        QuantizedByteVectorValues qbvv = mock(QuantizedByteVectorValues.class);
         VectorScorer expectedScorer = mock(VectorScorer.class);
         float[] target = { 1.0f, 2.0f };
-        when(fvv.scorer(target)).thenReturn(expectedScorer);
+        when(qbvv.scorer(target)).thenReturn(expectedScorer);
 
-        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), qbvv);
         assertSame(expectedScorer, wrapper.scorer(target));
-        verify(fvv).scorer(target);
+        verify(qbvv).scorer(target);
+    }
+
+    @SneakyThrows
+    public void testScorer_whenQuantizedValuesAreNull_thenReturnsNull() {
+        var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), null);
+        assertNull(wrapper.scorer(new float[] { 1.0f, 2.0f }));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/util/WarmupUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/WarmupUtilTests.java
@@ -106,6 +106,36 @@ public class WarmupUtilTests extends KNNTestCase {
         verify(mockSlice, times((int) sliceLength)).readByte();
     }
 
+    // When FloatVectorValues implements HasIndexSlice but getSlice() returns null (e.g. a
+    // two-slice wrapper like ScalarQuantizedFloatVectorValues fronted by SparseFloatVectorValuesImpl),
+    // readAll should fall through to iterating each vector.
+    public void testReadAllFloatVectorValues_whenHasIndexSliceButSliceIsNull_readsAllValues() throws IOException {
+        int size = 2;
+        FloatVectorValuesWithSlice mockValues = mock(FloatVectorValuesWithSlice.class);
+        when(mockValues.getSlice()).thenReturn(null);
+        when(mockValues.size()).thenReturn(size);
+
+        WarmupUtil.readAll((FloatVectorValues) mockValues);
+
+        for (int i = 0; i < size; i++) {
+            verify(mockValues).vectorValue(i);
+        }
+    }
+
+    // Same for the ByteVectorValues overload.
+    public void testReadAllByteVectorValues_whenHasIndexSliceButSliceIsNull_readsAllValues() throws IOException {
+        int size = 2;
+        ByteVectorValuesWithSlice mockValues = mock(ByteVectorValuesWithSlice.class);
+        when(mockValues.getSlice()).thenReturn(null);
+        when(mockValues.size()).thenReturn(size);
+
+        WarmupUtil.readAll((ByteVectorValues) mockValues);
+
+        for (int i = 0; i < size; i++) {
+            verify(mockValues).vectorValue(i);
+        }
+    }
+
     // Abstract helper types that combine VectorValues with HasIndexSlice so
     // Mockito can produce mocks matching the instanceof check in WarmupUtil.
     abstract static class FloatVectorValuesWithSlice extends FloatVectorValues implements HasIndexSlice {}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValuesTests.java
@@ -124,11 +124,20 @@ public class FaissFloatVectorValuesTests extends KNNTestCase {
         assertEquals(sparse.size(), copy.size());
     }
 
-    public void testSparseVectorsValues_whenNonHasIndexSlice_thenThrows() {
+    public void testSparseVectorsValues_whenNonHasIndexSlice_thenGetSliceReturnsNull() {
         final List<float[]> vectors = List.of(new float[] { 1.0f, 2.0f, 3.0f, 4.0f });
         final TestVectorValues.PreDefinedFloatVectorValues nonSliceValues = new TestVectorValues.PreDefinedFloatVectorValues(vectors);
 
-        expectThrows(IllegalArgumentException.class, () -> new FaissFloatVectorValues.SparseFloatVectorValuesImpl(nonSliceValues, null));
+        // Construction succeeds even when the wrapped values are not HasIndexSlice — required by
+        // consumers (e.g. two-slice wrappers like ScalarQuantizedFloatVectorValues) that build the
+        // sparse wrapper before touching the slice.
+        final FaissFloatVectorValues.SparseFloatVectorValuesImpl sparse = new FaissFloatVectorValues.SparseFloatVectorValuesImpl(
+            nonSliceValues,
+            null
+        );
+
+        // getSlice() returns null so consumers fall through to their non-slice path.
+        assertNull(sparse.getSlice());
     }
 
     private FaissFloatVectorValues createFaissFloatVectorValues() {


### PR DESCRIPTION
### Description
Fix SQ flat prefetch reading .veq instead of .vec by dropping HasIndexSlice from ScalarQuantizedFloatVectorValues. Expose float/quantized delegates via getters, route scorer() to quantized values, and warm only .veq (MOS handles .vec + .faiss).

### Related Issues
#3427 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
