### PR TITLE
Terminate remote index build early when merge is aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Support `index.knn.advanced.approximate_threshold` for the Lucene engine [#3451](https://github.com/opensearch-project/k-NN/pull/3451)
 * Convert document vectors to primitive arrays once per document in lateInteractionScore, instead of once per query-vector/document-vector pair [#3453](https://github.com/opensearch-project/k-NN/pull/3453)
+* Terminate remote index build early when the merge has been aborted [#3488](https://github.com/opensearch-project/k-NN/pull/3488)

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.codec.nativeindex.remote;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.common.StopWatch;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
+import org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy.BuildResult;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
 import java.io.IOException;
@@ -16,7 +17,9 @@ import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorV
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.BUILD_REQUEST_FAILURE_COUNT;
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.BUILD_REQUEST_SUCCESS_COUNT;
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION;
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_SUCCESS_COUNT;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION;
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.READ_FAILURE_COUNT;
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.READ_SUCCESS_COUNT;
 import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.READ_TIME;
@@ -132,17 +135,34 @@ public class RemoteIndexBuildMetrics {
     }
 
     /**
-     * Helper method to collect overall remote index build metrics
+     * Helper method to collect overall remote index build metrics. The {@link BuildResult} determines which outcome
+     * counter is incremented. Benign terminations (merge aborts and terminal IO exceptions) are tracked with their own
+     * counters rather than {@link org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue#INDEX_BUILD_FAILURE_COUNT},
+     * so that {@code INDEX_BUILD_FAILURE_COUNT} reflects only genuine build failures
      */
-    public void endRemoteIndexBuildMetrics(boolean wasSuccessful) {
+    public void endRemoteIndexBuildMetrics(BuildResult buildResult) {
         long time_in_millis = overallStopWatch.stop().totalTime().millis();
-        if (wasSuccessful) {
-            INDEX_BUILD_SUCCESS_COUNT.increment();
-            log.debug("Remote index build succeeded after {} ms for vector field [{}]", time_in_millis, fieldName);
-        } else {
-            INDEX_BUILD_FAILURE_COUNT.increment();
-            log.debug("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
+        final String outcome;
+        switch (buildResult) {
+            case SUCCESS:
+                INDEX_BUILD_SUCCESS_COUNT.increment();
+                outcome = "succeeded";
+                break;
+            case MERGE_ABORT:
+                INDEX_BUILD_MERGE_ABORT_EXCEPTION.increment();
+                outcome = "aborted";
+                break;
+            case TERMINAL_IO:
+                INDEX_BUILD_TERMINAL_EXCEPTION.increment();
+                outcome = "terminated";
+                break;
+            case FAILURE:
+            default:
+                INDEX_BUILD_FAILURE_COUNT.increment();
+                outcome = "failed";
+                break;
         }
+        log.debug("Remote index build {} after {} ms for vector field [{}]", outcome, time_in_millis, fieldName);
         if (isFlush) {
             REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS.decrement();
             REMOTE_INDEX_BUILD_CURRENT_FLUSH_SIZE.decrementBy(size);

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.nativeindex.remote;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.MergeAbortChecker;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.metadata.RepositoryMetadata;
 import org.opensearch.common.UUIDs;
@@ -17,6 +18,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.knn.common.exception.TerminalIOException;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.nativeindex.IndexBuildAbortedException;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategy;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
@@ -138,6 +140,22 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
     }
 
     /**
+     * The outcome of a remote index build attempt. Used to centralize metric emission in
+     * {@link RemoteIndexBuildMetrics#endRemoteIndexBuildMetrics(BuildResult)} so that benign terminations are not
+     * counted as build failures.
+     */
+    public enum BuildResult {
+        /** The build completed successfully. */
+        SUCCESS,
+        /** The build failed due to a genuine error and will fall back to a local CPU build. */
+        FAILURE,
+        /** The build was terminated because the merge was aborted (benign cancellation). */
+        MERGE_ABORT,
+        /** The build was terminated due to a terminal IO exception (index output closed). */
+        TERMINAL_IO
+    }
+
+    /**
      * Entry point for flush/merge operations. This method orchestrates the following:
      *      1. Writes required data to repository
      *      2. Triggers index build
@@ -152,7 +170,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
     @Override
     public void buildAndWriteIndex(BuildIndexParams indexInfo) throws IOException {
         metrics.startRemoteIndexBuildMetrics(indexInfo);
-        boolean success = false;
+        BuildResult buildResult = BuildResult.FAILURE;
         try {
             RepositoryContext repositoryContext = getRepositoryContext(indexInfo);
 
@@ -168,17 +186,29 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
 
             // 4. Download index file and write to indexOutput
             readFromRepository(indexInfo, repositoryContext, remoteBuildStatusResponse);
-            success = true;
+            buildResult = BuildResult.SUCCESS;
             return;
         } catch (TerminalIOException e) {
+            log.warn("Remote index build terminated for field [{}], not falling back to CPU build", indexInfo.getField(), e);
+            buildResult = BuildResult.TERMINAL_IO;
+            throw e;
+        } catch (IndexBuildAbortedException e) {
+            log.warn(
+                "Remote index build aborted due to merge cancellation for field [{}], not falling back to CPU build",
+                indexInfo.getField(),
+                e
+            );
+            buildResult = BuildResult.MERGE_ABORT;
             throw e;
         } catch (Exception e) {
             log.error("Failed to build index remotely: " + indexInfo, e);
         } finally {
-            metrics.endRemoteIndexBuildMetrics(success);
+            // Metric emission is centralized here so that benign terminations (merge aborts, terminal IO) are not
+            // counted as build failures. The exact counter incremented is determined by buildResult.
+            metrics.endRemoteIndexBuildMetrics(buildResult);
         }
         // Recreate the IndexOutput before fallback to discard any partially written remote data
-        assert !success : "Should not reach fallback path when remote build succeeded";
+        assert buildResult == BuildResult.FAILURE : "Should only reach fallback path when remote build failed";
         if (indexInfo.getIndexOutputWithBuffer().getBytesWritten() > 0) {
             log.info(
                 "Clearing the indexOutput buffer since some data has been written in file: {} : {} bytes, before falling back to local index build",
@@ -256,16 +286,19 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         RemoteBuildResponse remoteBuildResponse,
         BuildIndexParams indexInfo,
         RemoteIndexClient client
-    ) {
+    ) throws IndexBuildAbortedException {
         RemoteBuildStatusResponse remoteBuildStatusResponse;
         metrics.startWaitingMetrics();
         try {
             final RemoteBuildStatusRequest remoteBuildStatusRequest = RemoteBuildStatusRequest.builder()
                 .jobId(remoteBuildResponse.getJobId())
                 .build();
-            RemoteIndexWaiter waiter = RemoteIndexWaiterFactory.getRemoteIndexWaiter(client);
+            RemoteIndexWaiter waiter = RemoteIndexWaiterFactory.getRemoteIndexWaiter(client, MergeAbortChecker::isMergeAborted);
             remoteBuildStatusResponse = waiter.awaitVectorBuild(remoteBuildStatusRequest);
             return remoteBuildStatusResponse;
+        } catch (IndexBuildAbortedException e) {
+            // Propagate merge aborts so buildAndWriteIndex can terminate without falling back to a local CPU build.
+            throw e;
         } catch (InterruptedException | IOException e) {
             throw new RuntimeException(String.format("Await index build failed for vector field [%s]", indexInfo.getField()), e);
         } finally {

--- a/src/main/java/org/opensearch/knn/index/remote/RemoteIndexPoller.java
+++ b/src/main/java/org/opensearch/knn/index/remote/RemoteIndexPoller.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.remote;
 
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.opensearch.knn.index.codec.nativeindex.IndexBuildAbortedException;
 import org.opensearch.remoteindexbuild.client.RemoteIndexClient;
 import org.opensearch.remoteindexbuild.model.RemoteBuildStatusRequest;
 import org.opensearch.remoteindexbuild.model.RemoteBuildStatusResponse;
@@ -14,6 +15,7 @@ import org.opensearch.remoteindexbuild.model.RemoteBuildStatusResponse;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Random;
+import java.util.function.Supplier;
 
 import static org.opensearch.knn.index.KNNSettings.getRemoteBuildClientPollInterval;
 import static org.opensearch.knn.index.KNNSettings.getRemoteBuildClientTimeout;
@@ -35,14 +37,22 @@ public class RemoteIndexPoller implements RemoteIndexWaiter {
     public static final String FAILED_INDEX_BUILD = "FAILED_INDEX_BUILD";
 
     private final RemoteIndexClient client;
+    /** Supplier that returns true if the current merge operation has been aborted. Checked each poll iteration. */
+    private final Supplier<Boolean> isMergeAborted;
     private final Random random;
     @Setter
     private long timeout; // Timeout in nanoseconds, to use same units as System.nanoTime().
     @Setter
     private long pollInterval; // Poll interval in milliseconds
 
-    RemoteIndexPoller(RemoteIndexClient client) {
+    /**
+     * @param client         the remote index client used to check build status
+     * @param isMergeAborted supplier indicating whether the merge has been aborted; in production this is
+     *                       typically {@code MergeAbortChecker::isMergeAborted}
+     */
+    RemoteIndexPoller(RemoteIndexClient client, Supplier<Boolean> isMergeAborted) {
         this.client = client;
+        this.isMergeAborted = isMergeAborted;
         this.random = new Random();
         this.timeout = getRemoteBuildClientTimeout().getNanos();
         this.pollInterval = getRemoteBuildClientPollInterval().getMillis();
@@ -50,11 +60,14 @@ public class RemoteIndexPoller implements RemoteIndexWaiter {
 
     /**
      * Polls the remote endpoint for the status of the build job until timeout.
+     * On each iteration, checks whether the merge has been aborted via the {@code isMergeAborted} supplier.
+     * If aborted, throws {@link IndexBuildAbortedException} to terminate the build early.
      *
      * @param remoteBuildStatusRequest The response from the initial build request
      * @return RemoteBuildStatusResponse containing the path of the completed build job
-     * @throws InterruptedException if the thread is interrupted while polling
+     * @throws InterruptedException if the thread is interrupted while polling or the build fails/times out
      * @throws IOException if an I/O error occurs
+     * @throws IndexBuildAbortedException if the merge is aborted during polling
      */
     public RemoteBuildStatusResponse awaitVectorBuild(RemoteBuildStatusRequest remoteBuildStatusRequest) throws InterruptedException,
         IOException {
@@ -65,6 +78,9 @@ public class RemoteIndexPoller implements RemoteIndexWaiter {
         sleepWithJitter(pollInterval * INITIAL_DELAY_FACTOR);
 
         while (System.nanoTime() - startTime < timeout) {
+            if (isMergeAborted.get()) {
+                throw new IndexBuildAbortedException("Merge aborted during remote index build");
+            }
             RemoteBuildStatusResponse remoteBuildStatusResponse;
             try {
                 remoteBuildStatusResponse = client.getBuildStatus(remoteBuildStatusRequest);

--- a/src/main/java/org/opensearch/knn/index/remote/RemoteIndexWaiterFactory.java
+++ b/src/main/java/org/opensearch/knn/index/remote/RemoteIndexWaiterFactory.java
@@ -7,12 +7,17 @@ package org.opensearch.knn.index.remote;
 
 import org.opensearch.remoteindexbuild.client.RemoteIndexClient;
 
+import java.util.function.Supplier;
+
 public class RemoteIndexWaiterFactory {
 
     /**
      * Get the corresponding Waiter implementation for the given RemoteIndexClient. Defaults to Poller for now.
+     * @param client the remote index client used to check build status
+     * @param isMergeAborted supplier that returns true if the merge has been aborted; enables early termination
+     *                       of polling when the merge is no longer needed
      */
-    public static RemoteIndexWaiter getRemoteIndexWaiter(RemoteIndexClient client) {
-        return new RemoteIndexPoller(client);
+    public static RemoteIndexWaiter getRemoteIndexWaiter(RemoteIndexClient client, Supplier<Boolean> isMergeAborted) {
+        return new RemoteIndexPoller(client, isMergeAborted);
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/stats/KNNRemoteIndexBuildValue.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/KNNRemoteIndexBuildValue.java
@@ -34,6 +34,8 @@ public enum KNNRemoteIndexBuildValue {
     STATUS_REQUEST_FAILURE_COUNT("status_request_failure_count"),
     INDEX_BUILD_SUCCESS_COUNT("index_build_success_count"),
     INDEX_BUILD_FAILURE_COUNT("index_build_failure_count"),
+    INDEX_BUILD_MERGE_ABORT_EXCEPTION("index_build_merge_abort_exception"),
+    INDEX_BUILD_TERMINAL_EXCEPTION("index_build_terminal_exception"),
     WAITING_TIME("waiting_time_in_ms");
 
     @Getter

--- a/src/main/java/org/opensearch/knn/plugin/stats/KNNStats.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/KNNStats.java
@@ -242,6 +242,14 @@ public class KNNStats {
             KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT.getName(),
             KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT.getValue()
         );
+        clientStatsMap.put(
+            KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION.getName(),
+            KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION.getValue()
+        );
+        clientStatsMap.put(
+            KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.getName(),
+            KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.getValue()
+        );
         clientStatsMap.put(KNNRemoteIndexBuildValue.WAITING_TIME.getName(), KNNRemoteIndexBuildValue.WAITING_TIME.getValue());
 
         Map<String, Object> repoStatsMap = new HashMap<>();

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetricsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetricsTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.nativeindex.remote;
+
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
+import org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy.BuildResult;
+import org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_SUCCESS_COUNT;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.REMOTE_INDEX_BUILD_CURRENT_FLUSH_SIZE;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.REMOTE_INDEX_BUILD_CURRENT_MERGE_OPERATIONS;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.REMOTE_INDEX_BUILD_CURRENT_MERGE_SIZE;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.REMOTE_INDEX_BUILD_FLUSH_TIME;
+import static org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue.REMOTE_INDEX_BUILD_MERGE_TIME;
+
+/**
+ * Unit tests for {@link RemoteIndexBuildMetrics}, focusing on {@link RemoteIndexBuildMetrics#endRemoteIndexBuildMetrics}
+ * which maps each {@link BuildResult} to the correct outcome counter. Benign terminations (merge aborts, terminal IO)
+ * must be tracked with their own counters rather than {@link KNNRemoteIndexBuildValue#INDEX_BUILD_FAILURE_COUNT}.
+ */
+public class RemoteIndexBuildMetricsTests extends RemoteIndexBuildTests {
+
+    /**
+     * A SUCCESS outcome increments only the success counter.
+     */
+    public void testEndMetricsSuccessIncrementsSuccessCounterOnly() throws IOException {
+        runAndAssertOutcome(BuildResult.SUCCESS, INDEX_BUILD_SUCCESS_COUNT);
+    }
+
+    /**
+     * A FAILURE outcome increments only the failure counter.
+     */
+    public void testEndMetricsFailureIncrementsFailureCounterOnly() throws IOException {
+        runAndAssertOutcome(BuildResult.FAILURE, INDEX_BUILD_FAILURE_COUNT);
+    }
+
+    /**
+     * A MERGE_ABORT is a benign cancellation, tracked by its own counter and not counted as a build failure.
+     */
+    public void testEndMetricsMergeAbortIncrementsAbortCounterOnly() throws IOException {
+        runAndAssertOutcome(BuildResult.MERGE_ABORT, INDEX_BUILD_MERGE_ABORT_EXCEPTION);
+    }
+
+    /**
+     * A TERMINAL_IO termination is benign, tracked by its own counter and not counted as a build failure.
+     */
+    public void testEndMetricsTerminalIoIncrementsTerminalCounterOnly() throws IOException {
+        runAndAssertOutcome(BuildResult.TERMINAL_IO, INDEX_BUILD_TERMINAL_EXCEPTION);
+    }
+
+    /**
+     * For a flush operation, the current-flush gauges return to zero after start+end and only the flush timer is updated.
+     */
+    public void testEndMetricsFlushUpdatesFlushTimerAndGauges() throws IOException {
+        RemoteIndexBuildMetrics metrics = new RemoteIndexBuildMetrics();
+        metrics.startRemoteIndexBuildMetrics(buildParamsWithFlush(true));
+        metrics.endRemoteIndexBuildMetrics(BuildResult.SUCCESS);
+
+        // Start increments the gauges, end decrements them, so they net back to zero.
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS.getValue());
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_FLUSH_SIZE.getValue());
+        assertTrue(REMOTE_INDEX_BUILD_FLUSH_TIME.getValue() >= 0L);
+        // Merge counters must remain untouched for a flush operation.
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_MERGE_OPERATIONS.getValue());
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_MERGE_SIZE.getValue());
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_MERGE_TIME.getValue());
+    }
+
+    /**
+     * For a merge operation, the current-merge gauges return to zero after start+end and only the merge timer is updated.
+     */
+    public void testEndMetricsMergeUpdatesMergeTimerAndGauges() throws IOException {
+        RemoteIndexBuildMetrics metrics = new RemoteIndexBuildMetrics();
+        metrics.startRemoteIndexBuildMetrics(buildParamsWithFlush(false));
+        metrics.endRemoteIndexBuildMetrics(BuildResult.SUCCESS);
+
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_MERGE_OPERATIONS.getValue());
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_MERGE_SIZE.getValue());
+        assertTrue(REMOTE_INDEX_BUILD_MERGE_TIME.getValue() >= 0L);
+        // Flush counters must remain untouched for a merge operation.
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS.getValue());
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_CURRENT_FLUSH_SIZE.getValue());
+        assertEquals(0L, (long) REMOTE_INDEX_BUILD_FLUSH_TIME.getValue());
+    }
+
+    /**
+     * Runs a full start/end metrics cycle for the given {@link BuildResult} and asserts that only {@code expectedCounter}
+     * among the four outcome counters was incremented.
+     */
+    private void runAndAssertOutcome(BuildResult buildResult, KNNRemoteIndexBuildValue expectedCounter) throws IOException {
+        RemoteIndexBuildMetrics metrics = new RemoteIndexBuildMetrics();
+        metrics.startRemoteIndexBuildMetrics(buildIndexParams);
+        metrics.endRemoteIndexBuildMetrics(buildResult);
+
+        for (KNNRemoteIndexBuildValue outcomeCounter : new KNNRemoteIndexBuildValue[] {
+            INDEX_BUILD_SUCCESS_COUNT,
+            INDEX_BUILD_FAILURE_COUNT,
+            INDEX_BUILD_MERGE_ABORT_EXCEPTION,
+            INDEX_BUILD_TERMINAL_EXCEPTION }) {
+            long expected = outcomeCounter == expectedCounter ? 1L : 0L;
+            assertEquals("Unexpected value for " + outcomeCounter.getName(), expected, (long) outcomeCounter.getValue());
+        }
+    }
+
+    /**
+     * Builds a {@link BuildIndexParams} identical to the shared one but with a fixed {@code isFlush} value so the
+     * flush vs. merge branches of {@link RemoteIndexBuildMetrics} can be exercised deterministically.
+     */
+    private BuildIndexParams buildParamsWithFlush(boolean isFlush) {
+        return BuildIndexParams.builder()
+            .indexOutputWithBuffer(indexOutputWithBuffer)
+            .knnEngine(buildIndexParams.getKnnEngine())
+            .field(buildIndexParams.getField())
+            .vectorDataType(VectorDataType.FLOAT)
+            .indexParameters(buildIndexParams.getIndexParameters())
+            .knnVectorValuesSupplier(buildIndexParams.getKnnVectorValuesSupplier())
+            .totalLiveDocs(buildIndexParams.getTotalLiveDocs())
+            .segmentWriteState(segmentWriteState)
+            .isFlush(isFlush)
+            .build();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.common.exception.TerminalIOException;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.nativeindex.IndexBuildAbortedException;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -122,6 +124,40 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
 
         assertThrows(TerminalIOException.class, () -> { objectUnderTest.buildAndWriteIndex(buildIndexParams); });
         assertFalse(fallback.get());
+        // A terminal termination is benign and must not be counted as a build failure.
+        assertEquals(0L, (long) KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT.getValue());
+        assertEquals(1L, (long) KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.getValue());
+    }
+
+    /**
+     * Test that we do not fall back to the fallback BuildStrategy when an IndexBuildAbortedException is thrown.
+     * This simulates a merge abort during remote index build - the exception should propagate up
+     * rather than falling back to local build.
+     */
+    public void testRemoteIndexBuildStrategyAbortDoesNotFallback() throws IOException {
+        final SetOnce<Boolean> fallback = new SetOnce<>(Boolean.FALSE);
+
+        RemoteIndexBuildStrategy objectUnderTest = spy(
+            new RemoteIndexBuildStrategy(
+                () -> mock(RepositoriesService.class),
+                new TestIndexBuildStrategy(fallback),
+                mock(IndexSettings.class),
+                null
+            )
+        );
+
+        // Use doAnswer rather than doThrow: IndexBuildAbortedException is not assignable to the
+        // TerminalIOException declared by getRepositoryContext, so doThrow's checked-exception validation
+        // would reject it. The JVM does not enforce checked exceptions at runtime, and buildAndWriteIndex
+        // declares throws IOException, so the abort propagates just as it would from the polling phase.
+        doAnswer(invocation -> { throw new IndexBuildAbortedException("Merge aborted during remote index build"); }).when(objectUnderTest)
+            .getRepositoryContext(any());
+
+        assertThrows(IndexBuildAbortedException.class, () -> { objectUnderTest.buildAndWriteIndex(buildIndexParams); });
+        assertFalse(fallback.get());
+        // A merge abort is a benign cancellation and must not be counted as a build failure.
+        assertEquals(0L, (long) KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT.getValue());
+        assertEquals(1L, (long) KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION.getValue());
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/remote/RemoteIndexPollerTests.java
+++ b/src/test/java/org/opensearch/knn/index/remote/RemoteIndexPollerTests.java
@@ -16,6 +16,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.codec.nativeindex.IndexBuildAbortedException;
 import org.opensearch.remoteindexbuild.client.RemoteIndexClient;
 import org.opensearch.remoteindexbuild.model.RemoteBuildStatusRequest;
 import org.opensearch.remoteindexbuild.model.RemoteBuildStatusResponse;
@@ -24,8 +25,11 @@ import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static org.opensearch.knn.index.remote.RemoteIndexPoller.COMPLETED_INDEX_BUILD;
@@ -75,7 +79,7 @@ public class RemoteIndexPollerTests extends OpenSearchSingleNodeTestCase {
                 .build();
             when(mockClient.getBuildStatus(mockStatusRequest)).thenReturn(runningResponse);
 
-            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient);
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> false);
 
             assertThrows(InterruptedException.class, () -> poller.awaitVectorBuild(mockStatusRequest));
         } catch (Exception e) {
@@ -97,7 +101,7 @@ public class RemoteIndexPollerTests extends OpenSearchSingleNodeTestCase {
                 .build();
             when(mockClient.getBuildStatus(mockStatusRequest)).thenReturn(completedResponse);
 
-            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient);
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> false);
 
             RemoteBuildStatusResponse response = poller.awaitVectorBuild(mockStatusRequest);
             assertEquals(COMPLETED_INDEX_BUILD, response.getTaskStatus());
@@ -124,7 +128,7 @@ public class RemoteIndexPollerTests extends OpenSearchSingleNodeTestCase {
                 .build();
             when(mockClient.getBuildStatus(mockStatusRequest)).thenReturn(failedResponse);
 
-            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient);
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> false);
 
             InterruptedException exception = assertThrows(InterruptedException.class, () -> poller.awaitVectorBuild(mockStatusRequest));
             assertTrue(exception.getMessage().contains(errorMessage));
@@ -158,7 +162,7 @@ public class RemoteIndexPollerTests extends OpenSearchSingleNodeTestCase {
                 .fileName(null)
                 .errorMessage(null)
                 .build();
-            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient);
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> false);
 
             when(mockClient.getBuildStatus(mockStatusRequest)).thenReturn(invalidResponse);
             IOException exception = assertThrows(IOException.class, () -> poller.awaitVectorBuild(mockStatusRequest));
@@ -183,11 +187,61 @@ public class RemoteIndexPollerTests extends OpenSearchSingleNodeTestCase {
                 .fileName(null)
                 .errorMessage(null)
                 .build();
-            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient);
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> false);
 
             when(mockClient.getBuildStatus(mockStatusRequest)).thenReturn(invalidResponse);
             IOException exception = assertThrows(IOException.class, () -> poller.awaitVectorBuild(mockStatusRequest));
             assertEquals("Invalid response format, missing " + TASK_STATUS, exception.getMessage());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Test that when the merge is already aborted before polling begins, the poller throws
+     * IndexBuildAbortedException immediately without making any status requests to the remote service.
+     */
+    public void testAwaitVectorBuildMergeAborted() {
+        try (MockedStatic<KNNSettings> knnSettingsStaticMock = Mockito.mockStatic(KNNSettings.class)) {
+            knnSettingsStaticMock.when(KNNSettings::state).thenReturn(knnSettingsMock);
+
+            when(KNNSettings.getRemoteBuildClientTimeout()).thenReturn(TimeValue.timeValueMinutes(1));
+            when(KNNSettings.getRemoteBuildClientPollInterval()).thenReturn(TimeValue.timeValueMillis(10));
+
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> true);
+
+            assertThrows(IndexBuildAbortedException.class, () -> poller.awaitVectorBuild(mockStatusRequest));
+            verify(mockClient, never()).getBuildStatus(mockStatusRequest);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Test that when a merge is aborted mid-polling, the poller throws IndexBuildAbortedException
+     * after successfully polling twice. Simulates a real scenario where the merge is cancelled
+     * while the remote build is still in progress.
+     */
+    public void testAwaitVectorBuildMergeAbortedAfterPolling() {
+        try (MockedStatic<KNNSettings> knnSettingsStaticMock = Mockito.mockStatic(KNNSettings.class)) {
+            knnSettingsStaticMock.when(KNNSettings::state).thenReturn(knnSettingsMock);
+
+            when(KNNSettings.getRemoteBuildClientTimeout()).thenReturn(TimeValue.timeValueMinutes(1));
+            when(KNNSettings.getRemoteBuildClientPollInterval()).thenReturn(TimeValue.timeValueMillis(10));
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+
+            RemoteBuildStatusResponse runningResponse = RemoteBuildStatusResponse.builder()
+                .taskStatus(RUNNING_INDEX_BUILD)
+                .fileName(null)
+                .errorMessage(null)
+                .build();
+            when(mockClient.getBuildStatus(mockStatusRequest)).thenReturn(runningResponse);
+
+            // Abort after 2 poll iterations
+            RemoteIndexPoller poller = new RemoteIndexPoller(mockClient, () -> pollCount.incrementAndGet() > 2);
+
+            assertThrows(IndexBuildAbortedException.class, () -> poller.awaitVectorBuild(mockStatusRequest));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/opensearch/knn/plugin/stats/KNNStatsTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/stats/KNNStatsTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.plugin.stats;
+
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.Map;
+
+/**
+ * Unit tests for {@link KNNStats}, focusing on the remote vector index build stats map which surfaces the
+ * {@link KNNRemoteIndexBuildValue} counters (including the merge-abort and terminal-exception counters) through
+ * the {@code _stats} API.
+ */
+public class KNNStatsTests extends KNNTestCase {
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        for (KNNRemoteIndexBuildValue value : KNNRemoteIndexBuildValue.values()) {
+            value.reset();
+        }
+    }
+
+    /**
+     * The remote vector index build stats expose client, repository, and build sub-maps, and the client sub-map
+     * surfaces every client-side counter including the benign-termination counters added for early merge abort.
+     */
+    @SuppressWarnings("unchecked")
+    public void testRemoteIndexBuildStatsMapContainsAllCounters() {
+        KNNStats knnStats = new KNNStats();
+
+        Object remoteStatsValue = knnStats.getStats().get(StatNames.REMOTE_VECTOR_INDEX_BUILD_STATS.getName()).getValue();
+        assertTrue(remoteStatsValue instanceof Map);
+        Map<String, Map<String, Object>> remoteStats = (Map<String, Map<String, Object>>) remoteStatsValue;
+
+        // The three sub-maps must all be present.
+        assertTrue(remoteStats.containsKey(StatNames.CLIENT_STATS.getName()));
+        assertTrue(remoteStats.containsKey(StatNames.REPOSITORY_STATS.getName()));
+        assertTrue(remoteStats.containsKey(StatNames.BUILD_STATS.getName()));
+
+        Map<String, Object> clientStats = remoteStats.get(StatNames.CLIENT_STATS.getName());
+        assertTrue(clientStats.containsKey(KNNRemoteIndexBuildValue.INDEX_BUILD_SUCCESS_COUNT.getName()));
+        assertTrue(clientStats.containsKey(KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT.getName()));
+        // Benign-termination counters added for the early merge-abort feature.
+        assertTrue(clientStats.containsKey(KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION.getName()));
+        assertTrue(clientStats.containsKey(KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.getName()));
+    }
+
+    /**
+     * The stats map is backed by a supplier, so incrementing the underlying counters is reflected the next time the
+     * stat value is read.
+     */
+    @SuppressWarnings("unchecked")
+    public void testRemoteIndexBuildStatsReflectCounterValues() {
+        KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION.increment();
+        KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.increment();
+        KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.increment();
+
+        KNNStats knnStats = new KNNStats();
+        Map<String, Map<String, Object>> remoteStats = (Map<String, Map<String, Object>>) knnStats.getStats()
+            .get(StatNames.REMOTE_VECTOR_INDEX_BUILD_STATS.getName())
+            .getValue();
+        Map<String, Object> clientStats = remoteStats.get(StatNames.CLIENT_STATS.getName());
+
+        assertEquals(1L, (long) (Long) clientStats.get(KNNRemoteIndexBuildValue.INDEX_BUILD_MERGE_ABORT_EXCEPTION.getName()));
+        assertEquals(2L, (long) (Long) clientStats.get(KNNRemoteIndexBuildValue.INDEX_BUILD_TERMINAL_EXCEPTION.getName()));
+        assertEquals(0L, (long) (Long) clientStats.get(KNNRemoteIndexBuildValue.INDEX_BUILD_FAILURE_COUNT.getName()));
+    }
+}


### PR DESCRIPTION

### Description
Adds a merge-abort check to the remote index build polling loop. On each poll iteration, RemoteIndexPoller now consults an `isMergeAborted` supplier (wired to `MergeAbortChecker::isMergeAborted` in production) and throws an `IndexBuildAbortedException` if the merge has been aborted. This lets terminal failures (such as shard closure )proceed promptly instead of blocking until the remote build finishes.

RemoteIndexBuildStrategy propagates the abort (and the existing `TerminalIOException)` without falling back to a local CPU build, and emits new stats index_build_merge_abort_exception and index_build_terminal_exception.

I used the merge abort check functionality introduced in this PR for native engine on CPUs: https://github.com/opensearch-project/k-NN/pull/2529

### Related Issues
Resolves #3358

### Check List
- [ x] New functionality includes testing.
- [ x] New functionality has been documented.
- [x ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ x] Commits are signed per the DCO using `--signoff`.
- [ x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
