### PR TITLE
Fix when BQ file is not present in the segment as there is no vectors in the segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * Fix knn query against a field alias returning zero hits silently [#3485](https://github.com/opensearch-project/k-NN/pull/3485)
+* Fix when BQ file is not present in the segment as there is no vectors in the segment []()
 
 ### Refactoring
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)

--- a/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfo.java
+++ b/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfo.java
@@ -8,7 +8,9 @@ package org.opensearch.knn.index.query;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
 import org.opensearch.knn.quantization.models.quantizationParams.QuantizationParams;
@@ -21,6 +23,7 @@ import java.io.IOException;
  */
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Log4j2
 public class SegmentLevelQuantizationInfo {
     private final QuantizationParams quantizationParams;
     private final QuantizationState quantizationState;
@@ -35,10 +38,26 @@ public class SegmentLevelQuantizationInfo {
      */
     public static SegmentLevelQuantizationInfo build(final LeafReader leafReader, final FieldInfo fieldInfo, final String fieldName)
         throws IOException {
+        // Since we don't know top code has made sure that field is vector or not, we are doing this check to ensure that
+        // we validate it.
+        if (fieldInfo == null || fieldInfo.hasVectorValues() == false) {
+            log.debug("The segment field {} is not a vector field.", fieldName);
+            return null;
+        }
+
         final QuantizationParams quantizationParams = QuantizationService.getInstance().getQuantizationParams(fieldInfo);
         if (quantizationParams == null) {
             return null;
         }
+
+        // Before getting the quantization state check if this segment has vector docs or not. Just by checking fieldInfo
+        // you cannot make sure that it has docs. So we are validating it with FloatVectorValues.
+        final FloatVectorValues fvv = leafReader.getFloatVectorValues(fieldName);
+        if (fvv == null || fvv.size() == 0) {
+            log.debug("The segment has BQ field with name : {}, but no vectors in it.", fieldName);
+            return null;
+        }
+
         final QuantizationState quantizationState = SegmentLevelQuantizationUtil.getQuantizationState(leafReader, fieldName);
         return new SegmentLevelQuantizationInfo(quantizationParams, quantizationState);
     }

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -12,6 +12,7 @@ import lombok.SneakyThrows;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
@@ -1783,6 +1784,12 @@ public class KNNWeightTests extends KNNWeightTestCase {
             when(reader.getFieldInfos()).thenReturn(fieldInfos);
             when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
             when(fieldInfo.attributes()).thenReturn(attributesMap);
+            // The segment carries the quantized vector field with live vectors, so SegmentLevelQuantizationInfo.build
+            // proceeds past its field-is-vector / non-empty-segment guards to load the quantization state.
+            when(fieldInfo.hasVectorValues()).thenReturn(true);
+            final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+            when(floatVectorValues.size()).thenReturn(1);
+            when(reader.getFloatVectorValues(FIELD_NAME)).thenReturn(floatVectorValues);
             // fieldName, new float[0], tempCollector, null)
             doNothing().when(reader).searchNearestVectors(any(), eq(new float[0]), any(), any());
 

--- a/src/test/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfoTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfoTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.mockito.MockedStatic;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.quantization.models.quantizationParams.QuantizationParams;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.OneBitScalarQuantizationState;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SegmentLevelQuantizationInfoTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "my_vector";
+
+    private QuantizationParams quantizationParams() {
+        return ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
+    }
+
+    /**
+     * fieldInfo == null -> return null, and quantization params are never even looked up.
+     */
+    @SneakyThrows
+    public void testBuild_whenFieldInfoIsNull_thenReturnsNull() {
+        final LeafReader leafReader = mock(LeafReader.class);
+        try (MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class)) {
+            final QuantizationService quantizationService = mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
+
+            assertNull(SegmentLevelQuantizationInfo.build(leafReader, null, FIELD_NAME));
+
+            // The field-is-vector guard runs before any quantization lookup.
+            verify(quantizationService, never()).getQuantizationParams(any());
+            verify(leafReader, never()).getFloatVectorValues(anyString());
+        }
+    }
+
+    /**
+     * fieldInfo present but not a vector field -> return null before any quantization lookup.
+     */
+    @SneakyThrows
+    public void testBuild_whenFieldIsNotVectorField_thenReturnsNull() {
+        final LeafReader leafReader = mock(LeafReader.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.hasVectorValues()).thenReturn(false);
+
+        try (MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class)) {
+            final QuantizationService quantizationService = mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
+
+            assertNull(SegmentLevelQuantizationInfo.build(leafReader, fieldInfo, FIELD_NAME));
+
+            verify(quantizationService, never()).getQuantizationParams(any());
+            verify(leafReader, never()).getFloatVectorValues(anyString());
+        }
+    }
+
+    /**
+     * Vector field but no quantization params (non-quantized index) -> return null without reading vectors.
+     */
+    @SneakyThrows
+    public void testBuild_whenQuantizationParamsIsNull_thenReturnsNull() {
+        final LeafReader leafReader = mock(LeafReader.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.hasVectorValues()).thenReturn(true);
+
+        try (MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class)) {
+            final QuantizationService quantizationService = mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+
+            assertNull(SegmentLevelQuantizationInfo.build(leafReader, fieldInfo, FIELD_NAME));
+
+            // No params -> we must not attempt to read the (possibly missing) quantization state.
+            verify(leafReader, never()).getFloatVectorValues(anyString());
+        }
+    }
+
+    /**
+     * Core bug fix: quantized field is present in FieldInfos but the segment has zero live vector docs
+     * ({@link FloatVectorValues} is null). build() must return null instead of trying to open the
+     * missing .osknnqstate file.
+     */
+    @SneakyThrows
+    public void testBuild_whenFloatVectorValuesIsNull_thenReturnsNull() {
+        final LeafReader leafReader = mock(LeafReader.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.hasVectorValues()).thenReturn(true);
+        when(leafReader.getFloatVectorValues(FIELD_NAME)).thenReturn(null);
+
+        try (
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<SegmentLevelQuantizationUtil> utilMockedStatic = mockStatic(SegmentLevelQuantizationUtil.class)
+        ) {
+            final QuantizationService quantizationService = mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams());
+
+            assertNull(SegmentLevelQuantizationInfo.build(leafReader, fieldInfo, FIELD_NAME));
+
+            // Reader must not be asked for a quantization state that was never written.
+            utilMockedStatic.verify(() -> SegmentLevelQuantizationUtil.getQuantizationState(any(), anyString()), never());
+        }
+    }
+
+    /**
+     * Core bug fix: quantized field present but zero live vector docs (size() == 0) -> return null.
+     */
+    @SneakyThrows
+    public void testBuild_whenFloatVectorValuesIsEmpty_thenReturnsNull() {
+        final LeafReader leafReader = mock(LeafReader.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.hasVectorValues()).thenReturn(true);
+        final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+        when(floatVectorValues.size()).thenReturn(0);
+        when(leafReader.getFloatVectorValues(FIELD_NAME)).thenReturn(floatVectorValues);
+
+        try (
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<SegmentLevelQuantizationUtil> utilMockedStatic = mockStatic(SegmentLevelQuantizationUtil.class)
+        ) {
+            final QuantizationService quantizationService = mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams());
+
+            assertNull(SegmentLevelQuantizationInfo.build(leafReader, fieldInfo, FIELD_NAME));
+
+            utilMockedStatic.verify(() -> SegmentLevelQuantizationUtil.getQuantizationState(any(), anyString()), never());
+        }
+    }
+
+    /**
+     * Happy path: quantized field with live vector docs -> build the info carrying the params and state.
+     */
+    @SneakyThrows
+    public void testBuild_whenFieldHasVectors_thenReturnsInfo() {
+        final LeafReader leafReader = mock(LeafReader.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.hasVectorValues()).thenReturn(true);
+        final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+        when(floatVectorValues.size()).thenReturn(5);
+        when(leafReader.getFloatVectorValues(FIELD_NAME)).thenReturn(floatVectorValues);
+
+        final QuantizationParams quantizationParams = quantizationParams();
+        final QuantizationState quantizationState = OneBitScalarQuantizationState.builder()
+            .quantizationParams((ScalarQuantizationParams) quantizationParams)
+            .meanThresholds(new float[] { 1.2f, 2.3f, 3.4f, 4.5f })
+            .build();
+
+        try (
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<SegmentLevelQuantizationUtil> utilMockedStatic = mockStatic(SegmentLevelQuantizationUtil.class)
+        ) {
+            final QuantizationService quantizationService = mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
+            utilMockedStatic.when(() -> SegmentLevelQuantizationUtil.getQuantizationState(leafReader, FIELD_NAME))
+                .thenReturn(quantizationState);
+
+            final SegmentLevelQuantizationInfo info = SegmentLevelQuantizationInfo.build(leafReader, fieldInfo, FIELD_NAME);
+
+            assertNotNull(info);
+            assertEquals(quantizationParams, info.getQuantizationParams());
+            assertEquals(quantizationState, info.getQuantizationState());
+            utilMockedStatic.verify(() -> SegmentLevelQuantizationUtil.getQuantizationState(leafReader, FIELD_NAME));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -14,9 +14,12 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
@@ -27,6 +30,8 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
@@ -635,6 +640,160 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
             assertEquals(1, getTotalSegmentCount(indexName));
             validateKNNSearch(indexName, FIELD_NAME, DIMENSION, vectorDocCount, k);
         }
+    }
+
+    /**
+     * Regression test for the missing {@code .osknnqstate} quantization-state failure on the k-NN
+     * <b>search</b> read path (see {@code repro_osknnqstate_missing.sh}).
+     * <p>
+     * A FAISS binary (1-bit) quantized field can end up in a segment's FieldInfos while that segment
+     * holds zero live vector documents (all vector docs deleted then physically expunged by a merge).
+     * The writer skips {@code train()} for such a segment, so no {@code .osknnqstate} file is written.
+     * The reader {@link org.opensearch.knn.index.query.SegmentLevelQuantizationInfo#build} must detect
+     * the empty segment (via {@code FloatVectorValues}) and return {@code null} instead of
+     * unconditionally opening the absent state file, which previously threw
+     * {@code NoSuchFileException}/{@code FileNotFoundException} before the graceful exact-search fallback.
+     * <p>
+     * Unlike {@link #testForceMergeWithVectorlessSegment_whenFaissSQ_thenSucceed}, the vectorless segment
+     * is left un-merged alongside a healthy vector-bearing segment so that a live k-NN query touches it.
+     */
+    @SneakyThrows
+    public void testKnnSearchWithVectorlessSegment_whenFaissBinary_thenSucceed() {
+        final int vectorDocCount = 10;
+        final int k = 5;
+        final String indexName = INDEX_NAME + "_bq_empty_search";
+        final float[][] vectors = new float[vectorDocCount][DIMENSION];
+        for (int docId = 0; docId < vectorDocCount; docId++) {
+            Arrays.fill(vectors[docId], (float) docId);
+        }
+
+        try (
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(FIELD_NAME)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(NAME, "hnsw")
+                .field(KNN_ENGINE, FAISS_NAME)
+                .startObject(PARAMETERS)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "binary")
+                .startObject(PARAMETERS)
+                .field("bits", 1)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .startObject(FIELD_NAME_NON_KNN)
+                .field("type", "text")
+                .endObject()
+                .endObject()
+                .endObject()
+        ) {
+            createKnnIndex(indexName, buildKNNIndexSettings(-1), builder.toString());
+
+            // Segment A: vector docs plus one live non-vector "anchor" doc. The anchor keeps the segment
+            // alive after every vector doc below is replaced, so the field survives in FieldInfos.
+            final Request initialBulk = new Request("POST", "/_bulk");
+            initialBulk.addParameter("refresh", "true");
+            final StringBuilder initialBody = new StringBuilder();
+            for (int docId = 0; docId < vectorDocCount; docId++) {
+                initialBody.append("{\"index\":{\"_index\":\"")
+                    .append(indexName)
+                    .append("\",\"_id\":\"")
+                    .append(docId)
+                    .append("\"}}\n{\"")
+                    .append(FIELD_NAME)
+                    .append("\":")
+                    .append(Arrays.toString(vectors[docId]))
+                    .append("}\n");
+            }
+            initialBody.append("{\"index\":{\"_index\":\"")
+                .append(indexName)
+                .append("\",\"_id\":\"anchor\"}}\n{\"")
+                .append(FIELD_NAME_NON_KNN)
+                .append("\":\"anchor\"}\n");
+            initialBulk.setJsonEntity(initialBody.toString());
+            assertEquals(RestStatus.OK.getStatus(), client().performRequest(initialBulk).getStatusLine().getStatusCode());
+            assertEquals(1, getTotalSegmentCount(indexName));
+
+            // Replace every vector doc with a non-vector doc (soft-deletes the original vectors).
+            final Request replacementBulk = new Request("POST", "/_bulk");
+            replacementBulk.addParameter("refresh", "true");
+            final StringBuilder replacementBody = new StringBuilder();
+            for (int docId = 0; docId < vectorDocCount; docId++) {
+                replacementBody.append("{\"index\":{\"_index\":\"")
+                    .append(indexName)
+                    .append("\",\"_id\":\"")
+                    .append(docId)
+                    .append("\"}}\n{\"")
+                    .append(FIELD_NAME_NON_KNN)
+                    .append("\":\"replacement\"}\n");
+            }
+            replacementBulk.setJsonEntity(replacementBody.toString());
+            assertEquals(RestStatus.OK.getStatus(), client().performRequest(replacementBulk).getStatusLine().getStatusCode());
+            assertEquals(2, getTotalSegmentCount(indexName));
+
+            // Physically expunge the soft-deleted vector docs so the surviving segment keeps the field
+            // in FieldInfos with zero live vectors (hence no .osknnqstate is written). Soft-delete
+            // retention leases advance in the background, so poll -- flush + expunge-only merge -- until
+            // docs.deleted reaches 0 instead of forcing it with a retention-lease override setting.
+            assertBusy(() -> {
+                flushIndex(indexName);
+                final Request expunge = new Request("POST", "/" + indexName + "/_forcemerge");
+                expunge.addParameter("only_expunge_deletes", "true");
+                expunge.addParameter("flush", "true");
+                assertEquals(RestStatus.OK.getStatus(), client().performRequest(expunge).getStatusLine().getStatusCode());
+                refreshIndex(indexName);
+                assertEquals("soft-deleted vector docs were not physically expunged", 0, getDeletedDocCount(indexName));
+            }, 120, TimeUnit.SECONDS);
+            assertEquals(vectorDocCount + 1, getDocCount(indexName));
+
+            // Add a fresh, healthy vector-bearing segment. Do NOT merge -- the vectorless segment must
+            // remain a separate leaf so the k-NN query below actually reads it and exercises the
+            // SegmentLevelQuantizationInfo.build guard.
+            bulkAddKnnDocs(indexName, FIELD_NAME, vectors, vectorDocCount);
+            // At least two leaves must remain: the vectorless segment plus the fresh vector segment(s).
+            // A count of exactly 1 would mean everything was merged into a single healthy segment and the
+            // guard would never be exercised.
+            assertTrue(getTotalSegmentCount(indexName) >= 2);
+
+            // Before the fix this throws NoSuchFileException on the missing .osknnqstate of the
+            // vectorless segment. After the fix the empty segment degrades gracefully and the query
+            // returns the healthy segment's neighbors. We assert the full result set is returned (a
+            // shard failure would drop hits) rather than a strict neighbor order, since 1-bit binary
+            // quantization does not preserve exact ranking.
+            final float[] queryVector = new float[DIMENSION];
+            Arrays.fill(queryVector, (float) vectorDocCount);
+            final Response searchResponse = searchKNNIndex(
+                indexName,
+                KNNQueryBuilder.builder().k(k).fieldName(FIELD_NAME).vector(queryVector).build(),
+                k
+            );
+            final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+            assertEquals(k, results.size());
+        }
+    }
+
+    /**
+     * Number of soft-deleted (but not yet physically purged) docs in the primaries of an index,
+     * read from the {@code _stats/docs} API.
+     */
+    private int getDeletedDocCount(final String indexName) throws Exception {
+        final Request request = new Request("GET", "/" + indexName + "/_stats/docs");
+        final Response response = client().performRequest(request);
+        assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        final Map<String, Object> responseMap = createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            EntityUtils.toString(response.getEntity())
+        ).map();
+        final Map<String, Object> all = (Map<String, Object>) responseMap.get("_all");
+        final Map<String, Object> primaries = (Map<String, Object>) all.get("primaries");
+        final Map<String, Object> docs = (Map<String, Object>) primaries.get("docs");
+        return (Integer) docs.get("deleted");
     }
 
     /**


### PR DESCRIPTION
### Description
Fix when BQ file is not present in the segment as there is no vectors in the segment

#### Details
Fixes a `FileNotFoundException` / `NoSuchFileException` on the `.osknnqstate` quantization state file that fails k-NN search on quantized (BQ / `on_disk`) fields.


**Root cause **

  | Side | Guard | Result |
  |---|---|---|
  | `NativeEngines990KnnVectorsWriter.train()` | writes state only if `quantizationParams != null` **&&** `totalLiveDocs > 0` | segment whose quantized field has 0 live docs gets **no** `.osknnqstate` |
  | `SegmentLevelQuantizationInfo.build()` | checked `quantizationParams == null` only — no live-docs or file-existence check | unconditionally opened `.osknnqstate` → threw |

  Both sides derive "is quantized" from the same pure function
  (`QuantizationService.getQuantizationParams(fieldInfo)`), so the only dimension on which they disagreed was `totalLiveDocs > 0`.

  **Trigger.** A **merge** that carries the vector field forward while every doc holding the vector is non-live. The merged segment keeps the field in `FieldInfos` (schema-level union survives merge) and stays searchable, but has zero live vectors, so `train()` is skipped and no state file is written.

Only the merge path can do this: `flush()` counts `field.getVectors().size()` (the in-memory map, deletion-agnostic), whereas `mergeOneField()` counts via `MergedVectorValues`, which honors `liveDocs` and can be 0.

This is intermittent in practice because soft deletes retain deleted docs — and their vectors — until retention leases advance. A merge before that keeps the vectors (state written, search fine); one after physically purges them and produces the affected segment.



### Related Issues
NA

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
