### PR TITLE
Flip default to x32 for new HNSW indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.9](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
+* Make 32x compression (SQ 1-bit) the default for all new HNSW indices starting 3.9.0 [#3506](https://github.com/opensearch-project/k-NN/pull/3506)
 
 ### Maintenance
 

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -197,8 +197,10 @@ public class KNNConstants {
 
     public static final String MODE_PARAMETER = "mode";
     public static final String COMPRESSION_LEVEL_PARAMETER = "compression_level";
-    // Version at which the default compression level flips to x32 and the 'mode' parameter is deprecated.
-    public static final Version KNN_DEFAULT_COMPRESSION_FLIP_VERSION = Version.V_3_8_0;
+    // Version at which x32 (SQ 1-bit) becomes the default compression for ALL new HNSW indices (regardless
+    // of mode, unless the user explicitly configures a different compression_level) and the 'mode' parameter
+    // is deprecated.
+    public static final Version KNN_DEFAULT_COMPRESSION_FLIP_VERSION = Version.V_3_9_0;
 
     // Repository filepath constants
     public static final String VECTOR_BLOB_FILE_EXTENSION = ".knnvec";

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractMethodResolver.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.opensearch.knn.common.KNNConstants.KNN_DEFAULT_COMPRESSION_FLIP_VERSION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 
 /**
@@ -110,7 +111,10 @@ public abstract class AbstractMethodResolver implements MethodResolver {
         // The encoder should not be resolved if:
         // 1. The encoder is specified
         // 2. The compression is x1
-        // 3. The compression is not specified and the mode is not disk-based
+        // 3. The compression is not specified, the mode is not disk-based, and the index was created before
+        // the x32-default flip (KNN_DEFAULT_COMPRESSION_FLIP_VERSION). Starting with that version, x32 is
+        // the default for every new HNSW index, so the encoder must be resolved even when neither
+        // compression nor an on-disk mode was requested.
         if (isEncoderSpecified(knnMethodContext)) {
             return false;
         }
@@ -119,8 +123,11 @@ public abstract class AbstractMethodResolver implements MethodResolver {
             return false;
         }
 
+        Version version = knnMethodConfigContext.getVersionCreated();
+        boolean is32xDefaultVersion = version != null && version.onOrAfter(KNN_DEFAULT_COMPRESSION_FLIP_VERSION);
         if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel()) == false
-            && Mode.ON_DISK != knnMethodConfigContext.getMode()) {
+            && Mode.ON_DISK != knnMethodConfigContext.getMode()
+            && is32xDefaultVersion == false) {
             return false;
         }
 
@@ -185,9 +192,16 @@ public abstract class AbstractMethodResolver implements MethodResolver {
     }
 
     /**
-     * Resolves the default compression level from the config context. If the compression level is explicitly
-     * configured, returns it directly. Otherwise, for ON_DISK mode on V_3_6_0+, returns x32; for ON_DISK mode
-     * on earlier versions, returns the provided fallback; otherwise returns x1.
+     * Resolves the default compression level from the config context. The resolution order is:
+     * <ol>
+     *   <li>If the compression level is explicitly configured, return it directly.</li>
+     *   <li>If the index was created on or after {@code KNN_DEFAULT_COMPRESSION_FLIP_VERSION} (V_3_9_0), return
+     *       x32 regardless of mode. This is the default-compression flip: every new HNSW index gets x32
+     *       compression unless the user explicitly asked for something else.</li>
+     *   <li>Otherwise, for ON_DISK mode on V_3_6_0+, return x32; for ON_DISK mode on earlier versions, return
+     *       the provided fallback.</li>
+     *   <li>Otherwise (older versions, non-ON_DISK mode), return x1.</li>
+     * </ol>
      *
      * @param knnMethodConfigContext the config context
      * @param priorVersionOnDiskDefault the default compression for ON_DISK mode before V_3_6_0
@@ -200,10 +214,14 @@ public abstract class AbstractMethodResolver implements MethodResolver {
         if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())) {
             return knnMethodConfigContext.getCompressionLevel();
         }
+        Version version = knnMethodConfigContext.getVersionCreated();
+        // The x32-default flip: on V_3_9_0+, x32 is the default for all new HNSW indices, regardless of mode.
+        if (version != null && version.onOrAfter(KNN_DEFAULT_COMPRESSION_FLIP_VERSION)) {
+            return CompressionLevel.x32;
+        }
         if (knnMethodConfigContext.getMode() != Mode.ON_DISK) {
             return CompressionLevel.x1;
         }
-        Version version = knnMethodConfigContext.getVersionCreated();
         if (version != null && version.onOrAfter(Version.V_3_6_0)) {
             return CompressionLevel.x32;
         }

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -147,6 +148,26 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
         xContentBuilder.endObject();
         xContentBuilder.endObject();
         xContentBuilder.endObject();
+        request.source(xContentBuilder);
+        OpenSearchAssertions.assertAcked(client().admin().indices().putMapping(request).actionGet());
+    }
+
+    /**
+     * Create simple k-NN mapping with an explicit compression level (e.g. "1x" for an uncompressed index).
+     */
+    protected void createKnnIndexMapping(String indexName, String fieldName, Integer dimensions, String compressionLevel)
+        throws IOException {
+        PutMappingRequest request = new PutMappingRequest(indexName);
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimensions.toString())
+            .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel)
+            .endObject()
+            .endObject()
+            .endObject();
         request.source(xContentBuilder);
         OpenSearchAssertions.assertAcked(client().admin().indices().putMapping(request).actionGet());
     }

--- a/src/test/java/org/opensearch/knn/index/KNNFieldAliasQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNFieldAliasQueryTests.java
@@ -13,7 +13,9 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.KNNSingleNodeTestCase;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
@@ -54,6 +56,7 @@ public class KNNFieldAliasQueryTests extends KNNSingleNodeTestCase {
             .startObject(CONCRETE_FIELD)
             .field("type", "knn_vector")
             .field("dimension", DIMENSION)
+            .field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x1.getName())
             .startObject("method")
             .field("name", "hnsw")
             .field("engine", engine.getName())

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 
 import java.io.IOException;
@@ -71,7 +72,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
 
     public void testWarmup_shardPresentInCache() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
-        createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        createKnnIndexMapping(testIndexName, testFieldName, dimensions, CompressionLevel.x1.getName());
         updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
@@ -86,7 +87,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
 
     public void testWarmup_shardNotPresentInCache() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
-        createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        createKnnIndexMapping(testIndexName, testFieldName, dimensions, CompressionLevel.x1.getName());
         updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
         IndexShard indexShard;
         KNNIndexShard knnIndexShard;
@@ -191,7 +192,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     @SneakyThrows
     public void testClearCache_shardPresentInCache() {
         IndexService indexService = createKNNIndex(testIndexName);
-        createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        createKnnIndexMapping(testIndexName, testFieldName, dimensions, CompressionLevel.x1.getName());
         updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
         addKnnDoc(testIndexName, String.valueOf(randomInt()), testFieldName, new Float[] { randomFloat(), randomFloat() });
 

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
@@ -145,6 +145,88 @@ public class AbstractMethodResolverTests extends KNNTestCase {
         assertEquals(CompressionLevel.x1, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
     }
 
+    public void testGetDefaultCompressionLevel_whenV390OrLaterAndNoMode_thenReturnX32() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().versionCreated(Version.V_3_9_0).build();
+        assertEquals(CompressionLevel.x32, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenV390OrLaterAndInMemory_thenReturnX32() {
+        // The flip overrides mode: an unspecified compression on V_3_9_0+ resolves to x32 even for IN_MEMORY.
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).versionCreated(Version.V_3_9_0).build();
+        assertEquals(CompressionLevel.x32, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenV390OrLaterAndExplicitX1_thenReturnX1() {
+        // An explicit compression_level is always honored, even after the flip.
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder()
+            .compressionLevel(CompressionLevel.x1)
+            .versionCreated(Version.V_3_9_0)
+            .build();
+        assertEquals(CompressionLevel.x1, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenV380AndNoMode_thenReturnX1() {
+        // Before the flip version, an unspecified compression with no on-disk mode stays x1.
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().versionCreated(Version.V_3_8_0).build();
+        assertEquals(CompressionLevel.x1, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenV380AndOnDisk_thenReturnX32() {
+        // Existing ON_DISK behavior for versions between V_3_6_0 and the flip is unchanged.
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.ON_DISK).versionCreated(Version.V_3_8_0).build();
+        assertEquals(CompressionLevel.x32, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenV350AndOnDisk_thenReturnFallback() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.ON_DISK).versionCreated(Version.V_3_5_0).build();
+        assertEquals(CompressionLevel.x4, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testShouldEncoderBeResolved_whenV390OrLaterAndDefaultInMemory_thenResolve() {
+        // Before the flip, an unspecified compression + non-ON_DISK mode short-circuits encoder resolution.
+        // On V_3_9_0+, the encoder must be resolved so the x32 default takes effect.
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.V_3_8_0).build()
+            )
+        );
+        assertTrue(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.V_3_9_0).build()
+            )
+        );
+        assertTrue(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder()
+                    .vectorDataType(VectorDataType.FLOAT)
+                    .mode(Mode.IN_MEMORY)
+                    .versionCreated(Version.V_3_9_0)
+                    .build()
+            )
+        );
+        // An explicit x1 still short-circuits, even on V_3_9_0+.
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder()
+                    .vectorDataType(VectorDataType.FLOAT)
+                    .compressionLevel(CompressionLevel.x1)
+                    .versionCreated(Version.V_3_9_0)
+                    .build()
+            )
+        );
+        // Non-FLOAT vectors are never auto-encoded, even on V_3_9_0+.
+        assertFalse(
+            TEST_RESOLVER.shouldEncoderBeResolved(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BINARY).versionCreated(Version.V_3_9_0).build()
+            )
+        );
+    }
+
     public void testShouldEncoderBeResolved() {
         assertFalse(
             TEST_RESOLVER.shouldEncoderBeResolved(

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolverTests.java
@@ -38,7 +38,8 @@ public class FaissMethodResolverTests extends KNNTestCase {
             false,
             SpaceType.INNER_PRODUCT
         );
-        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x1, SpaceType.INNER_PRODUCT, ENCODER_FLAT, false);
+        // On V_3_9_0+ (Version.CURRENT), an unspecified compression flips to the x32 (SQ 1-bit) default.
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.INNER_PRODUCT, ENCODER_SQ, true);
 
         resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
@@ -129,8 +130,10 @@ public class FaissMethodResolverTests extends KNNTestCase {
             false,
             SpaceType.L2
         );
-        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x1, SpaceType.L2, ENCODER_FLAT, false);
+        // On V_3_9_0+ (Version.CURRENT), an unspecified compression flips to the x32 (SQ 1-bit) default.
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.L2, ENCODER_SQ, true);
 
