### PR TITLE
Add NEON SIMD kernel for FP16 L2 similarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Support `index.knn.advanced.approximate_threshold` for the Lucene engine [#3451](https://github.com/opensearch-project/k-NN/pull/3451)
 * Convert document vectors to primitive arrays once per document in lateInteractionScore, instead of once per query-vector/document-vector pair [#3453](https://github.com/opensearch-project/k-NN/pull/3453)
 * Terminate remote index build early when the merge has been aborted [#3488](https://github.com/opensearch-project/k-NN/pull/3488)
+* Add NEON SIMD kernel for FP16 L2 similarity [#3512](https://github.com/opensearch-project/k-NN/pull/3512)

--- a/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
@@ -141,18 +141,120 @@ struct ArmNeonFP16L2 final : BaseSimilarityFunction<BulkScoreTransformFunc, Scor
                                    int32_t* internalVectorIds,
                                    float* scores,
                                    const int32_t numVectors) {
-        // Prepare similarity calculation
-        auto func = dynamic_cast<faiss::ScalarQuantizer::SQDistanceComputer*>(srchContext->faissFunction.get());
-        knn_jni::util::ParameterCheck::require_non_null(
-            func, "Unexpected distance function acquired. Expected SQDistanceComputer, but it was something else");
+        // Bulk L2 with 4 batch
+        int32_t processedCount = 0;
+        constexpr int32_t vecBlock = 4;
+        const uint8_t* vectors[vecBlock];
+        const auto* queryPtr = (const float*) srchContext->queryVectorSimdAligned;
+        const int32_t dim = srchContext->dimension;
+        constexpr int32_t dimensionBatch = 8;
 
-        for (int32_t i = 0 ; i < numVectors ; ++i) {
-            // Calculate distance
-            auto vector = reinterpret_cast<uint8_t*>(srchContext->getVectorPointer(internalVectorIds[i]));
-            scores[i] = func->query_to_code(vector);
+        for ( ; (processedCount + vecBlock) <= numVectors ; processedCount += vecBlock) {
+            srchContext->getVectorPointersInBulk((uint8_t**)vectors, &internalVectorIds[processedCount], vecBlock);
+
+            // Score accumulator per each vector
+            float32x4_t acc0 = vdupq_n_f32(0.0f);
+            float32x4_t acc1 = vdupq_n_f32(0.0f);
+            float32x4_t acc2 = vdupq_n_f32(0.0f);
+            float32x4_t acc3 = vdupq_n_f32(0.0f);
+
+            // Batch L2 for 8 values
+            int32_t i = 0;
+            for (; i + dimensionBatch <= dim; i += dimensionBatch) {
+                // Load 8 FP32 query elements
+                float32x4_t q0 = vld1q_f32(queryPtr + i);
+                float32x4_t q1 = vld1q_f32(queryPtr + i + 4);
+
+                // Load 8 FP16 elements from each target and convert to FP32
+                float16x8_t h0 = vld1q_f16((const __fp16 *)(vectors[0] + i * 2));
+                float16x8_t h1 = vld1q_f16((const __fp16 *)(vectors[1] + i * 2));
+                float16x8_t h2 = vld1q_f16((const __fp16 *)(vectors[2] + i * 2));
+                float16x8_t h3 = vld1q_f16((const __fp16 *)(vectors[3] + i * 2));
+                float32x4_t d0_lo = vcvt_f32_f16(vget_low_f16(h0));
+                float32x4_t d0_hi = vcvt_f32_f16(vget_high_f16(h0));
+                float32x4_t d1_lo = vcvt_f32_f16(vget_low_f16(h1));
+                float32x4_t d1_hi = vcvt_f32_f16(vget_high_f16(h1));
+                float32x4_t d2_lo = vcvt_f32_f16(vget_low_f16(h2));
+                float32x4_t d2_hi = vcvt_f32_f16(vget_high_f16(h2));
+                float32x4_t d3_lo = vcvt_f32_f16(vget_low_f16(h3));
+                float32x4_t d3_hi = vcvt_f32_f16(vget_high_f16(h3));
+
+                if (i + 32 < dim) {
+                    __builtin_prefetch(queryPtr + i + 32);
+                    __builtin_prefetch(vectors[0] + (i + 32) * 2);
+                    __builtin_prefetch(vectors[1] + (i + 32) * 2);
+                    __builtin_prefetch(vectors[2] + (i + 32) * 2);
+                    __builtin_prefetch(vectors[3] + (i + 32) * 2);
+                }
+
+                // L2: diff = q - d, then acc += diff * diff (one FMA per half)
+                float32x4_t diff0_lo = vsubq_f32(q0, d0_lo);
+                float32x4_t diff0_hi = vsubq_f32(q1, d0_hi);
+                acc0 = vfmaq_f32(acc0, diff0_lo, diff0_lo);
+                acc0 = vfmaq_f32(acc0, diff0_hi, diff0_hi);
+
+                float32x4_t diff1_lo = vsubq_f32(q0, d1_lo);
+                float32x4_t diff1_hi = vsubq_f32(q1, d1_hi);
+                acc1 = vfmaq_f32(acc1, diff1_lo, diff1_lo);
+                acc1 = vfmaq_f32(acc1, diff1_hi, diff1_hi);
+
+                float32x4_t diff2_lo = vsubq_f32(q0, d2_lo);
+                float32x4_t diff2_hi = vsubq_f32(q1, d2_hi);
+                acc2 = vfmaq_f32(acc2, diff2_lo, diff2_lo);
+                acc2 = vfmaq_f32(acc2, diff2_hi, diff2_hi);
+
+                float32x4_t diff3_lo = vsubq_f32(q0, d3_lo);
+                float32x4_t diff3_hi = vsubq_f32(q1, d3_hi);
+                acc3 = vfmaq_f32(acc3, diff3_lo, diff3_lo);
+                acc3 = vfmaq_f32(acc3, diff3_hi, diff3_hi);
+            }
+
+            // Horizontal sum
+            scores[processedCount] = vaddvq_f32(acc0);
+            scores[processedCount + 1] = vaddvq_f32(acc1);
+            scores[processedCount + 2] = vaddvq_f32(acc2);
+            scores[processedCount + 3] = vaddvq_f32(acc3);
+
+            // Scalar tail.
+            for (; i < dim; i++) {
+                __fp16 h0 = *((const __fp16 *)(vectors[0] + i * 2));
+                __fp16 h1 = *((const __fp16 *)(vectors[1] + i * 2));
+                __fp16 h2 = *((const __fp16 *)(vectors[2] + i * 2));
+                __fp16 h3 = *((const __fp16 *)(vectors[3] + i * 2));
+                const float qv = queryPtr[i];
+                float d0 = qv - (float)h0; scores[processedCount] += d0 * d0;
+                float d1 = qv - (float)h1; scores[processedCount + 1] += d1 * d1;
+                float d2 = qv - (float)h2; scores[processedCount + 2] += d2 * d2;
+                float d3 = qv - (float)h3; scores[processedCount + 3] += d3 * d3;
+            }
         }
 
-        // Transform score values if it needs to
+        // Tail loop for remaining vectors
+        for (; processedCount < numVectors; ++processedCount) {
+            const auto* vecPtr = (const __fp16*) srchContext->getVectorPointer(internalVectorIds[processedCount]);
+            float32x4_t acc = vdupq_n_f32(0.0f);
+            int32_t i = 0;
+            for (; i <= dim - dimensionBatch; i += dimensionBatch) {
+                float32x4_t q0 = vld1q_f32(queryPtr + i);
+                float32x4_t q1 = vld1q_f32(queryPtr + i + 4);
+                float16x8_t h0 = vld1q_f16((const __fp16 *)(vecPtr + i));
+                float32x4_t d0_lo = vcvt_f32_f16(vget_low_f16(h0));
+                float32x4_t d0_hi = vcvt_f32_f16(vget_high_f16(h0));
+                float32x4_t diff_lo = vsubq_f32(q0, d0_lo);
+                float32x4_t diff_hi = vsubq_f32(q1, d0_hi);
+                acc = vfmaq_f32(acc, diff_lo, diff_lo);
+                acc = vfmaq_f32(acc, diff_hi, diff_hi);
+            }
+
+            float finalSum = vaddvq_f32(acc);
+            // Scalar tail for dimensions not divisible by 8
+            for (; i < dim; ++i) {
+                float d = queryPtr[i] - (float)vecPtr[i];
+                finalSum += d * d;
+            }
+            scores[processedCount] = finalSum;
+        }
+
         BulkScoreTransformFunc(scores, numVectors);
     }
 };


### PR DESCRIPTION
### Description
`ArmNeonFP16L2` had no dedicated NEON kernel unlike `ArmNeonFP16MaxIP,` `AVX512SPRFP16L2`, and `AVX512SPRFP16MaxIP`, it fell back to Faiss's generic `query_to_code()`, called one candidate at a time with no batching, no prefetch, and a virtual dispatch per candidate. This PR adds a batched NEON kernel for `ArmNeonFP16L2,` processing 4 candidate vectors per iteration and 8 dimensions per step.

### Benchmarking
The benchmark configuration uses the `cohere-1m` index with 768-dimensional L2 vectors and FAISS MOS HNSW configured with `m=16` and `ef_construction=256`with an FP16 SQ encoder on `r7g.2xlarge` (Graviton3) instance. The benchmark runs 10,000 queries with `k=100` and `ef_search=256`. There is a ~20% improvement in throughput.

Metric | Before | After
-- | -- | --
Mean throughput (ops/s) | 162.40 | 198.46
Median throughput (ops/s) | 162.54 | 199.21
Min throughput (ops/s) | 159.83 | 192.07
Max throughput (ops/s) | 164.26 | 200.23
p50 latency (ms) | 4.71674 | 3.60650
p90 latency (ms) | 5.23271 | 3.90269
p99 latency (ms) | 5.60241 | 4.15277
p99.9 latency (ms) | 5.91219 | 5.67879
p99.99 latency (ms) | 7.96964 | 8.20476
p100 latency (ms) | 9.19445 | 12.72493
Error rate (%) | 0 | 0
Recall@100 | 0.94 | 0.94
Recall@1 | 0.98 | 0.98

### Related Issues
Resolves #3510 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
