### PR TITLE
Add prefetch for Lucene engine's fp32 and binary vector data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * Fix knn query against a field alias returning zero hits silently [#3485](https://github.com/opensearch-project/k-NN/pull/3485)
+* Add prefetch for Lucene engine's fp32 and binary vector data type [#3504](https://github.com/opensearch-project/k-NN/pull/3504)
 
 ### Refactoring
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120BinaryVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120BinaryVectorScorer.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.codec.KNN9120Codec;
 
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -18,7 +17,9 @@ import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import java.io.IOException;
 
 /**
- * A FlatVectorsScorer to be used for scoring binary vectors. Meant to be used with {@link KNN9120BinaryVectorScorer}
+ * A {@link FlatVectorsScorer} for scoring binary (Hamming) vectors. Used by {@link KNN9120HnswBinaryVectorsFormat}.
+ * The query path returns a fixed-target {@link BinaryRandomVectorScorer}; graph construction uses the updateable
+ * {@link BinaryUpdatableRandomVectorScorer} produced by {@link BinaryRandomVectorScorerSupplier}.
  */
 public class KNN9120BinaryVectorScorer implements FlatVectorsScorer {
     @Override
@@ -48,46 +49,67 @@ public class KNN9120BinaryVectorScorer implements FlatVectorsScorer {
         byte[] queryVector
     ) throws IOException {
         if (randomAccessVectorValues instanceof ByteVectorValues) {
+            // The query path uses a fixed-target scorer that extends AbstractRandomVectorScorer, mirroring Lucene's
+            // DefaultFlatVectorScorer. Only the supplier path (graph construction) needs the updateable scorer below.
             return new BinaryRandomVectorScorer((ByteVectorValues) randomAccessVectorValues, queryVector);
         }
         throw new IllegalArgumentException("vectorValues must be an instance of RandomAccessVectorValues.Bytes");
     }
 
-    static class BinaryRandomVectorScorer implements UpdateableRandomVectorScorer {
-        private final ByteVectorValues vectorValues;
+    /**
+     * Fixed-target query scorer for binary vectors. Mirrors Lucene's {@code DefaultFlatVectorScorer}, which returns a
+     * plain {@link RandomVectorScorer.AbstractRandomVectorScorer} for the query path (as opposed to the updateable
+     * {@link BinaryUpdatableRandomVectorScorer} used during graph construction). Extending {@code AbstractRandomVectorScorer}
+     * keeps the query scorer compatible with wrappers such as the prefetching scorer.
+     */
+    static class BinaryRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
         private final byte[] queryVector;
 
         BinaryRandomVectorScorer(ByteVectorValues vectorValues, byte[] query) {
+            super(vectorValues);
             this.queryVector = query;
-            this.vectorValues = vectorValues;
         }
 
         @Override
         public float score(int node) throws IOException {
-            return KNNVectorSimilarityFunction.HAMMING.compare(queryVector, vectorValues.vectorValue(node));
+            return KNNVectorSimilarityFunction.HAMMING.compare(queryVector, ((ByteVectorValues) values()).vectorValue(node));
+        }
+    }
+
+    /**
+     * Just like a {@link BinaryRandomVectorScorer} but allows the scoring ordinal to be changed. Useful
+     * during indexing operations.
+     *
+     * <p>Mirrors Lucene's {@code DefaultFlatVectorScorer}: reads vectors for both {@link #score(int)} and
+     * {@link #setScoringOrdinal(int)} through an independent {@code targetVectors} copy (a distinct
+     * {@link ByteVectorValues} with its own {@code IndexInput} cursor and read buffer), while the base
+     * {@code values()} is used only for graph metadata. Using a separate copy avoids sharing a stateful
+     * cursor/buffer with the base values during graph construction.
+     */
+    static class BinaryUpdatableRandomVectorScorer extends UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer {
+        private final ByteVectorValues targetVectors;
+        private final byte[] vector;
+
+        BinaryUpdatableRandomVectorScorer(ByteVectorValues vectorValues, ByteVectorValues targetVectors, byte[] vector) {
+            super(vectorValues);
+            this.targetVectors = targetVectors;
+            this.vector = vector;
         }
 
         @Override
-        public int maxOrd() {
-            return vectorValues.size();
-        }
-
-        @Override
-        public int ordToDoc(int ord) {
-            return vectorValues.ordToDoc(ord);
-        }
-
-        @Override
-        public Bits getAcceptOrds(Bits acceptDocs) {
-            return vectorValues.getAcceptOrds(acceptDocs);
+        public float score(int node) throws IOException {
+            return KNNVectorSimilarityFunction.HAMMING.compare(vector, targetVectors.vectorValue(node));
         }
 
         @Override
         public void setScoringOrdinal(int node) throws IOException {
-            System.arraycopy(vectorValues.vectorValue(node), 0, queryVector, 0, queryVector.length);
+            System.arraycopy(targetVectors.vectorValue(node), 0, vector, 0, vector.length);
         }
     }
 
+    /**
+     * A supplier that creates {@link RandomVectorScorer} from an ordinal.
+     */
     static class BinaryRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
         protected final ByteVectorValues vectorValues;
         protected final ByteVectorValues targetVectors;
@@ -100,7 +122,7 @@ public class KNN9120BinaryVectorScorer implements FlatVectorsScorer {
         @Override
         public UpdateableRandomVectorScorer scorer() throws IOException {
             byte[] query = new byte[vectorValues.dimension()];
-            return new BinaryRandomVectorScorer(vectorValues, query);
+            return new BinaryUpdatableRandomVectorScorer(vectorValues, targetVectors, query);
         }
 
         @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
@@ -15,6 +15,7 @@ import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.TaskExecutor;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
@@ -38,7 +39,9 @@ public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
     private final int maxConn;
     private final int beamWidth;
     private final int tinySegmentsThreshold;
-    private static final FlatVectorsFormat flatVectorsFormat = new Lucene99FlatVectorsFormat(new KNN9120BinaryVectorScorer());
+    private static final FlatVectorsFormat flatVectorsFormat = new Lucene99FlatVectorsFormat(
+        new PrefetchableFlatVectorScorer(new KNN9120BinaryVectorScorer())
+    );
     private final int numMergeWorkers;
     private final TaskExecutor mergeExec;
 

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -106,6 +106,7 @@ import org.opensearch.knn.training.TrainingJobClusterStateListener;
 import org.opensearch.knn.training.TrainingJobRunner;
 import org.opensearch.knn.training.VectorReader;
 import org.opensearch.knn.grpc.proto.request.search.query.KNNQueryBuilderProtoConverter;
+import org.opensearch.lucene.Lucene99ScorerPatcher;
 import org.opensearch.plugins.ClusterPlugin;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.EnginePlugin;
@@ -254,6 +255,7 @@ public class KNNPlugin extends Plugin
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.repositoriesServiceSupplier = repositoriesServiceSupplier;
+        Lucene99ScorerPatcher.installOnce();
 
         // Initialize Native Memory loading strategies
         VectorReader vectorReader = new VectorReader(client);

--- a/src/main/java/org/opensearch/lucene/Lucene99ScorerPatcher.java
+++ b/src/main/java/org/opensearch/lucene/Lucene99ScorerPatcher.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.lucene;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Quick-and-dirty: reflectively wrap the FlatVectorsScorer inside the stock
+ * {@link Lucene99HnswVectorsFormat}'s shared {@code Lucene99FlatVectorsFormat} with a
+ * {@link PrefetchableFlatVectorScorer}.
+ *
+ * <p>The scorer lives in a {@code private final} <em>instance</em> field ({@code vectorsScorer}) on the
+ * single shared {@code Lucene99FlatVectorsFormat} that {@code Lucene99HnswVectorsFormat} holds in a
+ * {@code private static final} field. We read that shared instance and overwrite its scorer field once.
+ * Because {@code Lucene99FlatVectorsFormat#fieldsReader/fieldsWriter} read the field at call time, every
+ * reader/writer created after this runs picks up the wrapped scorer. The on-disk format name is unchanged,
+ * so there is no backward-compatibility impact.
+ *
+ * <p>Call {@link #installOnce()} once at plugin startup, before any index open/write.
+ *
+ * <p><b>Caveats:</b> this is a node-wide monkeypatch affecting every stock Lucene99 HNSW field (read and
+ * write); it must run before any index activity; it may require {@code suppressAccessChecks} /
+ * {@code accessDeclaredMembers} reflection permissions under a SecurityManager; and it is fragile across
+ * Lucene upgrades since it relies on {@code Lucene99FlatVectorsFormat} having exactly one
+ * {@link FlatVectorsScorer} field.
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class Lucene99ScorerPatcher {
+
+    private static volatile boolean installed = false;
+
+    /**
+     * Idempotently wraps the stock Lucene99 flat vector scorer with a {@link PrefetchableFlatVectorScorer}.
+     * Safe to call multiple times; only the first call mutates state.
+     */
+    public static synchronized void installOnce() {
+        if (installed) {
+            return;
+        }
+        try {
+            // 1) Read the shared Lucene99FlatVectorsFormat instance held in Lucene99HnswVectorsFormat's
+            // private static final field. Referencing the class forces its static init first.
+            final Field fmtField = findStaticFieldOfType(Lucene99HnswVectorsFormat.class, FlatVectorsFormat.class);
+            fmtField.setAccessible(true);
+            final Object flatFormat = fmtField.get(null); // static field -> null receiver
+
+            // 2) Locate the private final FlatVectorsScorer field on the flat format instance.
+            final Field scorerField = findFieldOfType(flatFormat.getClass(), FlatVectorsScorer.class);
+            scorerField.setAccessible(true);
+
+            final FlatVectorsScorer current = (FlatVectorsScorer) scorerField.get(flatFormat);
+            if (current instanceof PrefetchableFlatVectorScorer) {
+                installed = true; // already patched
+                return;
+            }
+
+            // 3) Overwrite the instance field with the prefetching wrapper.
+            scorerField.set(flatFormat, new PrefetchableFlatVectorScorer(current));
+            installed = true;
+        } catch (Exception e) {
+            log.warn("Failed to patch Lucene99 flat vector scorer to add Prefetchable Vector Scorer", e);
+        }
+    }
+
+    private static Field findStaticFieldOfType(final Class<?> owner, final Class<?> fieldType) {
+        for (Field f : owner.getDeclaredFields()) {
+            if (Modifier.isStatic(f.getModifiers()) && fieldType.isAssignableFrom(f.getType())) {
+                return f;
+            }
+        }
+        throw new IllegalStateException("No static field of type " + fieldType.getName() + " on " + owner.getName());
+    }
+
+    private static Field findFieldOfType(final Class<?> owner, final Class<?> fieldType) {
+        for (Field f : owner.getDeclaredFields()) {
+            if (fieldType.isAssignableFrom(f.getType())) {
+                return f;
+            }
+        }
+        throw new IllegalStateException("No field of type " + fieldType.getName() + " on " + owner.getName());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormatComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormatComponentTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnByteVectorQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableScorerTestUtils;
+import org.opensearch.knn.index.codec.util.UnitTestCodec;
+
+/**
+ * Component test for {@link KNN9120HnswBinaryVectorsFormat}: index a few binary (byte) vector documents through a
+ * segment written with this format, read the segment back, and validate both the scorer wiring and end-to-end search
+ * scores (which must match {@link KNNVectorSimilarityFunction#HAMMING}).
+ */
+public class KNN9120HnswBinaryVectorsFormatComponentTests extends KNNTestCase {
+
+    private static final String BINARY_VECTOR_FIELD = "binary_field";
+    private static final int BYTES_PER_VECTOR = 8;
+    private static final int NUM_DOCS = 4;
+
+    /**
+     * Index binary vectors, read them back, and validate the returned scorer.
+     *
+     * <p>The type assertions confirm the wiring is {@code PrefetchableFlatVectorScorer -> KNN9120BinaryVectorScorer}.
+     * The final behavioral assertion additionally exercises the query-time scoring entry point.
+     */
+    @SneakyThrows
+    public void testIndexAndRead_whenBinaryVectorsFormat_thenScorerIsPrefetchableBinaryScorer() {
+        try (Directory dir = newDirectory()) {
+            indexBinaryDocs(dir);
+
+            // ---- read the segment back and reach the per-field flat vectors reader ----
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = PrefetchableScorerTestUtils.flatVectorsReaderFor(reader, BINARY_VECTOR_FIELD);
+
+                // ---- validate the scorer wired into the reader ----
+                final FlatVectorsScorer scorer = flatVectorsReader.getFlatVectorScorer(BINARY_VECTOR_FIELD);
+                assertTrue(
+                    "flat vectors scorer must be prefetchable but was " + scorer.getClass().getName(),
+                    scorer instanceof PrefetchableFlatVectorScorer
+                );
+                final FlatVectorsScorer delegate = PrefetchableScorerTestUtils.getDelegate((PrefetchableFlatVectorScorer) scorer);
+                assertTrue(
+                    "prefetchable scorer must delegate to the binary scorer but was " + delegate.getClass().getName(),
+                    delegate instanceof KNN9120BinaryVectorScorer
+                );
+
+                // ---- validate the RandomVectorScorer returned for a binary query is the prefetchable variant ----
+                // The query path returns a fixed-target scorer (an AbstractRandomVectorScorer), so the prefetch
+                // wrapper applies just like it does on the float path.
+                final RandomVectorScorer randomVectorScorer = flatVectorsReader.getRandomVectorScorer(BINARY_VECTOR_FIELD, binaryVector(0));
+                assertTrue(
+                    "binary random vector scorer must be the prefetchable variant but was " + randomVectorScorer.getClass().getName(),
+                    randomVectorScorer instanceof PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer
+                );
+            }
+        }
+    }
+
+    /**
+     * Runs an actual kNN search over the indexed binary vectors and validates the returned scores against
+     * {@link KNNVectorSimilarityFunction#HAMMING}: the exact-match document ranks first with score {@code 1.0}, every
+     * hit's score equals the Hamming similarity for that document, and scores are returned in descending order.
+     */
+    @SneakyThrows
+    public void testSearch_whenBinaryVectorsFormat_thenScoresMatchHamming() {
+        try (Directory dir = newDirectory()) {
+            indexBinaryDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final int queryDoc = 2;
+                final byte[] query = binaryVector(queryDoc);
+
+                final TopDocs topDocs = searcher.search(new KnnByteVectorQuery(BINARY_VECTOR_FIELD, query, NUM_DOCS), NUM_DOCS);
+
+                assertEquals("all indexed docs should be returned", NUM_DOCS, topDocs.scoreDocs.length);
+
+                // Exact match must rank first with the maximum Hamming score (distance 0 -> 1 / (1 + 0) = 1.0).
+                assertEquals("exact-match doc must rank first", queryDoc, topDocs.scoreDocs[0].doc);
+                assertEquals("exact-match score must be 1.0", 1.0f, topDocs.scoreDocs[0].score, 1e-6f);
+
+                // Every hit's score must equal the Hamming similarity for that doc, and scores must be descending.
+                // docIds map 1:1 to insertion order here (single segment, sequential adds, force-merged, no deletes).
+                float previousScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    final float expected = KNNVectorSimilarityFunction.HAMMING.compare(query, binaryVector(scoreDoc.doc));
+                    assertEquals("score mismatch for doc " + scoreDoc.doc, expected, scoreDoc.score, 1e-6f);
+                    assertTrue("scores must be in descending order", scoreDoc.score <= previousScore);
+                    previousScore = scoreDoc.score;
+                }
+            }
+        }
+    }
+
+    private void indexBinaryDocs(final Directory dir) throws Exception {
+        final Codec codec = new UnitTestCodec(KNN9120HnswBinaryVectorsFormat::new);
+        final IndexWriterConfig iwc = newIndexWriterConfig().setCodec(codec);
+        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+            for (int i = 0; i < NUM_DOCS; i++) {
+                final Document doc = new Document();
+                doc.add(new KnnByteVectorField(BINARY_VECTOR_FIELD, binaryVector(i), VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+            writer.commit();
+        }
+    }
+
+    private static byte[] binaryVector(final int seed) {
+        final byte[] vector = new byte[BYTES_PER_VECTOR];
+        for (int i = 0; i < BYTES_PER_VECTOR; i++) {
+            vector[i] = (byte) (seed * 31 + i);
+        }
+        return vector;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableScorerTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableScorerTestUtils.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SegmentReader;
+import org.junit.Assume;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.lucene.Lucene99ScorerPatcher;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Shared test helpers for the prefetchable-scorer tests: reflection over the shared {@code Lucene99FlatVectorsFormat}
+ * scorer, patcher-flag reset, reader navigation to the per-field {@link FlatVectorsReader}, and unwrapping a
+ * {@link PrefetchableFlatVectorScorer}. Kept in one place so the patcher test and the two format component tests
+ * (which live in different packages) do not each re-declare the same reflection boilerplate.
+ */
+public final class PrefetchableScorerTestUtils {
+
+    private PrefetchableScorerTestUtils() {}
+
+    /**
+     * Handle for the process-wide {@code FlatVectorsScorer} on the shared {@code Lucene99FlatVectorsFormat}, used to
+     * save the pre-test scorer and restore it afterwards so tests do not pollute one another.
+     */
+    public static final class SharedScorerState {
+        private final Object flatFormat;
+        private final Field scorerField;
+        private final FlatVectorsScorer originalScorer;
+
+        private SharedScorerState(final Object flatFormat, final Field scorerField, final FlatVectorsScorer originalScorer) {
+            this.flatFormat = flatFormat;
+            this.scorerField = scorerField;
+            this.originalScorer = originalScorer;
+        }
+
+        /** Restores the scorer captured at {@link #resolveAndReset()} time and clears the patcher flag. */
+        public void restore() throws Exception {
+            if (scorerField != null && flatFormat != null && originalScorer != null) {
+                scorerField.set(flatFormat, originalScorer);
+            }
+            resetPatcherInstalledFlag();
+        }
+    }
+
+    /**
+     * Resolves the shared scorer, unwraps any existing prefetch wrapper so the test starts from a clean stock scorer
+     * (production bootstrap or another test in the same JVM may already have wrapped it), resets the patcher flag, and
+     * returns a handle for restoring later. Skips the test when the JVM forbids mutating the {@code private final}
+     * scorer field, since the patch itself cannot work in that case.
+     */
+    public static SharedScorerState resolveAndReset() throws Exception {
+        final Field fmtField = findStaticFieldOfType(Lucene99HnswVectorsFormat.class, FlatVectorsFormat.class);
+        fmtField.setAccessible(true);
+        final Object flatFormat = fmtField.get(null);
+
+        final Field scorerField = findFieldOfType(flatFormat.getClass(), FlatVectorsScorer.class);
+        scorerField.setAccessible(true);
+
+        FlatVectorsScorer current = (FlatVectorsScorer) scorerField.get(flatFormat);
+        if (current instanceof PrefetchableFlatVectorScorer) {
+            current = getDelegate((PrefetchableFlatVectorScorer) current);
+        }
+
+        try {
+            scorerField.set(flatFormat, current);
+        } catch (Exception e) {
+            Assume.assumeNoException("Cannot mutate Lucene99FlatVectorsFormat scorer field in this JVM", e);
+        }
+
+        resetPatcherInstalledFlag();
+        return new SharedScorerState(flatFormat, scorerField, current);
+    }
+
+    /** Reflectively resets {@code Lucene99ScorerPatcher.installed} to {@code false}. */
+    public static void resetPatcherInstalledFlag() throws Exception {
+        final Field installed = Lucene99ScorerPatcher.class.getDeclaredField("installed");
+        installed.setAccessible(true);
+        installed.setBoolean(null, false);
+    }
+
+    /** Returns the scorer that a {@link PrefetchableFlatVectorScorer} delegates to. */
+    public static FlatVectorsScorer getDelegate(final PrefetchableFlatVectorScorer wrapper) throws Exception {
+        final Field delegate = PrefetchableFlatVectorScorer.class.getDeclaredField("delegateScorer");
+        delegate.setAccessible(true);
+        return (FlatVectorsScorer) delegate.get(wrapper);
+    }
+
+    /** Navigates a reader to the per-field {@link FlatVectorsReader} backing the given field (leaf 0). */
+    public static FlatVectorsReader flatVectorsReaderFor(final DirectoryReader reader, final String field) throws Exception {
+        final LeafReader leafReader = reader.leaves().get(0).reader();
+        final SegmentReader segmentReader = Lucene.segmentReader(leafReader);
+
+        final KnnVectorsReader perFieldReader = segmentReader.getVectorReader();
+        if (perFieldReader instanceof PerFieldKnnVectorsFormat.FieldsReader == false) {
+            throw new IllegalStateException("expected a PerFieldKnnVectorsFormat.FieldsReader but was " + perFieldReader);
+        }
+        final KnnVectorsReader fieldReader = ((PerFieldKnnVectorsFormat.FieldsReader) perFieldReader).getFieldReader(field);
+        if (fieldReader == null) {
+            throw new IllegalStateException("expected a per-field reader for " + field);
+        }
+
+        // Lucene99HnswVectorsReader delegates scoring to an inner FlatVectorsReader.
+        return (FlatVectorsReader) getFieldValueOfType(fieldReader, FlatVectorsReader.class);
+    }
+
+    /** Returns the value of the first declared field of {@code owner} assignable to {@code fieldType}. */
+    public static Object getFieldValueOfType(final Object owner, final Class<?> fieldType) throws Exception {
+        for (Field f : owner.getClass().getDeclaredFields()) {
+            if (fieldType.isAssignableFrom(f.getType())) {
+                f.setAccessible(true);
+                return f.get(owner);
+            }
+        }
+        throw new IllegalStateException("No field of type " + fieldType.getName() + " on " + owner.getClass().getName());
+    }
+
+    /** Returns the first declared field of {@code owner} assignable to {@code fieldType}. */
+    public static Field findFieldOfType(final Class<?> owner, final Class<?> fieldType) {
+        for (Field f : owner.getDeclaredFields()) {
+            if (fieldType.isAssignableFrom(f.getType())) {
+                return f;
+            }
+        }
+        throw new IllegalStateException("No field of type " + fieldType.getName() + " on " + owner.getName());
+    }
+
+    /** Returns the first declared {@code static} field of {@code owner} assignable to {@code fieldType}. */
+    public static Field findStaticFieldOfType(final Class<?> owner, final Class<?> fieldType) {
+        for (Field f : owner.getDeclaredFields()) {
+            if (Modifier.isStatic(f.getModifiers()) && fieldType.isAssignableFrom(f.getType())) {
+                return f;
+            }
+        }
+        throw new IllegalStateException("No static field of type " + fieldType.getName() + " on " + owner.getName());
+    }
+}

--- a/src/test/java/org/opensearch/lucene/Lucene99HnswVectorsFormatComponentTests.java
+++ b/src/test/java/org/opensearch/lucene/Lucene99HnswVectorsFormatComponentTests.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.lucene;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableScorerTestUtils;
+import org.opensearch.knn.index.codec.util.UnitTestCodec;
+
+/**
+ * Component test for the stock {@link Lucene99HnswVectorsFormat} (float / fp32 HNSW), mirroring the binary format
+ * component test. It indexes a few float vector documents, reads the segment back, and validates the scorer wired
+ * into the flat vectors reader, plus end-to-end search scores:
+ *
+ * <ul>
+ *   <li>Without the patch, the reader returns the stock (non-prefetchable) scorer.</li>
+ *   <li>After {@link Lucene99ScorerPatcher#installOnce()}, the reader returns a {@link PrefetchableFlatVectorScorer},
+ *       the float {@link RandomVectorScorer} is the prefetchable variant, and a kNN search still produces scores that
+ *       match {@link VectorSimilarityFunction#EUCLIDEAN} — confirming the prefetch wrapper preserves scores.</li>
+ * </ul>
+ *
+ * <p>{@code installOnce()} mutates the process-wide scorer on the shared {@code Lucene99FlatVectorsFormat}, so each
+ * test resets that global state around itself (via {@link PrefetchableScorerTestUtils}).
+ */
+public class Lucene99HnswVectorsFormatComponentTests extends KNNTestCase {
+
+    private static final String FLOAT_VECTOR_FIELD = "float_field";
+    private static final int DIMENSION = 4;
+    private static final int NUM_DOCS = 4;
+
+    private PrefetchableScorerTestUtils.SharedScorerState scorerState;
+
+    @Before
+    @SneakyThrows
+    public void resolveSharedScorerAndReset() {
+        scorerState = PrefetchableScorerTestUtils.resolveAndReset();
+    }
+
+    @After
+    @SneakyThrows
+    public void restoreGlobalState() {
+        if (scorerState != null) {
+            scorerState.restore();
+        }
+    }
+
+    @SneakyThrows
+    public void testIndexAndRead_whenStockFormat_thenScorerIsNotPrefetchable() {
+        try (Directory dir = newDirectory()) {
+            indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = PrefetchableScorerTestUtils.flatVectorsReaderFor(reader, FLOAT_VECTOR_FIELD);
+
+                final FlatVectorsScorer scorer = flatVectorsReader.getFlatVectorScorer(FLOAT_VECTOR_FIELD);
+                assertFalse(
+                    "unpatched stock format must not return a prefetchable scorer but was " + scorer.getClass().getName(),
+                    scorer instanceof PrefetchableFlatVectorScorer
+                );
+
+                final RandomVectorScorer randomVectorScorer = flatVectorsReader.getRandomVectorScorer(FLOAT_VECTOR_FIELD, queryVector());
+                assertFalse(
+                    "unpatched random vector scorer must not be the prefetchable variant",
+                    randomVectorScorer instanceof PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer
+                );
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testIndexAndRead_afterInstallOnce_thenScorerIsPrefetchable() {
+        Lucene99ScorerPatcher.installOnce();
+
+        try (Directory dir = newDirectory()) {
+            indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = PrefetchableScorerTestUtils.flatVectorsReaderFor(reader, FLOAT_VECTOR_FIELD);
+
+                final FlatVectorsScorer scorer = flatVectorsReader.getFlatVectorScorer(FLOAT_VECTOR_FIELD);
+                assertTrue(
+                    "patched stock format must return a prefetchable scorer but was " + scorer.getClass().getName(),
+                    scorer instanceof PrefetchableFlatVectorScorer
+                );
+
+                // Unlike the binary scorer, the stock float scorer returns an AbstractRandomVectorScorer, so the
+                // prefetch wrapper applies cleanly on the float path.
+                final RandomVectorScorer randomVectorScorer = flatVectorsReader.getRandomVectorScorer(FLOAT_VECTOR_FIELD, queryVector());
+                assertTrue(
+                    "patched random vector scorer must be the prefetchable variant but was " + randomVectorScorer.getClass().getName(),
+                    randomVectorScorer instanceof PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer
+                );
+            }
+        }
+    }
+
+    /**
+     * Runs an actual kNN search over the indexed float vectors after installing the prefetch patch, and validates the
+     * returned scores against {@link VectorSimilarityFunction#EUCLIDEAN}: the exact-match document ranks first with
+     * score {@code 1.0}, every hit's score equals the Euclidean similarity for that document, and scores are returned
+     * in descending order. This confirms the prefetch wrapper preserves scores end-to-end on the float path.
+     */
+    @SneakyThrows
+    public void testSearch_afterInstallOnce_thenScoresMatchEuclidean() {
+        Lucene99ScorerPatcher.installOnce();
+
+        try (Directory dir = newDirectory()) {
+            indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final int queryDoc = 2;
+                final float[] query = floatVector(queryDoc);
+
+                final TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FLOAT_VECTOR_FIELD, query, NUM_DOCS), NUM_DOCS);
+
+                assertEquals("all indexed docs should be returned", NUM_DOCS, topDocs.scoreDocs.length);
+
+                // Exact match must rank first with the maximum Euclidean score (distance 0 -> 1 / (1 + 0) = 1.0).
+                assertEquals("exact-match doc must rank first", queryDoc, topDocs.scoreDocs[0].doc);
+                assertEquals("exact-match score must be 1.0", 1.0f, topDocs.scoreDocs[0].score, 1e-6f);
+
+                // Every hit's score must equal the Euclidean similarity for that doc, and scores must be descending.
+                // docIds map 1:1 to insertion order here (single segment, sequential adds, force-merged, no deletes).
+                float previousScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    final float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, floatVector(scoreDoc.doc));
+                    assertEquals("score mismatch for doc " + scoreDoc.doc, expected, scoreDoc.score, 1e-6f);
+                    assertTrue("scores must be in descending order", scoreDoc.score <= previousScore);
+                    previousScore = scoreDoc.score;
+                }
+            }
+        }
+    }
+
+    private void indexFloatDocs(final Directory dir) throws Exception {
+        final Codec codec = new UnitTestCodec(Lucene99HnswVectorsFormat::new);
+        final IndexWriterConfig iwc = newIndexWriterConfig().setCodec(codec);
+        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+            for (int i = 0; i < NUM_DOCS; i++) {
+                final Document doc = new Document();
+                doc.add(new KnnFloatVectorField(FLOAT_VECTOR_FIELD, floatVector(i), VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+            writer.commit();
+        }
+    }
+
+    private static float[] floatVector(final int seed) {
+        final float[] vector = new float[DIMENSION];
+        for (int i = 0; i < DIMENSION; i++) {
+            vector[i] = (seed + 1) * 0.1f + i * 0.01f;
+        }
+        return vector;
+    }
+
+    private static float[] queryVector() {
+        return floatVector(0);
+    }
+}

--- a/src/test/java/org/opensearch/lucene/Lucene99ScorerPatcherTests.java
+++ b/src/test/java/org/opensearch/lucene/Lucene99ScorerPatcherTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.lucene;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableScorerTestUtils;
+
+/**
+ * Tests for {@link Lucene99ScorerPatcher}.
+ *
+ * <p>{@code installOnce()} mutates process-wide state: the {@code FlatVectorsScorer} on the single shared
+ * {@code Lucene99FlatVectorsFormat} held by {@link Lucene99HnswVectorsFormat}, plus a static {@code installed}
+ * flag on the patcher. Each test therefore resets both around itself (via {@link PrefetchableScorerTestUtils}) so it
+ * does not depend on (or pollute) other tests. When the JVM forbids mutating the {@code private final} scorer field
+ * the patch cannot work at all, so the tests are skipped rather than failed.
+ */
+public class Lucene99ScorerPatcherTests extends KNNTestCase {
+
+    private PrefetchableScorerTestUtils.SharedScorerState scorerState;
+
+    @Before
+    @SneakyThrows
+    public void resolveSharedScorerAndReset() {
+        scorerState = PrefetchableScorerTestUtils.resolveAndReset();
+    }
+
+    @After
+    @SneakyThrows
+    public void restoreGlobalState() {
+        if (scorerState != null) {
+            scorerState.restore();
+        }
+    }
+
+    /**
+     * End-to-end check that the global patch is actually visible through a freshly-initialized
+     * {@link Lucene99HnswVectorsFormat} (not just the raw static field): the format shares the single patched
+     * {@code Lucene99FlatVectorsFormat}, and its {@code toString()} embeds the scorer, so after {@code installOnce()}
+     * every new format instance reports the {@link PrefetchableFlatVectorScorer}.
+     */
+    @Test
+    @SneakyThrows
+    public void testFreshFormatInstanceReflectsGlobalPatch() {
+        final String prefetchableMarker = PrefetchableFlatVectorScorer.class.getSimpleName();
+
+        // Before patching, a newly constructed format must expose the stock (non-prefetchable) scorer.
+        assertFalse(
+            "precondition: a fresh Lucene99HnswVectorsFormat must not report a prefetchable scorer before installOnce()",
+            new Lucene99HnswVectorsFormat().toString().contains(prefetchableMarker)
+        );
+
+        Lucene99ScorerPatcher.installOnce();
+
+        // After patching, any newly constructed format must report the prefetchable scorer through its public API.
+        assertTrue(
+            "a Lucene99HnswVectorsFormat initialized after installOnce() must report the prefetchable scorer",
+            new Lucene99HnswVectorsFormat().toString().contains(prefetchableMarker)
+        );
+    }
+}


### PR DESCRIPTION
## Description

Adds memory **prefetching** to the Lucene engine's HNSW query-scoring path for both **fp32 (float)** and **binary (Hamming)** vector data types. During graph search, vector data for the next set of candidate nodes is prefetched
  before bulk scoring the current batch, reducing cache-miss stalls in the distance loop.

Prefetching is implemented by a decorator, `PrefetchableFlatVectorScorer`, that wraps the underlying `FlatVectorsScorer` and issues prefetch hints ahead of `bulkScore`. It delegates the graph-build (supplier) path unchanged and
  only augments the query-time scorer.

### How it's wired per data type

**Binary (`KNN9120HnswBinaryVectorsFormat`)**
  - The format now wraps `KNN9120BinaryVectorScorer` in `PrefetchableFlatVectorScorer`.
  - `KNN9120BinaryVectorScorer` was split into two scorers, mirroring Lucene's `DefaultFlatVectorScorer`:
    - `BinaryRandomVectorScorer` — a **fixed-target query scorer** that extends `RandomVectorScorer.AbstractRandomVectorScorer` (query path).
    - `BinaryUpdatableRandomVectorScorer` — the **updateable graph-construction scorer** that extends `UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer`, produced by the supplier's `scorer()`.
  - Previously a single updateable scorer served both paths; that made the query-path scorer incompatible with the prefetch wrapper (it isn't an `AbstractRandomVectorScorer`). The split fixes that and aligns with the upstream Lucene
  pattern.

**fp32 (stock `Lucene99HnswVectorsFormat`)**
  - The stock format pins its `FlatVectorsScorer` in a `private static final` field and is resolved on read by its SPI format name, so we cannot change the scorer at construction without a new format name (which would carry
  backward-compatibility cost).
  - Instead, `Lucene99ScorerPatcher.installOnce()` reflectively wraps the shared `Lucene99FlatVectorsFormat`'s scorer with `PrefetchableFlatVectorScorer` once at plugin startup. `KNNPlugin` invokes it during component
  initialization. The call is idempotent, and if the JVM forbids the field mutation it logs and no-ops.


### Backward compatibility

  No on-disk impact. The format **name** is unchanged and the `FlatVectorsScorer` is **not** persisted — it only affects how distances are computed at query time. Existing segments read back identically; only scoring latency
  changes.

## Changes

  - `KNN9120BinaryVectorScorer` — split into fixed-target query scorer + updateable build scorer.
  - `KNN9120HnswBinaryVectorsFormat` — wrap the binary scorer with `PrefetchableFlatVectorScorer`.
  - `Lucene99ScorerPatcher` (new) — reflectively installs the prefetch wrapper on the stock Lucene99 float scorer; idempotent, startup-only.
  - `KNNPlugin` — call `Lucene99ScorerPatcher.installOnce()`.
  - Tests:
    - `KNN9120HnswBinaryVectorsFormatComponentTests` — index binary docs → read back → assert the wired scorer is `PrefetchableFlatVectorScorer → KNN9120BinaryVectorScorer` and the query scorer is the prefetchable variant.
    - `Lucene99HnswVectorsFormatComponentTests` — index float docs; assert stock scorer by default and prefetchable after `installOnce()`.
    - `Lucene99ScorerPatcherTests` — patch is visible through a freshly-constructed `Lucene99HnswVectorsFormat`.
    - `PrefetchableScorerTestUtils` (new) — shared reflection / reader-navigation / global-state helpers.


## Next Steps
1. Create a new format for Lucene which ensure that any new segments getting written start to use the KNN Plugin Lucene format which doesn't need the reflection to change the Scorer. Since all classes for LuceneHNSWFormat and FlatFormat is final, we will need a new format which uses stock readers and writers but with correct scorer.


### Related Issues
NA

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