+        // BINARY vectors are not affected by the x32 default flip and stay uncompressed (x1).
         resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BINARY).versionCreated(Version.CURRENT).build(),
@@ -358,17 +361,17 @@ public class FaissMethodResolverTests extends KNNTestCase {
         validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x1, SpaceType.INNER_PRODUCT, ENCODER_FLAT, false);
     }
 
-    public void testResolveMethod_whenNoCompressionSpecified_thenResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_8_0+, keep x1 for older versions
+    public void testResolveMethod_whenNoCompressionSpecifiedOnV390OrLater_thenResolvesToX32() {
+        // On V_3_9_0+ (Version.CURRENT), FLOAT HNSW indices with no compression flip to the x32 (SQ 1-bit) default.
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
             false,
             SpaceType.L2
         );
-        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
         assertEquals(
-            ENCODER_FLAT,
+            ENCODER_SQ,
             ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
                 .getMethodComponentContext()
                 .getParameters()
@@ -381,15 +384,16 @@ public class FaissMethodResolverTests extends KNNTestCase {
             false,
             SpaceType.L2
         );
-        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
         assertEquals(
-            ENCODER_FLAT,
+            ENCODER_SQ,
             ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
                 .getMethodComponentContext()
                 .getParameters()
                 .get(METHOD_ENCODER_PARAMETER)).getName()
         );
 
