### PR TITLE
[Backport 2.19] Add Eclipse P2 mirror to avoid download.eclipse.org outages (k-NN)

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -9,7 +9,7 @@ allprojects {
         java {
             target 'src/**/*.java'
             removeUnusedImports()
-	    eclipse().configFile rootProject.file('buildSrc/formatterConfig.xml')
+	    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
 	    trimTrailingWhitespace()
         }
     }


### PR DESCRIPTION
### Description
Manual backport of #3501 to the `2.19` branch. Routes the Spotless Eclipse JDT formatter provisioning through the OpenSearch CI mirror (`https://ci.opensearch.org/`) instead of `download.eclipse.org` to avoid upstream outages/timeouts. Only the Eclipse P2 mirror one-liner is backported; any unrelated changes bundled in the original PR are not included.

### Issues Resolved
Backport of #3501
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
