### PR TITLE
Moving remote vector index build image to latest rather than snapshot since snapshot one is failing

### DIFF
--- a/.github/workflows/remote_index_build.yml
+++ b/.github/workflows/remote_index_build.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Pull Remote Index Build Docker Image from Docker Hub
         run: |
-          docker pull opensearchstaging/remote-vector-index-builder:api-snapshot
+          docker pull opensearchstaging/remote-vector-index-builder:api-latest
 
       - name: Pull LocalStack Docker image
         run: |
@@ -101,7 +101,7 @@ jobs:
 
       - name: Run Docker container
         run: |
-          docker run --rm -d --name remote-index-builder-container --gpus all -p 80:1025 -e S3_ENDPOINT_URL=http://172.17.0.1:4566 -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} -e AWS_DEFAULT_REGION=${{env.AWS_DEFAULT_REGION}} -e AWS_SESSION_TOKEN=${{env.AWS_SESSION_TOKEN}} opensearchstaging/remote-vector-index-builder:api-snapshot
+          docker run --rm -d --name remote-index-builder-container --gpus all -p 80:1025 -e S3_ENDPOINT_URL=http://172.17.0.1:4566 -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} -e AWS_DEFAULT_REGION=${{env.AWS_DEFAULT_REGION}} -e AWS_SESSION_TOKEN=${{env.AWS_SESSION_TOKEN}} opensearchstaging/remote-vector-index-builder:api-latest
           sleep 5
 
       - name: Run tests


### PR DESCRIPTION
### Description
Moving remote vector index build image to latest rather than snapshot since snapshot one is failing.

We are working on fixing the remote vector index build snapshot image, in the meantime I am moving the CIs to use latest image which is the latest released image of RVIB


### Related Issues
NA

<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