+        // BINARY vectors are excluded from the flip and remain uncompressed (x1).
         resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             new KNNMethodContext(KNNEngine.FAISS, SpaceType.HAMMING, new MethodComponentContext(METHOD_HNSW, Map.of())),
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BINARY).versionCreated(Version.CURRENT).build(),
@@ -442,51 +446,60 @@ public class FaissMethodResolverTests extends KNNTestCase {
         validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.L2, QFrameBitEncoder.NAME, true);
     }
 
-    public void testResolveMethod_whenNoCompressionAcrossVersions_thenAlwaysResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_8_0 → assert x1,
-        // indexVersionCreated >= V_3_8_0 → assert x32
-        Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
+    public void testResolveMethod_whenNoCompressionAcrossVersions_thenFlipsAtV390() {
+        // Before the x32-default flip (V_3_9_0), an unspecified compression resolves to x1 (flat).
+        Version[] preFlipVersions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.V_3_8_0 };
+        // On or after the flip, it resolves to x32 (SQ 1-bit).
+        Version[] postFlipVersions = new Version[] { Version.V_3_9_0, Version.CURRENT };
 
-        for (Version version : versions) {
-            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+        for (Version version : preFlipVersions) {
+            for (KNNMethodContext methodContext : new KNNMethodContext[] {
                 null,
-                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
-                false,
-                SpaceType.L2
-            );
-            assertEquals(
-                "Expected x1 for version " + version + " with no compression specified",
-                CompressionLevel.x1,
-                resolvedMethodContext.getCompressionLevel()
-            );
-            assertEquals(
-                ENCODER_FLAT,
-                ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
-                    .getMethodComponentContext()
-                    .getParameters()
-                    .get(METHOD_ENCODER_PARAMETER)).getName()
-            );
+                new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())) }) {
+                ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                    methodContext,
+                    KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                    false,
+                    SpaceType.L2
+                );
+                assertEquals(
+                    "Expected x1 for version " + version + " with no compression specified",
+                    CompressionLevel.x1,
+                    resolvedMethodContext.getCompressionLevel()
+                );
+                assertEquals(
+                    ENCODER_FLAT,
+                    ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                        .getMethodComponentContext()
+                        .getParameters()
+                        .get(METHOD_ENCODER_PARAMETER)).getName()
+                );
+            }
         }
 
