### PR TITLE
Add restart-upgrade BWC test for derived-source _source bloat on merge (#3465)

### DIFF
--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -190,6 +190,15 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
+    // The _source-bloat-on-merge fix (#3465, issue #3316) shipped in 3.8; the regression only reproduces
+    // when the old cluster predates it, so skip that test when the old cluster already has the fix.
+    boolean derivedSourceMergeFixAlreadyPresent = Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.8.0")
+    if (derivedSourceMergeFixAlreadyPresent) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT.testDerivedSourceExcludeMergeBloatBefore3_8_0"
+        }
+    }
+
     if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
@@ -232,7 +241,7 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
-    
+
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 }
@@ -381,6 +390,15 @@ task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
             knn_bwc_version.startsWith("2.19.")) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
+        }
+    }
+
+    // The _source-bloat-on-merge fix (#3465, issue #3316) shipped in 3.8; the regression only reproduces
+    // when the old cluster predates it, so skip that test when the old cluster already has the fix.
+    boolean derivedSourceMergeFixAlreadyPresent = Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.8.0")
+    if (derivedSourceMergeFixAlreadyPresent) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT.testDerivedSourceExcludeMergeBloatBefore3_8_0"
         }
     }
 

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -190,8 +190,8 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         }
     }
 
-    // The _source-bloat-on-merge fix (#3465, issue #3316) shipped in 3.8; the regression only reproduces
-    // when the old cluster predates it, so skip that test when the old cluster already has the fix.
+    // The _source-bloat-on-merge fix (#3465, issue #3316) shipped in 3.8; the pre-fix bloat this test compares
+    // against only exists when the old cluster predates it, so skip the test when the old cluster has the fix.
     boolean derivedSourceMergeFixAlreadyPresent = Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.8.0")
     if (derivedSourceMergeFixAlreadyPresent) {
         filter {
@@ -393,8 +393,8 @@ task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
         }
     }
 
