### PR TITLE
Fix flaky RescoreKnnVectorQueryTests.testRescoreQuery

### DIFF
--- a/src/test/java/org/opensearch/knn/index/query/RescoreKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RescoreKnnVectorQueryTests.java
@@ -89,7 +89,7 @@ public class RescoreKnnVectorQueryTests extends OpenSearchTestCase {
                 Query innerQuery = new MatchAllDocsQuery();
                 try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
                     mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
-                    IndexSearcher searcher = newSearcher(reader, false, false);
+                    IndexSearcher searcher = new IndexSearcher(reader);
                     RescoreKNNVectorQuery rescoreKnnVectorQuery = new RescoreKNNVectorQuery(innerQuery, FIELD_NAME, finalK, queryVector, 1);
                     TopDocs rescoredDocs = searcher.search(rescoreKnnVectorQuery, finalK);
                     assertEquals(finalK, rescoredDocs.scoreDocs.length);

--- a/src/test/java/org/opensearch/knn/index/query/RescoreKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RescoreKnnVectorQueryTests.java
@@ -89,7 +89,7 @@ public class RescoreKnnVectorQueryTests extends OpenSearchTestCase {
                 Query innerQuery = new MatchAllDocsQuery();
                 try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
                     mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
-                    IndexSearcher searcher = newSearcher(reader, true, false);
+                    IndexSearcher searcher = newSearcher(reader, false, false);
                     RescoreKNNVectorQuery rescoreKnnVectorQuery = new RescoreKNNVectorQuery(innerQuery, FIELD_NAME, finalK, queryVector, 1);
                     TopDocs rescoredDocs = searcher.search(rescoreKnnVectorQuery, finalK);
                     assertEquals(finalK, rescoredDocs.scoreDocs.length);


### PR DESCRIPTION
### Description

Disable randomized reader wrapping in `testRescoreQuery`.

With the failing seed, `newSearcher(reader, true, false)` can wrap the
index reader in a `ParallelLeafReader`. `ExactSearcher` expects the leaf
to unwrap to a `SegmentReader`, so the test fails before exercising the
production rescore path.

Disabling this test-only wrapper makes the test deterministic while
preserving production behavior.

This test-only change does not require a changelog entry. Please apply
the `skip-changelog` label.

### Related Issues

Resolves #3505

### Testing

```shell
./gradlew ':test' \
  --tests 'org.opensearch.knn.index.query.RescoreKnnVectorQueryTests.testRescoreQuery' \
  -Dtests.seed=6D564762C7B93DE4
```

### Check List

- [x] New functionality includes testing. (No new functionality; test-only fix.)
- [x] New functionality has been documented. (Not applicable.)
- [x] API changes companion pull request created. (Not applicable; no API changes.)
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR created. (Not applicable.)

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