-        for (Version version : versions) {
-            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
-                new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
-                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
-                false,
-                SpaceType.L2
-            );
-            assertEquals(
-                "Expected x1 for version " + version + " with HNSW and no compression",
-                CompressionLevel.x1,
-                resolvedMethodContext.getCompressionLevel()
-            );
-            assertEquals(
-                ENCODER_FLAT,
-                ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
-                    .getMethodComponentContext()
-                    .getParameters()
-                    .get(METHOD_ENCODER_PARAMETER)).getName()
-            );
+        for (Version version : postFlipVersions) {
+            for (KNNMethodContext methodContext : new KNNMethodContext[] {
+                null,
+                new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())) }) {
+                ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                    methodContext,
+                    KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                    false,
+                    SpaceType.L2
+                );
+                assertEquals(
+                    "Expected x32 for version " + version + " with no compression specified",
+                    CompressionLevel.x32,
+                    resolvedMethodContext.getCompressionLevel()
+                );
+                assertEquals(
+                    ENCODER_SQ,
+                    ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                        .getMethodComponentContext()
+                        .getParameters()
+                        .get(METHOD_ENCODER_PARAMETER)).getName()
+                );
+            }
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
@@ -40,7 +40,8 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         assertFalse(resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().isEmpty());
         assertEquals(KNNEngine.LUCENE, resolvedMethodContext.getKnnMethodContext().getKnnEngine());
         assertEquals(SpaceType.INNER_PRODUCT, resolvedMethodContext.getKnnMethodContext().getSpaceType());