-    // The _source-bloat-on-merge fix (#3465, issue #3316) shipped in 3.8; the regression only reproduces
-    // when the old cluster predates it, so skip that test when the old cluster already has the fix.
+    // The _source-bloat-on-merge fix (#3465, issue #3316) shipped in 3.8; the pre-fix bloat this test compares
+    // against only exists when the old cluster predates it, so skip the test when the old cluster has the fix.
     boolean derivedSourceMergeFixAlreadyPresent = Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.8.0")
     if (derivedSourceMergeFixAlreadyPresent) {
         filter {

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -201,9 +201,15 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
         return builder.toString();
     }
 
-    // BWC regression test for #3316 (fixed in #3465): seed indices on the old cluster, then force-merge on
-    // the upgraded cluster and verify the vector is not re-injected into _source. The bug only reproduces
-    // before the 3.8 fix, so the build.gradle version filter excludes this test for BWC versions >= 3.8.
+    // BWC regression test for the derived-source _source-bloat-on-merge fix (#3465, issue #3316). We build the
+    // same index (derived source + _source.exclude) with the same documents on each cluster and compare sizes:
+    // - oldBuilt: created, indexed, and force-merged on the OLD (pre-fix) cluster. Its force-merge re-injects
+    // the excluded vector back into _source, so it is bloated. It is kept (not deleted) so it survives the
+    // restart as the "before" reference.
+    // - newBuilt: a separate index created, indexed, and force-merged on the UPGRADED (fixed) cluster with the
+    // same documents. The fix keeps the vector out of _source on merge.
+    // The new-cluster index must therefore be strictly smaller than the pre-fix one; both are deleted at the end.
+    // This only holds when the old cluster predates the fix, so build.gradle excludes this test for BWC >= 3.8.
     public void testDerivedSourceExcludeMergeBloatBefore3_8_0() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
 
@@ -211,114 +217,76 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
         String excludedKeywordField = "label";
         int dimension = 128;
 
-        String derivedExclude = getIndexName("knn-bwc", "derived-exclude-", false);
-        String nonDerivedExclude = getIndexName("knn-bwc", "nonderived-exclude-", false);
-        String derivedNoExclude = getIndexName("knn-bwc", "derived-noexclude-", false);
+        String oldBuilt = getIndexName("knn-bwc", "old-exclude-", false);
+        String newBuilt = getIndexName("knn-bwc", "new-exclude-", false);
 
         if (isRunningAgainstOldCluster()) {
-            createSourceExcludeIndex(derivedExclude, vectorField, excludedKeywordField, dimension, true, true);
-            createSourceExcludeIndex(nonDerivedExclude, vectorField, excludedKeywordField, dimension, false, true);
-            createSourceExcludeIndex(derivedNoExclude, vectorField, excludedKeywordField, dimension, true, false);
-
-            // Index the first 100 docs (ids 0..99, 5 batches of 20) into each index and flush so
-            // multiple segments are written on old.
-            indexSourceExcludeDocs(
-                List.of(derivedExclude, nonDerivedExclude, derivedNoExclude),
-                vectorField,
-                excludedKeywordField,
-                dimension,
-                0
-            );
-            flushIndex(derivedExclude);
-            flushIndex(nonDerivedExclude);
-            flushIndex(derivedNoExclude);
-            // No assertions on the old cluster: this phase only seeds indices/segments that survive the
-            // restart. The fix is exercised by the force-merge on the upgraded cluster below.
+            // Build and force-merge on the pre-fix cluster: the merge re-injects vectors into _source (#3316),
+            // so this index is bloated. It is kept (not deleted here) and survives the restart as the reference.
+            createSourceExcludeIndex(oldBuilt, vectorField, excludedKeywordField, dimension, true, true);
+            indexSourceExcludeDocs(List.of(oldBuilt), vectorField, excludedKeywordField, dimension, 0);
+            forceMergeKnnIndex(oldBuilt, 1);
         } else {
-            // Index another 100 docs (5 batches of 20) on the upgraded node starting right after the
-            // old-cluster ids, then force-merge to a single segment.
-            int newClusterStartId = NUM_BATCHES * DOCS_PER_BATCH;
-            indexSourceExcludeDocs(
-                List.of(derivedExclude, nonDerivedExclude, derivedNoExclude),
-                vectorField,
-                excludedKeywordField,
-                dimension,
-                newClusterStartId
-            );
-            forceMergeKnnIndex(derivedExclude, 1);
-            forceMergeKnnIndex(nonDerivedExclude, 1);
-            forceMergeKnnIndex(derivedNoExclude, 1);
+            try {
+                // Create a new index and index the same documents on the upgraded (fixed) cluster, then merge.
+                createSourceExcludeIndex(newBuilt, vectorField, excludedKeywordField, dimension, true, true);
+                indexSourceExcludeDocs(List.of(newBuilt), vectorField, excludedKeywordField, dimension, 0);
+                forceMergeKnnIndex(newBuilt, 1);
 
-            // Correctness (the #2472 guard): a search fetching 10+ adjacent documents still reconstructs
-            // the full vector into _source, and the excluded field is absent.
-            assertVectorPresentAndFieldExcluded(derivedExclude, vectorField, excludedKeywordField, dimension, 20);
+                // Correctness (the #2472 guard): a search fetching 10+ adjacent documents still reconstructs the
+                // full vector into _source, and the excluded field is absent.
+                assertVectorPresentAndFieldExcluded(newBuilt, vectorField, excludedKeywordField, dimension, 20);
 
-            // kNN search must still work after the upgrade + force-merge and must return identical top-k
-            // across all three indices - the fix only changes what is stored in _source, not what the
-            // vector index returns. This runs unconditionally (not just in exhaustive mode).
-            float[] queryVector = new float[dimension];
-            Random queryRandom = new Random(4321);
-            for (int d = 0; d < dimension; d++) {
-                queryVector[d] = queryRandom.nextFloat();
-            }
-            int k = 10;
-            List<String> derivedExcludeIds = knnSearchDocIds(derivedExclude, vectorField, queryVector, k);
-            List<String> nonDerivedExcludeIds = knnSearchDocIds(nonDerivedExclude, vectorField, queryVector, k);
-            List<String> derivedNoExcludeIds = knnSearchDocIds(derivedNoExclude, vectorField, queryVector, k);
+                // kNN search must still work after the upgrade + force-merge - the fix only changes what is
+                // stored in _source, not what the vector index returns.
+                float[] queryVector = new float[dimension];
+                Random queryRandom = new Random(4321);
+                for (int d = 0; d < dimension; d++) {
+                    queryVector[d] = queryRandom.nextFloat();
+                }
+                int k = 10;
+                assertEquals(
+                    "Expected k results from the new-cluster index",
+                    k,
+                    knnSearchDocIds(newBuilt, vectorField, queryVector, k).size()
+                );
 
-            assertEquals("Expected k results from derived+exclude index", k, derivedExcludeIds.size());
-            assertEquals(
-                "derived+exclude and non-derived+exclude indices should return the same top-k docs",
-                nonDerivedExcludeIds,
-                derivedExcludeIds
-            );
-            assertEquals(
-                "derived+exclude and derived+no-exclude indices should return the same top-k docs",
-                derivedNoExcludeIds,
-                derivedExcludeIds
-            );
+                int oldBuiltSize = indexSizeInBytes(oldBuilt);
+                int newBuiltSize = indexSizeInBytes(newBuilt);
 
-            if (isExhaustive()) {
-                int derivedExcludeSize = indexSizeInBytes(derivedExclude);
-                int nonDerivedExcludeSize = indexSizeInBytes(nonDerivedExclude);
-                int derivedNoExcludeSize = indexSizeInBytes(derivedNoExclude);
-
-                // The bug's signature: after the force-merge on the upgraded node the vector must not be
-                // re-injected, so derived+exclude stays well below the non-derived index.
+                // Same mapping and same documents, but the fixed code does not re-inject vectors into _source on
+                // merge, so the new-cluster index must be strictly smaller than the pre-fix (bloated) one. The
+                // vector index files are identical across both, so the difference is exactly the un-bloated _source.
                 assertTrue(
                     String.format(
                         Locale.ROOT,
-                        "After force-merge on new cluster the derived+exclude index (%d bytes) should be"
-                            + " smaller than the non-derived+exclude index (%d bytes)",
-                        derivedExcludeSize,
-                        nonDerivedExcludeSize
+                        "New-cluster (fixed) index (%d bytes) should be smaller than the old-cluster (pre-fix) index "
+                            + "(%d bytes) for the same documents, since the fix keeps vectors out of _source on merge",
+                        newBuiltSize,
+                        oldBuiltSize
                     ),
-                    derivedExcludeSize < nonDerivedExcludeSize
+                    newBuiltSize < oldBuiltSize
                 );
-
-                // ...and it should have shrunk back essentially to the no-exclude baseline rather than
-                // bloating toward the non-derived (full-vector-in-_source) size. With the fix the only
-                // difference from the baseline is minor exclude-related overhead, so allow just 10% over
-                // the baseline - far below the re-injected-vector size.
-                long baselineTolerance = derivedNoExcludeSize + (derivedNoExcludeSize / 10);
-                assertTrue(
-                    String.format(
-                        Locale.ROOT,
-                        "After force-merge the derived+exclude index (%d bytes) should stay within 10%% of the"
-                            + " derived+no-exclude baseline (%d bytes, i.e. <= %d bytes), not bloat toward the"
-                            + " non-derived size (%d bytes)",
-                        derivedExcludeSize,
-                        derivedNoExcludeSize,
-                        baselineTolerance,
-                        nonDerivedExcludeSize
-                    ),
-                    derivedExcludeSize <= baselineTolerance
-                );
+            } finally {
+                // BWC tests preserve indices across the restart (preserveIndicesUponCompletion() == true), so both
+                // are cleaned up explicitly at the end. Best-effort deletes so a failed assertion above does not
+                // leak the indices into later tests in this suite.
+                deleteIndicesQuietly(oldBuilt, newBuilt);
             }
+        }
+    }
 
-            deleteKNNIndex(derivedExclude);
-            deleteKNNIndex(nonDerivedExclude);
-            deleteKNNIndex(derivedNoExclude);
+    /**
+     * Best-effort delete of the given indices, used on cleanup paths where a delete failure (for example a
+     * missing index) must not mask the real test failure.
+     */
+    private void deleteIndicesQuietly(String... indices) {
+        for (String index : indices) {
+            try {
+                deleteKNNIndex(index);
+            } catch (Exception e) {
+                logger.warn("Failed to delete index [" + index + "] during cleanup", e);
+            }
         }
     }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -5,23 +5,30 @@
 
 package org.opensearch.knn.bwc;
 
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.DerivedSourceTestCase;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.common.KNNConstants;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.TestUtils.BWC_VERSION;
 import static org.opensearch.knn.TestUtils.CLIENT_TIMEOUT_VALUE;
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
@@ -192,6 +199,270 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
             .endObject()
             .endObject();
         return builder.toString();
+    }
+
+    // BWC regression test for #3316 (fixed in #3465): seed indices on the old cluster, then force-merge on
+    // the upgraded cluster and verify the vector is not re-injected into _source. The bug only reproduces
+    // before the 3.8 fix, so the build.gradle version filter excludes this test for BWC versions >= 3.8.
+    public void testDerivedSourceExcludeMergeBloatBefore3_8_0() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        String vectorField = "test_vector";
+        String excludedKeywordField = "label";
+        int dimension = 128;
+
+        String derivedExclude = getIndexName("knn-bwc", "derived-exclude-", false);
+        String nonDerivedExclude = getIndexName("knn-bwc", "nonderived-exclude-", false);
+        String derivedNoExclude = getIndexName("knn-bwc", "derived-noexclude-", false);
+
+        if (isRunningAgainstOldCluster()) {
+            createSourceExcludeIndex(derivedExclude, vectorField, excludedKeywordField, dimension, true, true);
+            createSourceExcludeIndex(nonDerivedExclude, vectorField, excludedKeywordField, dimension, false, true);
+            createSourceExcludeIndex(derivedNoExclude, vectorField, excludedKeywordField, dimension, true, false);
+
+            // Index the first 100 docs (ids 0..99, 5 batches of 20) into each index and flush so
+            // multiple segments are written on old.
+            indexSourceExcludeDocs(
+                List.of(derivedExclude, nonDerivedExclude, derivedNoExclude),
+                vectorField,
+                excludedKeywordField,
+                dimension,
+                0
+            );
+            flushIndex(derivedExclude);
+            flushIndex(nonDerivedExclude);
+            flushIndex(derivedNoExclude);
+            // No assertions on the old cluster: this phase only seeds indices/segments that survive the
+            // restart. The fix is exercised by the force-merge on the upgraded cluster below.
+        } else {
+            // Index another 100 docs (5 batches of 20) on the upgraded node starting right after the
+            // old-cluster ids, then force-merge to a single segment.
+            int newClusterStartId = NUM_BATCHES * DOCS_PER_BATCH;
+            indexSourceExcludeDocs(
+                List.of(derivedExclude, nonDerivedExclude, derivedNoExclude),
+                vectorField,
+                excludedKeywordField,
+                dimension,
+                newClusterStartId
+            );
+            forceMergeKnnIndex(derivedExclude, 1);
+            forceMergeKnnIndex(nonDerivedExclude, 1);
+            forceMergeKnnIndex(derivedNoExclude, 1);
+
+            // Correctness (the #2472 guard): a search fetching 10+ adjacent documents still reconstructs
+            // the full vector into _source, and the excluded field is absent.
+            assertVectorPresentAndFieldExcluded(derivedExclude, vectorField, excludedKeywordField, dimension, 20);
+
+            // kNN search must still work after the upgrade + force-merge and must return identical top-k
+            // across all three indices - the fix only changes what is stored in _source, not what the
+            // vector index returns. This runs unconditionally (not just in exhaustive mode).
+            float[] queryVector = new float[dimension];
+            Random queryRandom = new Random(4321);
+            for (int d = 0; d < dimension; d++) {
+                queryVector[d] = queryRandom.nextFloat();
+            }
+            int k = 10;
+            List<String> derivedExcludeIds = knnSearchDocIds(derivedExclude, vectorField, queryVector, k);
+            List<String> nonDerivedExcludeIds = knnSearchDocIds(nonDerivedExclude, vectorField, queryVector, k);
+            List<String> derivedNoExcludeIds = knnSearchDocIds(derivedNoExclude, vectorField, queryVector, k);
+
+            assertEquals("Expected k results from derived+exclude index", k, derivedExcludeIds.size());
+            assertEquals(
+                "derived+exclude and non-derived+exclude indices should return the same top-k docs",
+                nonDerivedExcludeIds,
+                derivedExcludeIds
+            );
+            assertEquals(
+                "derived+exclude and derived+no-exclude indices should return the same top-k docs",
+                derivedNoExcludeIds,
+                derivedExcludeIds
+            );
+
+            if (isExhaustive()) {
+                int derivedExcludeSize = indexSizeInBytes(derivedExclude);
+                int nonDerivedExcludeSize = indexSizeInBytes(nonDerivedExclude);
+                int derivedNoExcludeSize = indexSizeInBytes(derivedNoExclude);
+
+                // The bug's signature: after the force-merge on the upgraded node the vector must not be
+                // re-injected, so derived+exclude stays well below the non-derived index.
+                assertTrue(
+                    String.format(
+                        Locale.ROOT,
+                        "After force-merge on new cluster the derived+exclude index (%d bytes) should be"
+                            + " smaller than the non-derived+exclude index (%d bytes)",
+                        derivedExcludeSize,
+                        nonDerivedExcludeSize
+                    ),
+                    derivedExcludeSize < nonDerivedExcludeSize
+                );
+
+                // ...and it should have shrunk back essentially to the no-exclude baseline rather than
+                // bloating toward the non-derived (full-vector-in-_source) size. With the fix the only
+                // difference from the baseline is minor exclude-related overhead, so allow just 10% over
+                // the baseline - far below the re-injected-vector size.
+                long baselineTolerance = derivedNoExcludeSize + (derivedNoExcludeSize / 10);
+                assertTrue(
+                    String.format(
+                        Locale.ROOT,
+                        "After force-merge the derived+exclude index (%d bytes) should stay within 10%% of the"
+                            + " derived+no-exclude baseline (%d bytes, i.e. <= %d bytes), not bloat toward the"
+                            + " non-derived size (%d bytes)",
+                        derivedExcludeSize,
+                        derivedNoExcludeSize,
+                        baselineTolerance,
+                        nonDerivedExcludeSize
+                    ),
+                    derivedExcludeSize <= baselineTolerance
+                );
+            }
+
+            deleteKNNIndex(derivedExclude);
+            deleteKNNIndex(nonDerivedExclude);
+            deleteKNNIndex(derivedNoExclude);
+        }
+    }
+
+    // Each phase writes NUM_BATCHES segments (one refresh per batch) so the subsequent force-merge has
+    // >1 segment to combine. The #3316 bug only manifests when a segment merge actually runs.
+    private static final int NUM_BATCHES = 5;
+    private static final int DOCS_PER_BATCH = 20;
+
+    private void indexSourceExcludeDocs(
+        List<String> indices,
+        String vectorField,
+        String excludedKeywordField,
+        int dimension,
+        int startIdInclusive
+    ) throws IOException {
+        int nextId = startIdInclusive;
+        for (int batch = 0; batch < NUM_BATCHES; batch++) {
+            indexSourceExcludeBatch(indices, vectorField, excludedKeywordField, dimension, nextId, nextId + DOCS_PER_BATCH - 1);
+            nextId += DOCS_PER_BATCH;
+        }
+    }
+
+    // Indexes docs [startIdInclusive, endIdInclusive] into every index and refreshes once, producing a
+    // single new segment per index (addKnnDoc does not refresh per doc).
+    private void indexSourceExcludeBatch(
+        List<String> indices,
+        String vectorField,
+        String excludedKeywordField,
+        int dimension,
+        int startIdInclusive,
+        int endIdInclusive
+    ) throws IOException {
+        // Seed by start id so the batch generates distinct-but-reproducible vectors.
+        Random random = new Random(startIdInclusive);
+        for (int i = startIdInclusive; i <= endIdInclusive; i++) {
+            float[] vector = new float[dimension];
+            for (int d = 0; d < dimension; d++) {
+                vector[d] = random.nextFloat();
+            }
+            String docId = String.valueOf(i);
+            String doc = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(vectorField, vector)
+                .field(excludedKeywordField, "label-" + i)
+                .endObject()
+                .toString();
+            for (String index : indices) {
+                addKnnDoc(index, docId, doc);
+            }
+        }
+        for (String index : indices) {
+            refreshIndex(index);
+        }
+    }
+
+    private void createSourceExcludeIndex(
+        String indexName,
+        String vectorField,
+        String excludedKeywordField,
+        int dimension,
+        boolean derivedSourceEnabled,
+        boolean withExclude
+    ) throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject();
+        if (withExclude) {
+            mapping.startObject("_source").array("excludes", excludedKeywordField).endObject();
+        }
+        mapping.startObject(KNNConstants.PROPERTIES)
+            .startObject(vectorField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .endObject()
+            .startObject(excludedKeywordField)
+            .field(KNNConstants.TYPE, "keyword")
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(
+            indexName,
+            Settings.builder().put("index.knn", true).put("index.knn.derived_source.enabled", derivedSourceEnabled).build(),
+            mapping.toString()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertVectorPresentAndFieldExcluded(String indexName, String vectorField, String excludedField, int dimension, int size)
+        throws Exception {
+        XContentBuilder searchBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("size", size)
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Request searchRequest = new Request("POST", "/" + indexName + "/_search");
+        searchRequest.setJsonEntity(searchBuilder.toString());
+        Response response = client().performRequest(searchRequest);
+
+        List<Object> hitsList = parseSearchResponseHits(EntityUtils.toString(response.getEntity()));
+
+        assertTrue("Expected at least 10 hits to exercise the sequential fetch path", hitsList.size() >= 10);
+        for (Object hitObj : hitsList) {
+            Map<String, Object> source = (Map<String, Object>) ((Map<String, Object>) hitObj).get("_source");
+            assertTrue(
+                String.format(Locale.ROOT, "Vector field '%s' should be reconstructed into _source", vectorField),
+                source.containsKey(vectorField)
+            );
+            assertEquals(
+                String.format(Locale.ROOT, "Reconstructed vector '%s' should have full dimension", vectorField),
+                dimension,
+                ((List<Object>) source.get(vectorField)).size()
+            );
+            assertFalse(
+                String.format(Locale.ROOT, "Excluded field '%s' should be absent from _source", excludedField),
+                source.containsKey(excludedField)
+            );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> knnSearchDocIds(String indexName, String vectorField, float[] queryVector, int k) throws Exception {
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(vectorField)
+            .field("vector", queryVector)
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = searchKNNIndex(indexName, queryBuilder, k);
+        List<Object> hits = parseSearchResponseHits(EntityUtils.toString(response.getEntity()));
+
+        List<String> docIds = new ArrayList<>();
+        for (Object hit : hits) {
+            docIds.add((String) ((Map<String, Object>) hit).get("_id"));
+        }
+        return docIds;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description
Adds testDerivedSourceExcludeMergeBloatBefore3_8_0 to DerivedSourceBWCRestartIT. The #3316 bug re-injected the vector into stored _source on merge when derived source was enabled and the mapping filtered _source. This BWC test seeds three indices (derived+exclude, non-derived+exclude, derived+no-exclude) on the old cluster, then on the upgraded cluster ingests more docs, force-merges, and asserts the vector is reconstructed into _source, the excluded field is absent, kNN top-k is identical across all three indices, and (in exhaustive mode) the derived+exclude index stays near the no-exclude baseline and well below the non-derived size.

The bug only reproduces before the 3.8 fix, so the build.gradle version filter excludes the test for BWC versions >= 3.8 in both the old-cluster and upgraded-cluster tasks.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
