### PR TITLE
Add 3.0.0-3.8.0 to BWC test version matrix

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -32,10 +32,13 @@ on:
 jobs:
   Restart-Upgrade-BWCTests-k-NN:
     strategy:
+      # Let every bwc_version job run to completion, so one failing version does not mask results for
+      # the others across a parallel matrix.
+      fail-fast: false
       matrix:
         java: [ 21 ]
         os: [ubuntu-latest]
-        bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0", "2.12.0", "2.13.0", "2.14.0", "2.15.0", "2.16.0", "2.17.0", "2.18.0","2.19.1", "2.20.0-SNAPSHOT"]
+        bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0", "2.12.0", "2.13.0", "2.14.0", "2.15.0", "2.16.0", "2.17.0", "2.18.0","2.19.1", "2.20.0-SNAPSHOT", "3.0.0", "3.1.0", "3.2.0", "3.3.0", "3.4.0", "3.5.0", "3.6.0", "3.7.0", "3.8.0"]
         opensearch_version : [ "3.9.0-SNAPSHOT" ]
         exclude:
           - os: windows-latest
@@ -129,10 +132,13 @@ jobs:
 
   Rolling-Upgrade-BWCTests-k-NN:
     strategy:
+      # Let every bwc_version job run to completion, so one failing version does not mask results for
+      # the others across a parallel matrix.
+      fail-fast: false
       matrix:
         java: [ 21 ]
         os: [ubuntu-latest]
-        bwc_version: [ "2.20.0-SNAPSHOT" ]
+        bwc_version: [ "2.20.0-SNAPSHOT", "3.8.0" ]
         opensearch_version: [ "3.9.0-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -4,6 +4,7 @@
  */
 
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.opensearch.gradle.Version
 import org.apache.tools.ant.taskdefs.condition.Os
 
 apply from : "$rootDir/qa/build.gradle"
@@ -41,6 +42,18 @@ testClusters {
 
 def versionsBelow2_3 = ["1.", "2.0.", "2.1.", "2.2."]
 def versionOnOrAfter2_17 = ["2.17", "2.18", "2.19", "2.20", "3."]
+
+// nmslib index creation is blocked from 3.0.0, the legacy index-level knn settings
+// (index.knn.algo_param.*, index.knn.space_type) were removed in the same release, and derived source
+// became enabled by default for every k-NN index. Tests that depend on the pre-3.0 behaviour of any of
+// these on the old cluster can only run when the old cluster predates 3.0.0.
+boolean bwcVersionOnOrAfter3_0_0 = Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.0.0")
+// The sq encoder requires the bits parameter from 3.6.0, so a legacy no-bits sq mapping can no longer be
+// created on the old cluster.
+boolean bwcVersionOnOrAfter3_6_0 = Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.6.0")
+// The plugin relaxed its merge policy in 3.6.0 (#3128), so this marks the versions still on the more
+// aggressive pre-fix behaviour.
+boolean bwcVersionBefore3_6_0 = Version.fromString(knn_bwc_version_no_qualifier).before("3.6.0")
 // Task to run BWC tests against the old cluster
 task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     dependsOn "zipBwcPlugin"
@@ -180,6 +193,39 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
+        }
+    }
+
+    if (bwcVersionOnOrAfter3_0_0) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockNMSLIBIndexCreationPost3_0_0"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexCustomLegacyFieldMapping"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
+            excludeTestsMatching "org.opensearch.knn.bwc.MemoryOptimizedSearchIT.testMemoryOptimizedSearchWithNmslib"
+            excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnNmslibIndex"
+            excludeTestsMatching "org.opensearch.knn.bwc.WarmupIT.testKNNWarmupCustomLegacyFieldMapping"
+            // Parameterized class, so the reported test name carries a {compression:...} suffix
+            excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT.testOldSettingPreservedOnUpgrade*"
+        }
+    }
+
+    if (bwcVersionOnOrAfter3_6_0) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16_onOldClusterThenUpgraded_thenSucceed"
+            excludeTestsMatching "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16WithClip_onOldClusterThenUpgraded_thenSucceed"
+            excludeTestsMatching "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16WithOnDisk_onOldClusterThenUpgraded_thenSucceed"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
+        }
+    }
+
+    // The plugin only relaxed the merge policy in 3.6.0 (#3128). On 3.0.0 - 3.5.0 core's more aggressive
+    // defaults (floor_segment 16MB, max_merge_at_once 30) merge the two small flushed segments back into
+    // one, so these tests cannot establish the >= 2 segment precondition they need on the old cluster.
+    if (bwcVersionOnOrAfter3_0_0 && bwcVersionBefore3_6_0) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithFaissRestartUpgrade"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithLuceneRestartUpgrade"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithCompressionRestartUpgrade"
         }
     }
 
@@ -348,6 +394,39 @@ task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
     if (invalidPrefixesFor1bitScalarQuantizerChecks.any { knn_bwc_version.startsWith(it) }) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndex1bitScalarQuantizer"