-        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        // On V_3_9_0+ (Version.CURRENT), an unspecified compression flips to the x32 default.
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
 
         resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
@@ -544,18 +545,22 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         );
     }
 
-    public void testResolveMethod_whenNoCompressionSpecified_thenResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_8_0+, keep x1 for older versions
+    public void testResolveMethod_whenNoCompressionSpecifiedOnV390OrLater_thenResolvesToX32() {
+        // On V_3_9_0+ (Version.CURRENT), FLOAT HNSW indices with no compression flip to the x32 (SQ 1-bit) default.
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
             false,
             SpaceType.L2
         );
-        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
         assertEquals(KNNEngine.LUCENE, resolvedMethodContext.getKnnMethodContext().getKnnEngine());
-        assertFalse(
-            resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
+        assertEquals(
+            ENCODER_SQ,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
         );
 
         resolvedMethodContext = TEST_RESOLVER.resolveMethod(
@@ -564,11 +569,16 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
             false,
             SpaceType.L2
         );
-        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
-        assertFalse(
-            resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
+        assertEquals(
+            ENCODER_SQ,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
         );
 
+        // BYTE vectors are excluded from the flip and remain uncompressed (x1) with no encoder.
         resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BYTE).versionCreated(Version.CURRENT).build(),
@@ -579,6 +589,25 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         assertFalse(
             resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
         );
+    }
+
+    public void testResolveMethod_whenNoCompressionSpecifiedBeforeV390_thenResolvesToX1() {
+        // Before the flip (V_3_9_0), FLOAT HNSW indices with no compression and no on-disk mode stay x1.
+        for (Version version : new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_8_0 }) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals("Expected x1 for version " + version, CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+            assertFalse(
+                resolvedMethodContext.getKnnMethodContext()
+                    .getMethodComponentContext()
+                    .getParameters()
+                    .containsKey(METHOD_ENCODER_PARAMETER)
+            );
+        }
     }
 
     public void testResolveMethod_whenOnDiskMode_thenSQEncoderHasBits1() {
@@ -601,52 +630,63 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         assertEquals(1, encoderCtx.getParameters().get(LUCENE_SQ_BITS));
     }
 
-    public void testResolveMethod_whenNoCompressionAcrossVersions_thenAlwaysResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_8_0 → assert x1,
-        // indexVersionCreated >= V_3_8_0 → assert x32
-        Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
+    public void testResolveMethod_whenNoCompressionAcrossVersions_thenFlipsAtV390() {
+        Version[] preFlipVersions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.V_3_8_0 };
+        Version[] postFlipVersions = new Version[] { Version.V_3_9_0, Version.CURRENT };
 
-        for (Version version : versions) {
-            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+        // Before the flip, FLOAT HNSW indices with no compression resolve to x1 (no encoder).
+        for (Version version : preFlipVersions) {
+            for (KNNMethodContext methodContext : new KNNMethodContext[] {
                 null,
-                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
-                false,
-                SpaceType.L2
-            );
-            assertEquals(
-                "Expected x1 for version " + version + " with no compression specified",
-                CompressionLevel.x1,
-                resolvedMethodContext.getCompressionLevel()
-            );
-            assertFalse(
-                resolvedMethodContext.getKnnMethodContext()
-                    .getMethodComponentContext()
-                    .getParameters()
-                    .containsKey(METHOD_ENCODER_PARAMETER)
-            );
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())) }) {
+                ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                    methodContext,
+                    KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                    false,
+                    SpaceType.L2
+                );
+                assertEquals(
+                    "Expected x1 for version " + version + " with no compression specified",
+                    CompressionLevel.x1,
+                    resolvedMethodContext.getCompressionLevel()
+                );
+                assertFalse(
+                    resolvedMethodContext.getKnnMethodContext()
+                        .getMethodComponentContext()
+                        .getParameters()
+                        .containsKey(METHOD_ENCODER_PARAMETER)
+                );
+            }
         }
 
