### PR TITLE
[FlakyTest] Fix the flaky test in KNNVectorDVLeafFieldDataTests happening due to multiple segments getting created in component test

### DIFF
--- a/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
@@ -56,6 +56,10 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
             doc.add(new NumericDocValuesField(MOCK_NUMERIC_INDEX_FIELD_NAME, 1000 + i));
             writer.addDocument(doc);
         }
+        // Force a single segment so all docs land in one leaf. The Lucene test framework randomizes
+        // IndexWriterConfig flushing, which can otherwise split docs across segments and make tests that
+        // read only leaves().get(0) flaky.
+        writer.forceMerge(1);
         writer.commit();
         writer.close();
     }
@@ -186,6 +190,8 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
                 doc3.add(new KnnFloatVectorField(MOCK_INDEX_FIELD_NAME, vector3, VectorSimilarityFunction.EUCLIDEAN));
                 writer.addDocument(doc3);
 
+                // Single segment so all docs are in leaves().get(0) regardless of the randomized IWC flush behavior.
+                writer.forceMerge(1);
                 writer.commit();
             }
 
@@ -298,6 +304,8 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
                 Document doc2 = new Document();
                 doc2.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, byteVector2, VectorSimilarityFunction.EUCLIDEAN));
                 writer.addDocument(doc2);
+                // Single segment so both docs are in leaves().get(0) regardless of the randomized IWC flush behavior.
+                writer.forceMerge(1);
                 writer.commit();
             }
 
@@ -371,6 +379,8 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
                 Document doc2 = new Document();
                 doc2.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, binaryVector2, VectorSimilarityFunction.EUCLIDEAN));
                 writer.addDocument(doc2);
+                // Single segment so both docs are in leaves().get(0) regardless of the randomized IWC flush behavior.
+                writer.forceMerge(1);
                 writer.commit();
             }
 


### PR DESCRIPTION
### Description
Fix the flaky test in KNNVectorDVLeafFieldDataTests happening due to multiple segments getting created in component test.

Failure: https://github.com/opensearch-project/k-NN/actions/runs/32316930841/job/96271159805?pr=3504

Failing seed passing now
```
./gradlew ':test' --tests 'org.opensearch.knn.index.KNNVectorDVLeafFieldDataTests.testGetLeafValueFetcher_multipleDocuments_iteratesCorrectly' -Dtests.seed=1B412D638C313984
```

### Related Issues
NA

<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