+        }
+    }
+
+    if (bwcVersionOnOrAfter3_0_0) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockNMSLIBIndexCreationPost3_0_0"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexCustomLegacyFieldMapping"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
+            excludeTestsMatching "org.opensearch.knn.bwc.MemoryOptimizedSearchIT.testMemoryOptimizedSearchWithNmslib"
+            excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnNmslibIndex"
+            excludeTestsMatching "org.opensearch.knn.bwc.WarmupIT.testKNNWarmupCustomLegacyFieldMapping"
+            // Parameterized class, so the reported test name carries a {compression:...} suffix
+            excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT.testOldSettingPreservedOnUpgrade*"
+        }
+    }
+
+    if (bwcVersionOnOrAfter3_6_0) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16_onOldClusterThenUpgraded_thenSucceed"
+            excludeTestsMatching "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16WithClip_onOldClusterThenUpgraded_thenSucceed"
+            excludeTestsMatching "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16WithOnDisk_onOldClusterThenUpgraded_thenSucceed"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
+        }
+    }
+
+    // The plugin only relaxed the merge policy in 3.6.0 (#3128). On 3.0.0 - 3.5.0 core's more aggressive
+    // defaults (floor_segment 16MB, max_merge_at_once 30) merge the two small flushed segments back into
+    // one, so these tests cannot establish the >= 2 segment precondition they need on the old cluster.
+    if (bwcVersionOnOrAfter3_0_0 && bwcVersionBefore3_6_0) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithFaissRestartUpgrade"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithLuceneRestartUpgrade"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithCompressionRestartUpgrade"
         }
     }
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -4,6 +4,7 @@
  */
 
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.opensearch.gradle.Version
 import org.apache.tools.ant.taskdefs.condition.Os
 
 apply from : "$rootDir/qa/build.gradle"
@@ -18,6 +19,38 @@ String knn_bwc_version = System.getProperty("tests.bwc.version", default_bwc_ver
 boolean isSnapshot = knn_bwc_version.contains("-SNAPSHOT")
 String knn_bwc_version_no_qualifier = isSnapshot ? knn_bwc_version - "-SNAPSHOT" : knn_bwc_version
 String baseName = "knnBwcCluster-rolling"
+
+// Tests whose old-node phase depends on behaviour that changed within the 3.x line. Every task in the
+// rolling upgrade runs the same test classes across the old, mixed and upgraded rounds, so an excluded
+// test has to be excluded from all of them for the rounds to stay consistent.
+List<String> excludedBwcTests = []
+// nmslib index creation is blocked from 3.0.0, so an nmslib index can only be seeded on the old node
+// when the old cluster predates 3.0.0.
+if (Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.0.0")) {
+    excludedBwcTests += "org.opensearch.knn.bwc.IndexingIT.testBlockNMSLIBIndexCreationPost3_0_0_RollingUpgrade"
+}
+// The sq encoder requires the bits parameter from 3.6.0, so a legacy no-bits sq mapping can no longer be
+// created on the old node.
+if (Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.6.0")) {
+    excludedBwcTests += [
+        "org.opensearch.knn.bwc.FaissSQIT.testHNSWSQFP16_rollingUpgrade_thenSucceed",
+        "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16WithClip_rollingUpgrade_thenSucceed",
+        "org.opensearch.knn.bwc.FaissSQIT.testLegacySQFP16WithOnDisk_rollingUpgrade_thenSucceed"
+    ]
+}
+// The plugin only relaxed the merge policy in 3.6.0 (#3128). On 3.0.0 - 3.5.0 core's more aggressive
+// defaults (floor_segment 16MB, max_merge_at_once 30) merge the two small flushed segments back into
+// one, so these tests cannot establish the >= 2 segment precondition they need on the old node. This is
+// a no-op for the current 3.8.0 matrix entry, but keeps parity with the restart-upgrade suite in case
+// 3.0.0 - 3.5.0 are added here later.
+if (Version.fromString(knn_bwc_version_no_qualifier).onOrAfter("3.0.0")
+        && Version.fromString(knn_bwc_version_no_qualifier).before("3.6.0")) {
+    excludedBwcTests += [
+        "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithFaissRollingUpgrade",
+        "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithLuceneRollingUpgrade",
+        "org.opensearch.knn.bwc.IndexingIT.testMixedSegmentsWithCompressionRollingUpgrade"
+    ]
+}
 
 // Creates a test cluster of previous version and loads k-NN plugin of bwcVersion
 testClusters {
@@ -51,6 +84,12 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
 
+    excludedBwcTests.each { excludedTest ->
+        filter {
+            excludeTestsMatching excludedTest
+        }
+    }
+
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 }
@@ -76,6 +115,12 @@ task testAgainstOneThirdUpgradedCluster(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
 
+    excludedBwcTests.each { excludedTest ->
+        filter {
+            excludeTestsMatching excludedTest
+        }
+    }
+
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 }
@@ -98,6 +143,12 @@ task testAgainstTwoThirdsUpgradedCluster(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
 
+    excludedBwcTests.each { excludedTest ->
+        filter {
+            excludeTestsMatching excludedTest
+        }
+    }
+
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 }
@@ -119,6 +170,12 @@ task testRollingUpgrade(type: StandaloneRestIntegTestTask) {
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.security.manager', 'false'
+
+    excludedBwcTests.each { excludedTest ->
+        filter {
+            excludeTestsMatching excludedTest
+        }
+    }
 
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath


### PR DESCRIPTION
### Description
The restart-upgrade and rolling-upgrade BWC matrices only contained 2.x versions, so no 3.x -> current upgrade path was exercised. The auto-append in the updateVersion task anchors on major.(minor-1).patch, so it can only add one entry per bump and needs the previous 3.x version already present to chain from; with no 3.x entry it was a silent no-op and the whole 3.0-3.8 range was missed.

Seed the full 3.0.0-3.7.0 chain into both matrices. This restores 3.x -> current BWC coverage now, and lets subsequent version bumps auto-append the next 3.x version. Verified by running './gradlew updateVersion -DnewVersion=3.9.0-SNAPSHOT', which appends 3.8.0 to both matrices as expected.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