-        for (Version version : versions) {
-            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
-                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
-                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
-                false,
-                SpaceType.L2
-            );
-            assertEquals(
-                "Expected x1 for version " + version + " with HNSW and no compression",
-                CompressionLevel.x1,
-                resolvedMethodContext.getCompressionLevel()
-            );
-            assertFalse(
-                resolvedMethodContext.getKnnMethodContext()
-                    .getMethodComponentContext()
-                    .getParameters()
-                    .containsKey(METHOD_ENCODER_PARAMETER)
-            );
+        // On or after the flip, FLOAT HNSW indices with no compression resolve to x32 (SQ 1-bit) encoder.
+        for (Version version : postFlipVersions) {
+            for (KNNMethodContext methodContext : new KNNMethodContext[] {
+                null,
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())) }) {
+                ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                    methodContext,
+                    KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                    false,
+                    SpaceType.L2
+                );
+                assertEquals(
+                    "Expected x32 for version " + version + " with no compression specified",
+                    CompressionLevel.x32,
+                    resolvedMethodContext.getCompressionLevel()
+                );
+                assertEquals(
+                    ENCODER_SQ,
+                    ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                        .getMethodComponentContext()
+                        .getParameters()
+                        .get(METHOD_ENCODER_PARAMETER)).getName()
+                );
+            }
         }
 
-        for (Version version : versions) {
+        // BYTE vectors are excluded from the flip and always resolve to x1, regardless of version.
+        for (Version version : postFlipVersions) {
             ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
                 null,
                 KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BYTE).versionCreated(version).build(),

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -2118,7 +2118,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
 
-        // Default to faiss and ensure legacy is in use
+        // Default to faiss and ensure legacy is in use. On V_3_9_0+ (CURRENT), an index with no explicit
+        // compression_level flips to the x32 (SQ 1-bit) default.
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
@@ -2136,10 +2137,10 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             KNNEngine.DEFAULT,
             SpaceType.L2,
             VectorDataType.FLOAT,
-            CompressionLevel.x1,
+            CompressionLevel.x32,
             CompressionLevel.NOT_CONFIGURED,
             Mode.NOT_CONFIGURED,
-            false
+            true
         );
 
         // If mode is in memory and 1x compression, again use default legacy

--- a/src/test/java/org/opensearch/knn/plugin/transport/ClearCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/ClearCacheTransportActionTests.java
@@ -15,6 +15,7 @@ import org.opensearch.cluster.routing.ShardsIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.index.IndexService;
 import org.opensearch.knn.KNNSingleNodeTestCase;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 
 import java.util.EnumSet;
@@ -34,7 +35,7 @@ public class ClearCacheTransportActionTests extends KNNSingleNodeTestCase {
         assertEquals(0, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().size());
 
         IndexService indexService = createIndex(testIndex, getKNNDefaultIndexSettingsBuildsGraphAlways());
-        createKnnIndexMapping(testIndex, TEST_FIELD, DIMENSIONS);
+        createKnnIndexMapping(testIndex, TEST_FIELD, DIMENSIONS, CompressionLevel.x1.getName());
         addKnnDoc(testIndex, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
         ShardRouting shardRouting = indexService.iterator().next().routingEntry();
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/KNNWarmupTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/KNNWarmupTransportActionTests.java
@@ -15,6 +15,7 @@ import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.ShardsIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.index.IndexService;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.core.rest.RestStatus;
 
@@ -38,7 +39,7 @@ public class KNNWarmupTransportActionTests extends KNNSingleNodeTestCase {
         assertEquals(0, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().size());
 
         indexService = createIndex(testIndexName, getKNNDefaultIndexSettingsBuildsGraphAlways());
-        createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        createKnnIndexMapping(testIndexName, testFieldName, dimensions, CompressionLevel.x1.getName());
         shardRouting = indexService.iterator().next().routingEntry();
 
         knnWarmupTransportAction.shardOperation(knnWarmupRequest, shardRouting);


### PR DESCRIPTION
### Description
- Flips the flag to default to 32x compression for HNSW indices

### Related Issues
Resolves #3290 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
