### PR TITLE
[FP16 PR-2] Add custom codecs for Flat and Lucene HNSW

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
+
+import java.io.IOException;
+
+/**
+ * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
+ * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom {@link KNN1040HalfFloatFlatVectorsWriter}
+ * and {@link KNN1040HalfFloatFlatVectorsReader} for storage and retrieval of half-float vectors.
+ */
+public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
+
+    static final String NAME = "KNN1040HalfFloatFlatVectorsFormat";
+    static final String META_CODEC_NAME = "KNN1040HalfFloatFlatVectorsFormatMeta";
+    static final String VECTOR_DATA_CODEC_NAME = "KNN1040HalfFloatFlatVectorsFormatData";
+    static final String META_EXTENSION = "vemf";
+    static final String VECTOR_DATA_EXTENSION = "vec";
+    static final int VERSION_START = 0;
+    static final int VERSION_CURRENT = VERSION_START;
+    static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+
+    private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new KNN1040HalfFloatVectorScorer(
+        new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorsScorerProvider.getLucene99FlatVectorsScorer()))
+    );
+
+    public KNN1040HalfFloatFlatVectorsFormat() {
+        super(NAME);
+    }
+
+    @Override
+    public FlatVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new KNN1040HalfFloatFlatVectorsWriter(state, KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
+    }
+
+    @Override
+    public FlatVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return new KNN1040HalfFloatFlatVectorsReader(state, KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s(scorer=%s)", getClass().getSimpleName(), KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
@@ -59,6 +60,6 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
 
     @Override
     public String toString() {
-        return String.format("%s(scorer=%s)", getClass().getSimpleName(), KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
+        return String.format(Locale.ROOT, "%s(scorer=%s)", getClass().getSimpleName(), KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.internal.hppc.IntObjectHashMap;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.DataAccessHint;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.FileDataHint;
+import org.apache.lucene.store.FileTypeHint;
+import org.apache.lucene.store.IOContext.FileOpenHint;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_START;
+
+/**
+ * Reader for half-precision (FP16) flat vector fields, reading vectors from {@code .vec} and
+ * per-field metadata from {@code .vemf}.
+ *
+ * With mmap and a native SIMD type, scoring goes through {@code NativeEngines990KnnVectorsScorer}
+ * and {@code NativeRandomVectorScorer}; otherwise {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer}.
+ */
+@Log4j2
+public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(KNN1040HalfFloatFlatVectorsReader.class);
+
+    private static final int BULK_SCORE_BATCH_SIZE = 64;
+    private static final String VECTOR_VALUES_SLICE = "KNN1040HalfFloatFlatVectorsValuesSlice";
+
+    private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
+    private final IndexInput vectorData;
+    private final FieldInfos fieldInfos;
+    private final FlatVectorsScorer scorer;
+    private final IOContext dataContext;
+
+    public KNN1040HalfFloatFlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer) throws IOException {
+        this(state, scorer, DataAccessHint.RANDOM);
+    }
+
+    public KNN1040HalfFloatFlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer, DataAccessHint accessHint)
+        throws IOException {
+        super();
+        this.scorer = scorer;
+        this.fieldInfos = state.fieldInfos;
+        final FileOpenHint[] hints = Stream.of(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint)
+            .filter(Objects::nonNull)
+            .toArray(FileOpenHint[]::new);
+        this.dataContext = state.context.withHints(hints);
+
+        boolean success = false;
+        try {
+            int versionMeta = readMetadata(state);
+            vectorData = openDataInput(state, versionMeta, VECTOR_DATA_EXTENSION, VECTOR_DATA_CODEC_NAME, dataContext);
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    private static IndexInput openDataInput(
+        SegmentReadState state,
+        int versionMeta,
+        String fileExtension,
+        String codecName,
+        IOContext context
+    ) throws IOException {
+        String fileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
+        IndexInput in = state.directory.openInput(fileName, context);
+        boolean success = false;
+        try {
+            int versionVectorData = CodecUtil.checkIndexHeader(
+                in,
+                codecName,
+                VERSION_START,
+                VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            if (versionMeta != versionVectorData) {
+                throw new CorruptIndexException(
+                    "Format versions mismatch: meta=" + versionMeta + ", " + codecName + "=" + versionVectorData,
+                    in
+                );
+            }
+            CodecUtil.retrieveChecksum(in);
+            success = true;
+            return in;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(in);
+            }
+        }
+    }
+
+    private int readMetadata(SegmentReadState state) throws IOException {
+        String metaFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, META_EXTENSION);
+        int versionMeta;
+        try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName)) {
+            Throwable priorE = null;
+            try {
+                versionMeta = CodecUtil.checkIndexHeader(
+                    meta,
+                    META_CODEC_NAME,
+                    VERSION_START,
+                    VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                readFields(meta);
+            } catch (Throwable t) {
+                priorE = t;
+                throw t;
+            } finally {
+                CodecUtil.checkFooter(meta, priorE);
+            }
+        }
+        return versionMeta;
+    }
+
+    private void readFields(ChecksumIndexInput meta) throws IOException {
+        for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
+            FieldInfo info = fieldInfos.fieldInfo(fieldNumber);
+            if (info == null) {
+                throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
+            }
+            fields.put(info.number, FieldEntry.create(meta, info));
+        }
+    }
+
+    // Order must match Lucene94FieldInfosFormat#SIMILARITY_FUNCTIONS; listed explicitly so the
+    // on-disk ordinal does not depend on VectorSimilarityFunction's declaration order.
+    private static final List<VectorSimilarityFunction> SIMILARITY_FUNCTIONS = List.of(
+        VectorSimilarityFunction.EUCLIDEAN,
+        VectorSimilarityFunction.DOT_PRODUCT,
+        VectorSimilarityFunction.COSINE,
+        VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+    );
+
+    private static VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
+        int i = input.readInt();
+        if (i < 0 || i >= SIMILARITY_FUNCTIONS.size()) {
+            throw new IllegalArgumentException("invalid distance function: " + i);
+        }
+        return SIMILARITY_FUNCTIONS.get(i);
+    }
+
+    private static VectorEncoding readVectorEncoding(DataInput input) throws IOException {
+        int encodingId = input.readInt();
+        if (encodingId < 0 || encodingId >= VectorEncoding.values().length) {
+            throw new CorruptIndexException("Invalid vector encoding id: " + encodingId, input);
+        }
+        return VectorEncoding.values()[encodingId];
+    }
+
+    private FieldEntry getFieldEntryOrThrow(String field) {
+        final FieldInfo info = fieldInfos.fieldInfo(field);
+        final FieldEntry entry;
+        if (info == null || (entry = fields.get(info.number)) == null) {
+            throw new IllegalArgumentException("field=\"" + field + "\" not found");
+        }
+        return entry;
+    }
+
+    private FieldEntry getFieldEntry(String field, VectorEncoding expectedEncoding) {
+        final FieldEntry fieldEntry = getFieldEntryOrThrow(field);
+        if (fieldEntry.vectorEncoding != expectedEncoding) {
+            throw new IllegalArgumentException(
+                "field=\"" + field + "\" is encoded as: " + fieldEntry.vectorEncoding + " expected: " + expectedEncoding
+            );
+        }
+        return fieldEntry;
+    }
+
+    /**
+     * Builds a fresh {@link KNN1040HalfFloatFlatVectorsValues} over {@code entry}'s slice of the
+     * {@code .vec} file.
+     */
+    private KNN1040HalfFloatFlatVectorsValues newVectorValues(FieldEntry entry) throws IOException {
+        IndexInput slice = vectorData.slice(VECTOR_VALUES_SLICE, entry.vectorDataOffset, entry.vectorDataLength);
+        DirectMonotonicReader ordToDocReader = entry.ordToDoc.isDense() ? null : entry.ordToDoc.getDirectMonotonicReader(vectorData);
+        return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, scorer, entry.similarity);
+    }
+
+    @Override
+    public FloatVectorValues getFloatVectorValues(String field) throws IOException {
+        final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
+        KNN1040HalfFloatFlatVectorsValues base = newVectorValues(entry);
+        long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(base.getSlice(), 0, base.getSlice().length());
+        return addressAndSize != null ? new MMapFloatVectorValues(base, addressAndSize) : base;
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(String field, float[] target) throws IOException {
+        final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
+        KNN1040HalfFloatFlatVectorsValues base = newVectorValues(entry);
+        // Empty segment: search() relies on a null scorer to mean "nothing to collect".
+        if (base.size() == 0) {
+            return null;
+        }
+        return KNN1040HalfFloatFlatVectorsValues.selectScorer(base, target, entry.similarity);
+    }
+
+    // Exhaustive brute-force search over all FP16 vectors, scoring ords in batches.
+    @Override
+    public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        RandomVectorScorer randomScorer = getRandomVectorScorer(field, target);
+        if (randomScorer == null) {
+            return;
+        }
+
+        int numVectors = randomScorer.maxOrd();
+        if (numVectors == 0 || knnCollector.k() == 0) {
+            return;
+        }
+
+        final Bits acceptedOrds = randomScorer.getAcceptOrds(acceptDocs.bits());
+        int[] ords = new int[BULK_SCORE_BATCH_SIZE];
+        float[] scores = new float[BULK_SCORE_BATCH_SIZE];
+        int numOrds = 0;
+
+        for (int i = 0; i < numVectors; i++) {
+            if (acceptedOrds == null || acceptedOrds.get(i)) {
+                if (knnCollector.earlyTerminated()) {
+                    break;
+                }
+                ords[numOrds++] = i;
+                if (numOrds == BULK_SCORE_BATCH_SIZE) {
+                    collectBatch(randomScorer, knnCollector, ords, scores, numOrds);
+                    numOrds = 0;
+                }
+            }
+        }
+
+        if (numOrds > 0) {
+            collectBatch(randomScorer, knnCollector, ords, scores, numOrds);
+        }
+    }
+
+    private void collectBatch(RandomVectorScorer scorer, KnnCollector knnCollector, int[] ords, float[] scores, int numOrds)
+        throws IOException {
+        knnCollector.incVisitedCount(numOrds);
+        if (scorer.bulkScore(ords, scores, numOrds) > knnCollector.minCompetitiveSimilarity()) {
+            for (int j = 0; j < numOrds; j++) {
+                knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+            }
+        }
+    }
+
+    @Override
+    public ByteVectorValues getByteVectorValues(String field) throws IOException {
+        throw new UnsupportedOperationException("FP16 format does not support byte vectors");
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(String field, byte[] target) throws IOException {
+        throw new UnsupportedOperationException("FP16 format does not support byte vector scoring");
+    }
+
+    @Override
+    public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+        return scorer;
+    }
+
+    @Override
+    public FlatVectorsReader getMergeInstance() throws IOException {
+        vectorData.updateIOContext(dataContext.withHints(DataAccessHint.SEQUENTIAL));
+        return this;
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        CodecUtil.checksumEntireFile(vectorData);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return KNN1040HalfFloatFlatVectorsReader.SHALLOW_SIZE + fields.ramBytesUsed();
+    }
+
+    @Override
+    public Map<String, Long> getOffHeapByteSize(FieldInfo fieldInfo) {
+        final FieldEntry entry = getFieldEntryOrThrow(fieldInfo.name);
+        return Map.of(VECTOR_DATA_EXTENSION, entry.vectorDataLength());
+    }
+
+    @Override
+    public void finishMerge() throws IOException {
+        // Revert the sequential access hint applied by getMergeInstance().
+        vectorData.updateIOContext(dataContext);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(vectorData);
+    }
+
+    private record FieldEntry(VectorSimilarityFunction similarity, VectorEncoding vectorEncoding, long vectorDataOffset,
+        long vectorDataLength, int dimension, int size, OrdToDocDISIReaderConfiguration ordToDoc, FieldInfo info) {
+
+        FieldEntry {
+            if (similarity != info.getVectorSimilarityFunction()) {
+                throw new IllegalStateException(
+                    "Inconsistent vector similarity function for field=\""
+                        + info.name
+                        + "\"; "
+                        + similarity
+                        + " != "
+                        + info.getVectorSimilarityFunction()
+                );
+            }
+            int infoVectorDimension = info.getVectorDimension();
+            if (infoVectorDimension != dimension) {
+                throw new IllegalStateException(
+                    "Inconsistent vector dimension for field=\"" + info.name + "\"; " + infoVectorDimension + " != " + dimension
+                );
+            }
+
+            // FP16: 2 bytes per dimension, where Lucene's flat format uses encoding.byteSize.
+            final int byteSize = Short.BYTES;
+            long vectorBytes = Math.multiplyExact((long) infoVectorDimension, byteSize);
+            long numBytes = Math.multiplyExact(vectorBytes, size);
+            if (numBytes != vectorDataLength) {
+                throw new IllegalStateException(
+                    "Vector data length "
+                        + vectorDataLength
+                        + " not matching size="
+                        + size
+                        + " * dim="
+                        + dimension
+                        + " * byteSize="
+                        + byteSize
+                        + " = "
+                        + numBytes
+                );
+            }
+        }
+
+        static FieldEntry create(IndexInput input, FieldInfo info) throws IOException {
+            final VectorEncoding vectorEncoding = readVectorEncoding(input);
+            final VectorSimilarityFunction similarityFunction = readSimilarityFunction(input);
+            final var vectorDataOffset = input.readVLong();
+            final var vectorDataLength = input.readVLong();
+            final var dimension = input.readVInt();
+            final var size = input.readInt();
+            final var ordToDoc = OrdToDocDISIReaderConfiguration.fromStoredMeta(input, size);
+            return new FieldEntry(similarityFunction, vectorEncoding, vectorDataOffset, vectorDataLength, dimension, size, ordToDoc, info);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -339,6 +339,11 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         long vectorDataLength, int dimension, int size, OrdToDocDISIReaderConfiguration ordToDoc, FieldInfo info) {
 
         FieldEntry {
+            if (vectorEncoding != VectorEncoding.FLOAT32) {
+                throw new IllegalStateException(
+                    "Unexpected vector encoding for field=\"" + info.name + "\"; expected FLOAT32, got " + vectorEncoding
+                );
+            }
             if (similarity != info.getVectorSimilarityFunction()) {
                 throw new IllegalStateException(
                     "Inconsistent vector similarity function for field=\""

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -260,10 +260,10 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         int numOrds = 0;
 
         for (int i = 0; i < numVectors; i++) {
+            if (knnCollector.earlyTerminated()) {
+                break;
+            }
             if (acceptedOrds == null || acceptedOrds.get(i)) {
-                if (knnCollector.earlyTerminated()) {
-                    break;
-                }
                 ords[numOrds++] = i;
                 if (numOrds == BULK_SCORE_BATCH_SIZE) {
                     collectBatch(randomScorer, knnCollector, ords, scores, numOrds);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import java.io.IOException;
+
+/**
+ * Decodes FP16 (2 bytes/dimension) vector bytes to {@code float[]} on access.
+ *
+ * Implements {@link HasIndexSlice} so that {@link org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues}
+ * can expose the underlying slice for I/O prefetching. Callers must not hand an instance of this
+ * class directly to Lucene's own flat vector scorer factory ({@code Lucene99FlatVectorsScorer}):
+ * that factory independently detects {@code HasIndexSlice} and reads the raw slice assuming
+ * 4 bytes/dimension (float32), which silently overreads past the buffer on this FP16 (2 bytes/dimension)
+ * data. Use {@link #selectFallbackScorer(KNN1040HalfFloatFlatVectorsValues, float[], VectorSimilarityFunction)}
+ * instead whenever mmap addresses are unavailable, or the similarity function has no native SIMD type.
+ */
+class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements HasIndexSlice {
+    private final int dimension;
+    private final int size;
+    private final IndexInput slice;
+    private final int byteSize;
+    private final float[] value;
+    private final byte[] rawBytes;
+    private final DirectMonotonicReader ordToDocReader;
+    private final FlatVectorsScorer flatVectorsScorer;
+    private final VectorSimilarityFunction similarity;
+    private int lastOrd = -1;
+
+    KNN1040HalfFloatFlatVectorsValues(
+        int dimension,
+        int size,
+        IndexInput slice,
+        DirectMonotonicReader ordToDocReader,
+        FlatVectorsScorer flatVectorsScorer,
+        VectorSimilarityFunction similarity
+    ) {
+        this.dimension = dimension;
+        this.size = size;
+        this.slice = slice;
+        this.byteSize = dimension * Short.BYTES;
+        this.value = new float[dimension];
+        this.rawBytes = new byte[byteSize];
+        this.ordToDocReader = ordToDocReader;
+        this.flatVectorsScorer = flatVectorsScorer;
+        this.similarity = similarity;
+    }
+
+    @Override
+    public IndexInput getSlice() {
+        return slice;
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public int getVectorByteLength() {
+        return byteSize;
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+        return ordToDocReader == null ? createDenseIterator() : createSparseIterator();
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+        return ordToDocReader == null ? ord : (int) ordToDocReader.get(ord);
+    }
+
+    @Override
+    public float[] vectorValue(int ord) throws IOException {
+        if (ord == lastOrd) {
+            return value;
+        }
+        lastOrd = ord;
+        readRawVectorBytes(ord, rawBytes, 0);
+        KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.byteToFloatArray(rawBytes, value, dimension, 0);
+        return value;
+    }
+
+    /**
+     * Reads the raw FP16 bytes for {@code ord} into {@code dest}, starting at
+     * {@code destOffset}. Used by {@link KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer} to feed native SIMD
+     * scoring without a Java-side FP16-to-FP32 decode.
+     */
+    void readRawVectorBytes(int ord, byte[] dest, int destOffset) throws IOException {
+        slice.seek((long) ord * byteSize);
+        slice.readBytes(dest, destOffset, byteSize);
+    }
+
+    int byteSize() {
+        return byteSize;
+    }
+
+    @Override
+    public VectorScorer scorer(float[] target) throws IOException {
+        if (size() == 0) {
+            return null;
+        }
+        KNN1040HalfFloatFlatVectorsValues copy = copy();
+        DocIndexIterator iterator = copy.iterator();
+        RandomVectorScorer scorer = selectScorer(copy, target, similarity);
+        return new VectorScorer() {
+            @Override
+            public float score() throws IOException {
+                return scorer.score(iterator.index());
+            }
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return iterator;
+            }
+
+            @Override
+            public Bulk bulk(DocIdSetIterator matchingDocs) {
+                return Bulk.fromRandomScorerSparse(scorer, iterator, matchingDocs);
+            }
+        };
+    }
+
+    @Override
+    public KNN1040HalfFloatFlatVectorsValues copy() throws IOException {
+        return new KNN1040HalfFloatFlatVectorsValues(dimension, size, slice.clone(), ordToDocReader, flatVectorsScorer, similarity);
+    }
+
+    /**
+     * Selects the fastest available scorer for {@code values}: mmap-backed native SIMD
+     * when address extraction succeeds and the similarity has a native type, otherwise
+     * {@link #selectFallbackScorer}. Shared by both the reader's {@code getRandomVectorScorer} and
+     * this class's {@link #scorer(float[])}.
+     */
+    static RandomVectorScorer selectScorer(KNN1040HalfFloatFlatVectorsValues values, float[] target, VectorSimilarityFunction similarity)
+        throws IOException {
+        long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(
+            values.getSlice(),
+            0,
+            values.getSlice().length()
+        );
+        SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
+        if (addressAndSize != null && nativeType != null) {
+            // Safe only with both mmap and a native type: the chain then builds
+            // NativeRandomVectorScorer directly and never reaches Lucene's delegate.
+            MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(values, addressAndSize);
+            return values.flatVectorsScorer.getRandomVectorScorer(similarity, mmapValues, target);
+        }
+        // Never hand `values` to the shared chain: Lucene's delegate would read its HasIndexSlice
+        // slice as float32 and overrun this FP16 data.
+        return selectFallbackScorer(values, target, similarity);
+    }
+
+    /**
+     * Builds a {@link RandomVectorScorer} that never exposes {@code values} to Lucene's own flat
+     * vector scorer factory. Used whenever mmap address extraction fails, or the similarity
+     * function has no native SIMD type. Wrapped in {@link PrefetchableRandomVectorScorer} - same as
+     * {@link #selectScorer}'s mmap tier gets via {@code KNN1040HalfFloatVectorScorer#getRandomVectorScorer} -
+     * so this tier still prefetches ahead of bulk scoring during graph traversal.
+     */
+    static RandomVectorScorer selectFallbackScorer(
+        KNN1040HalfFloatFlatVectorsValues values,
+        float[] target,
+        VectorSimilarityFunction similarity
+    ) {
+        SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
+        RandomVectorScorer.AbstractRandomVectorScorer scorer;
+        if (nativeType != null && SimdFp16.isSIMDSupported()) {
+            scorer = new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(values, target, nativeType, null);
+        } else {
+            scorer = new RandomVectorScorer.AbstractRandomVectorScorer(values) {
+                @Override
+                public float score(int node) throws IOException {
+                    return similarity.compare(target, values.vectorValue(node));
+                }
+            };
+        }
+        return new PrefetchableRandomVectorScorer(scorer);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import org.apache.lucene.util.ArrayUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT;
+
+/**
+ * Writer for half-precision (FP16) flat vector fields. Encodes incoming FP32 vectors to FP16
+ * (2 bytes per dimension) and writes them sequentially to a {@code .vec} file, with per-field
+ * metadata stored in a {@code .vemf} file.
+ *
+ * The on-disk layout follows the same structural pattern as Lucene's {@code Lucene99FlatVectorsWriter}:
+ * Each float dimension is converted to IEEE 754 half-float and stored as 2 bytes in little-endian order.
+ */
+public class KNN1040HalfFloatFlatVectorsWriter extends FlatVectorsWriter {
+
+    private static final long SHALLOW_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(KNN1040HalfFloatFlatVectorsWriter.class);
+
+    private static final int VECTOR_DATA_ALIGNMENT = 64;
+
+    private final SegmentWriteState segmentWriteState;
+    private final IndexOutput meta;
+    private final IndexOutput vectorData;
+    private final List<FieldData> fields = new ArrayList<>();
+    private boolean finished;
+
+    private record FieldData(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo) {
+    }
+
+    /**
+     * Creates a new writer for FP16 flat vectors.
+     *
+     * @param state  the segment write state
+     * @param scorer the flat vectors scorer used for scoring during indexing
+     * @throws IOException if an I/O error occurs while creating output files
+     */
+    public KNN1040HalfFloatFlatVectorsWriter(SegmentWriteState state, FlatVectorsScorer scorer) throws IOException {
+        super(scorer);
+        this.segmentWriteState = state;
+
+        boolean success = false;
+        try {
+            String metaFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, META_EXTENSION);
+            String vectorDataFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, VECTOR_DATA_EXTENSION);
+
+            meta = state.directory.createOutput(metaFileName, state.context);
+            vectorData = state.directory.createOutput(vectorDataFileName, state.context);
+
+            CodecUtil.writeIndexHeader(meta, META_CODEC_NAME, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+            CodecUtil.writeIndexHeader(vectorData, VECTOR_DATA_CODEC_NAME, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    @Override
+    public FlatFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
+        checkFloat32Encoding(fieldInfo);
+        // NOTE: FlatFieldVectorsWriter has no public static create() method.
+        FlatFieldVectorsWriter<?> fieldWriter = new FloatFieldWriter(fieldInfo);
+        fields.add(new FieldData(fieldWriter, fieldInfo));
+        return fieldWriter;
+    }
+
+    private static void checkFloat32Encoding(FieldInfo fieldInfo) {
+        if (fieldInfo.getVectorEncoding() != VectorEncoding.FLOAT32) {
+            throw new IllegalArgumentException(
+                "FP16 flat format only supports FLOAT32 encoding, got ["
+                    + fieldInfo.getVectorEncoding()
+                    + "] for field ["
+                    + fieldInfo.name
+                    + "]"
+            );
+        }
+    }
+
+    /**
+     * Returns the aligned offset for a field's vector data, mirroring {@code
+     * Lucene99FlatVectorsWriter.alignOutput}. Needed because {@link #writeMeta} also writes
+     * ord-to-doc data into {@code .vec}, so a later field would otherwise start unaligned.
+     */
+    private static long alignOutput(IndexOutput output) throws IOException {
+        return output.alignFilePointer(VECTOR_DATA_ALIGNMENT);
+    }
+
+    @Override
+    public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+        for (FieldData field : fields) {
+            if (sortMap == null) {
+                writeField(field.fieldWriter(), field.fieldInfo(), maxDoc);
+            } else {
+                writeSortingField(field.fieldWriter(), field.fieldInfo(), maxDoc, sortMap);
+            }
+            field.fieldWriter().finish();
+        }
+    }
+
+    @Override
+    public void finish() throws IOException {
+        if (finished) {
+            throw new IllegalStateException("already finished");
+        }
+        finished = true;
+        if (meta != null) {
+            meta.writeInt(-1);
+            CodecUtil.writeFooter(meta);
+        }
+        if (vectorData != null) {
+            CodecUtil.writeFooter(vectorData);
+        }
+    }
+
+    @Override
+    public void mergeOneFlatVectorField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+        checkFloat32Encoding(fieldInfo);
+
+        // Delegates to MergedVectorValues so vectors come out in final merged-segment doc order,
+        // with deletions filtered and index sorting applied. A naive per-reader loop can't
+        // reproduce this order: under an index sort, each reader's docs are remapped to
+        // non-contiguous ids interleaved with other readers' docs in the merged segment, not laid
+        // out reader-by-reader.
+        final FloatVectorValues mergedValues = KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
+
+        final long vectorDataOffset = alignOutput(vectorData);
+        final DocsWithFieldSet docsWithField = writeVectorData(vectorData, mergedValues, fieldInfo.getVectorDimension());
+        final long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        writeMeta(fieldInfo, segmentWriteState.segmentInfo.maxDoc(), vectorDataOffset, vectorDataLength, docsWithField);
+    }
+
+    // Encodes vectors to FP16 and writes them, returning the documents that have a vector.
+    private static DocsWithFieldSet writeVectorData(IndexOutput output, FloatVectorValues values, int dimension) throws IOException {
+        final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        final DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+        final KnnVectorValues.DocIndexIterator iterator = values.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+            final float[] vector = values.vectorValue(iterator.index());
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vector, outputBuffer, dimension);
+            output.writeBytes(outputBuffer, 0, outputBuffer.length);
+            docsWithField.add(doc);
+        }
+        return docsWithField;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long total = SHALLOW_RAM_BYTES_USED;
+        for (FieldData field : fields) {
+            total += field.fieldWriter().ramBytesUsed();
+        }
+        return total;
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(meta, vectorData);
+    }
+
+    private void writeField(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo, int maxDoc) throws IOException {
+        final int dimension = fieldInfo.getVectorDimension();
+        final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        @SuppressWarnings("unchecked")
+        final List<float[]> vectors = (List<float[]>) fieldWriter.getVectors();
+
+        final long vectorDataOffset = alignOutput(vectorData);
+        for (float[] vector : vectors) {
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vector, outputBuffer, dimension);
+            vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
+        }
+        final long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        writeMeta(fieldInfo, maxDoc, vectorDataOffset, vectorDataLength, fieldWriter.getDocsWithFieldSet());
+    }
+
+    private void writeSortingField(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo, int maxDoc, Sorter.DocMap sortMap)
+        throws IOException {
+        final int dimension = fieldInfo.getVectorDimension();
+        final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        @SuppressWarnings("unchecked")
+        final List<float[]> vectors = (List<float[]>) fieldWriter.getVectors();
+
+        final DocsWithFieldSet docsWithFieldSet = fieldWriter.getDocsWithFieldSet();
+        final int[] ordMap = new int[docsWithFieldSet.cardinality()]; // new ord to old ord
+        final DocsWithFieldSet newDocsWithField = new DocsWithFieldSet();
+        mapOldOrdToNewOrd(docsWithFieldSet, sortMap, null, ordMap, newDocsWithField);
+
+        final long vectorDataOffset = alignOutput(vectorData);
+        for (int ordinal : ordMap) {
+            final float[] vector = vectors.get(ordinal);
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vector, outputBuffer, dimension);
+            vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
+        }
+        final long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        writeMeta(fieldInfo, maxDoc, vectorDataOffset, vectorDataLength, newDocsWithField);
+    }
+
+    private void writeMeta(FieldInfo fieldInfo, int maxDoc, long vectorDataOffset, long vectorDataLength, DocsWithFieldSet docsWithField)
+        throws IOException {
+        meta.writeInt(fieldInfo.number);
+        meta.writeInt(fieldInfo.getVectorEncoding().ordinal());
+        meta.writeInt(fieldInfo.getVectorSimilarityFunction().ordinal());
+        meta.writeVLong(vectorDataOffset);
+        meta.writeVLong(vectorDataLength);
+        meta.writeVInt(fieldInfo.getVectorDimension());
+
+        // write docIDs
+        final int count = docsWithField.cardinality();
+        meta.writeInt(count);
+        OrdToDocDISIReaderConfiguration.writeStoredMeta(DIRECT_MONOTONIC_BLOCK_SHIFT, meta, vectorData, count, maxDoc, docsWithField);
+    }
+
+    /**
+     * Per-field writer that stores {@code float[]} on heap during indexing.
+     */
+    private static class FloatFieldWriter extends FlatFieldVectorsWriter<float[]> {
+        private static final long FIELD_WRITER_SHALLOW_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FloatFieldWriter.class);
+
+        private final FieldInfo fieldInfo;
+        private final List<float[]> vectors = new ArrayList<>();
+        private final DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+        private boolean finished;
+        private int lastDocID = -1;
+
+        FloatFieldWriter(FieldInfo fieldInfo) {
+            this.fieldInfo = fieldInfo;
+        }
+
+        @Override
+        public void addValue(int docID, float[] vectorValue) throws IOException {
+            if (finished) {
+                throw new IllegalStateException("already finished");
+            }
+            if (docID == lastDocID) {
+                throw new IllegalArgumentException("VectorValuesField \"" + fieldInfo.name + "\" appears more than once in this document");
+            }
+            docsWithField.add(docID);
+            vectors.add(copyValue(vectorValue));
+            lastDocID = docID;
+        }
+
+        @Override
+        public float[] copyValue(float[] value) {
+            return ArrayUtil.copyOfSubArray(value, 0, fieldInfo.getVectorDimension());
+        }
+
+        @Override
+        public List<float[]> getVectors() {
+            return vectors;
+        }
+
+        @Override
+        public DocsWithFieldSet getDocsWithFieldSet() {
+            return docsWithField;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            long size = FIELD_WRITER_SHALLOW_RAM_BYTES_USED;
+            if (vectors.isEmpty()) return size;
+            return size + docsWithField.ramBytesUsed() + (long) vectors.size() * (RamUsageEstimator.NUM_BYTES_OBJECT_REF
+                + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER) + (long) vectors.size() * fieldInfo.getVectorDimension() * fieldInfo
+                    .getVectorEncoding().byteSize;
+        }
+
+        @Override
+        public void finish() throws IOException {
+            finished = true;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return finished;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -150,11 +150,17 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
 
                 @Override
                 public float score(int node) throws IOException {
+                    if (prefetchableDelegate == null) {
+                        throw new IllegalStateException("setScoringOrdinal must be called before score");
+                    }
                     return prefetchableDelegate.score(node);
                 }
 
                 @Override
                 public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                    if (prefetchableDelegate == null) {
+                        throw new IllegalStateException("setScoringOrdinal must be called before bulkScore");
+                    }
                     return prefetchableDelegate.bulkScore(nodes, scores, numNodes);
                 }
             };

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -186,6 +186,9 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
      * build - unlike search's fixed-for-the-scorer's-lifetime query.
      */
     static class HalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+        // Matches KNN1040HalfFloatFlatVectorsReader's bulk batch size, so the non-mmap buffer is
+        // pre-sized for a typical bulkScore() call instead of reallocating on the first one.
+        private static final int BULK_SCORE_BATCH_SIZE = 64;
         private final KNN1040HalfFloatFlatVectorsValues values;
         private final SimdVectorComputeService.SimilarityFunctionType nativeFunctionType;
         private final long[] addressAndSize;
@@ -206,7 +209,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
             this.nativeFunctionType = nativeFunctionType;
             this.addressAndSize = addressAndSize;
             if (!usesMmapAddress()) {
-                this.vectorBytesBuffer = new byte[values.byteSize()];
+                this.vectorBytesBuffer = new byte[values.byteSize() * BULK_SCORE_BATCH_SIZE];
             }
             setTarget(target);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
+
+import java.io.IOException;
+
+/**
+ * Wraps a {@link FlatVectorsScorer} to give HNSW graph construction (flush's incremental build and
+ * merge's graph rebuild) a decode-free scorer supplier for FP16 values, matching the decode-free path
+ * search already gets via {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer}. Without
+ * this, {@code getRandomVectorScorerSupplier} has no SIMD-aware path and decodes on every graph-edge
+ * comparison instead of once per vector.
+ *
+ * <p>Delegates everything else unchanged, so it's safe to wrap any existing scorer chain - this class
+ * only touches the one method, and only activates for our own {@link KNN1040HalfFloatFlatVectorsValues}.
+ */
+public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
+    private final FlatVectorsScorer delegate;
+
+    public KNN1040HalfFloatVectorScorer(FlatVectorsScorer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues
+    ) throws IOException {
+        FloatVectorValues bottomValues = WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues);
+        // MMapFloatVectorValues doesn't extend WrappedFloatVectorValues, so the unwrap above stops at
+        // it rather than reaching the FP16 values it wraps - unwrap that one extra layer here. Keep its
+        // address around: when present, candidate scoring can read straight from mapped memory instead
+        // of copying each candidate's bytes out of the IndexInput slice first.
+        long[] addressAndSize = null;
+        if (bottomValues instanceof MMapFloatVectorValues mmapValues) {
+            addressAndSize = mmapValues.getAddressAndSize();
+            bottomValues = mmapValues.getDelegate();
+        }
+        if (bottomValues instanceof KNN1040HalfFloatFlatVectorsValues halfFloatValues) {
+            final SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(
+                similarityFunction
+            );
+            if (nativeType != null && SimdFp16.isSIMDSupported()) {
+                return new HalfFloatRandomVectorScorerSupplier(halfFloatValues, nativeType, addressAndSize);
+            }
+            // No native FP16 kernel for this similarity function (e.g. COSINE - see
+            // NativeEngines990KnnVectorsScorer#getNativeFunctionType), or SIMD isn't available. Must
+            // still never hand `halfFloatValues` to `delegate` below: that's Lucene's *optimized*
+            // scorer chain, which detects HasIndexSlice and reads the raw slice assuming 4
+            // bytes/dimension (float32), corrupting/crashing on this FP16 (2 bytes/dimension) data -
+            // the same danger `KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer` already avoids
+            // for search. DefaultFlatVectorScorer is Lucene's plain, non-accelerated scorer: it only
+            // ever calls FloatVectorValues#vectorValue(ord) - our own correct FP16 decode - and never
+            // does any HasIndexSlice/memory-segment detection, so it's safe here even though the
+            // values also implement HasIndexSlice for the (separate, guarded) mmap-native path above.
+            return DefaultFlatVectorScorer.INSTANCE.getRandomVectorScorerSupplier(similarityFunction, halfFloatValues);
+        }
+        return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        float[] target
+    ) throws IOException {
+        return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        byte[] target
+    ) throws IOException {
+        return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+    }
+
+    @Override
+    public String toString() {
+        return "KNN1040HalfFloatVectorScorer(delegate=" + delegate + ")";
+    }
+
+    /**
+     * Builds {@link UpdateableRandomVectorScorer}s for HNSW graph construction that read raw FP16
+     * bytes directly for candidate comparisons via {@link HalfFloatRandomVectorScorer} - the
+     * same decode-free path search already uses. The "current" graph node set via
+     * {@link UpdateableRandomVectorScorer#setScoringOrdinal} is decoded once (via
+     * {@link KNN1040HalfFloatFlatVectorsValues#vectorValue}) to build the native search context;
+     * every subsequent candidate comparison against it stays fully byte-based - one decode per graph
+     * node instead of one per graph edge, versus the generic Lucene fallback this replaces.
+     */
+    private static final class HalfFloatRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
+        private final KNN1040HalfFloatFlatVectorsValues values;
+        private final KNN1040HalfFloatFlatVectorsValues targetValues;
+        private final SimdVectorComputeService.SimilarityFunctionType nativeType;
+        private final long[] addressAndSize;
+
+        HalfFloatRandomVectorScorerSupplier(
+            KNN1040HalfFloatFlatVectorsValues values,
+            SimdVectorComputeService.SimilarityFunctionType nativeType,
+            long[] addressAndSize
+        ) throws IOException {
+            this.values = values;
+            this.targetValues = values.copy();
+            this.nativeType = nativeType;
+            this.addressAndSize = addressAndSize;
+        }
+
+        @Override
+        public UpdateableRandomVectorScorer scorer() {
+            return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
+                private HalfFloatRandomVectorScorer delegate;
+                // Wraps `delegate` once it exists, prefetching candidate bytes ahead of each bulkScore
+                // call - same PrefetchableRandomVectorScorer used for search's mmap tier and the flat
+                // fallback tier. Built once alongside `delegate` and reused across setScoringOrdinal
+                // calls, same as the buffer/native-context reuse below.
+                private PrefetchableRandomVectorScorer prefetchableDelegate;
+
+                @Override
+                public void setScoringOrdinal(int node) throws IOException {
+                    float[] target = targetValues.vectorValue(node);
+                    if (delegate == null) {
+                        delegate = new HalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
+                        prefetchableDelegate = new PrefetchableRandomVectorScorer(delegate);
+                    } else {
+                        // Reuse the existing scorer/buffer instead of allocating a fresh one for every
+                        // graph node - only the native search context needs to change.
+                        delegate.setTarget(target);
+                    }
+                }
+
+                @Override
+                public float score(int node) throws IOException {
+                    return prefetchableDelegate.score(node);
+                }
+
+                @Override
+                public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                    return prefetchableDelegate.bulkScore(nodes, scores, numNodes);
+                }
+            };
+        }
+
+        @Override
+        public RandomVectorScorerSupplier copy() throws IOException {
+            return new HalfFloatRandomVectorScorerSupplier(values.copy(), nativeType, addressAndSize);
+        }
+    }
+
+    /**
+     * Scores FP16 vectors via native SIMD. When {@code addressAndSize} is available (the segment
+     * being read from is mmap-backed), candidates are scored directly off mapped memory by ordinal -
+     * the same zero-copy mechanism {@link org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer}
+     * uses for search - via {@link SimdVectorComputeService#scoreSimilarity}/{@code scoreSimilarityInBulk}.
+     * Otherwise candidates are read one at a time from the segment's {@link org.apache.lucene.store.IndexInput}
+     * slice into a heap buffer before scoring via {@link SimdVectorComputeService#scoreSimilarityInBulkFromFp16Bytes}.
+     *
+     * The search context (query buffer + similarity function, plus the mmap address when present) is
+     * saved once per target in {@link #setTarget}, since the "current" graph node being scored against
+     * changes on every {@link UpdateableRandomVectorScorer#setScoringOrdinal} call during HNSW graph
+     * build - unlike search's fixed-for-the-scorer's-lifetime query.
+     */
+    static class HalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+        private final KNN1040HalfFloatFlatVectorsValues values;
+        private final SimdVectorComputeService.SimilarityFunctionType nativeFunctionType;
+        private final long[] addressAndSize;
+        private byte[] vectorBytesBuffer;
+        private final float[] singleScoreBuffer = new float[1];
+        private final int[] singleVectorId = new int[] { 0 };
+        // Positional ids of the vectors packed into vectorBytesBuffer - only used without an mmap address
+        private int[] identityIds = new int[0];
+
+        HalfFloatRandomVectorScorer(
+            KNN1040HalfFloatFlatVectorsValues values,
+            float[] target,
+            SimdVectorComputeService.SimilarityFunctionType nativeFunctionType,
+            long[] addressAndSize
+        ) {
+            super(values);
+            this.values = values;
+            this.nativeFunctionType = nativeFunctionType;
+            this.addressAndSize = addressAndSize;
+            if (!usesMmapAddress()) {
+                this.vectorBytesBuffer = new byte[values.byteSize()];
+            }
+            setTarget(target);
+        }
+
+        private boolean usesMmapAddress() {
+            return addressAndSize != null && addressAndSize.length > 0;
+        }
+
+        // Repoints the native search context at a new target vector, reusing this scorer's buffers -
+        // lets callers that score against many targets in sequence (e.g. HNSW graph build) avoid
+        // allocating a fresh scorer per target.
+        void setTarget(float[] target) {
+            SimdVectorComputeService.saveSearchContext(
+                target,
+                usesMmapAddress() ? addressAndSize : new long[0],
+                nativeFunctionType.ordinal()
+            );
+        }
+
+        @Override
+        public float score(int node) throws IOException {
+            if (usesMmapAddress()) {
+                return SimdVectorComputeService.scoreSimilarity(node);
+            }
+            values.readRawVectorBytes(node, vectorBytesBuffer, 0);
+            SimdVectorComputeService.scoreSimilarityInBulkFromFp16Bytes(vectorBytesBuffer, 1, singleVectorId, singleScoreBuffer);
+            return singleScoreBuffer[0];
+        }
+
+        @Override
+        public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+            if (usesMmapAddress()) {
+                return SimdVectorComputeService.scoreSimilarityInBulk(nodes, scores, numNodes);
+            }
+            int byteSize = values.byteSize();
+            int requiredBytes = numNodes * byteSize;
+            if (vectorBytesBuffer.length < requiredBytes) {
+                vectorBytesBuffer = new byte[requiredBytes];
+            }
+            for (int i = 0; i < numNodes; i++) {
+                values.readRawVectorBytes(nodes[i], vectorBytesBuffer, i * byteSize);
+            }
+            growIdentityIds(numNodes);
+            return SimdVectorComputeService.scoreSimilarityInBulkFromFp16Bytes(vectorBytesBuffer, numNodes, identityIds, scores);
+        }
+
+        private void growIdentityIds(int numNodes) {
+            int previousLength = identityIds.length;
+            if (previousLength >= numNodes) {
+                return;
+            }
+            identityIds = new int[numNodes];
+            for (int i = 0; i < numNodes; i++) {
+                identityIds[i] = i;
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatVectorsFormat.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.search.TaskExecutor;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_NUM_MERGE_WORKER;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_GRAPH_THRESHOLD;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.MAXIMUM_BEAM_WIDTH;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.MAXIMUM_MAX_CONN;
+
+/**
+ * HNSW format for half-float vectors. Mostly identical to {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat},
+ * but uses {@link KNN1040HalfFloatFlatVectorsFormat} as the flat vector delegate so the graph's backing
+ * storage is half-float instead of float, inheriting its SIMD-accelerated scorer for graph traversal.
+ */
+public class KNN1040HnswHalfFloatVectorsFormat extends KnnVectorsFormat {
+
+    private final int maxConn;
+    private final int beamWidth;
+    private final int tinySegmentsThreshold;
+    private final int numMergeWorkers;
+    private final TaskExecutor mergeExec;
+    private static final FlatVectorsFormat flatVectorsFormat = new KNN1040HalfFloatFlatVectorsFormat();
+
+    private static final String NAME = "KNN1040HnswHalfFloatVectorsFormat";
+
+    public KNN1040HnswHalfFloatVectorsFormat() {
+        this(DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null, HNSW_GRAPH_THRESHOLD);
+    }
+
+    public KNN1040HnswHalfFloatVectorsFormat(int maxConn, int beamWidth, int numMergeWorkers, ExecutorService mergeExec) {
+        this(maxConn, beamWidth, numMergeWorkers, mergeExec, HNSW_GRAPH_THRESHOLD);
+    }
+
+    public KNN1040HnswHalfFloatVectorsFormat(
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec,
+        int tinySegmentsThreshold
+    ) {
+        super(NAME);
+        if (maxConn <= 0 || maxConn > MAXIMUM_MAX_CONN) {
+            throw new IllegalArgumentException(
+                "maxConn must be positive and less than or equal to " + MAXIMUM_MAX_CONN + "; maxConn=" + maxConn
+            );
+        }
+        if (beamWidth <= 0 || beamWidth > MAXIMUM_BEAM_WIDTH) {
+            throw new IllegalArgumentException(
+                "beamWidth must be positive and less than or equal to " + MAXIMUM_BEAM_WIDTH + "; beamWidth=" + beamWidth
+            );
+        }
+        if (numMergeWorkers == 1 && mergeExec != null) {
+            throw new IllegalArgumentException("No executor service is needed as we'll use single thread to merge");
+        }
+        this.maxConn = maxConn;
+        this.beamWidth = beamWidth;
+        this.tinySegmentsThreshold = tinySegmentsThreshold;
+        this.numMergeWorkers = numMergeWorkers;
+        this.mergeExec = mergeExec != null ? new TaskExecutor(mergeExec) : null;
+    }
+
+    @Override
+    public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new Lucene99HnswVectorsWriter(
+            state,
+            maxConn,
+            beamWidth,
+            flatVectorsFormat,
+            flatVectorsFormat.fieldsWriter(state),
+            numMergeWorkers,
+            mergeExec,
+            tinySegmentsThreshold
+        );
+    }
+
+    @Override
+    public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return new Lucene99HnswVectorsReader(state, flatVectorsFormat.fieldsReader(state));
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            Locale.ROOT,
+            "%s(maxConn=%d, beamWidth=%d, tinySegmentsThreshold=%d, flatVectorFormat=%s)",
+            getClass().getSimpleName(),
+            maxConn,
+            beamWidth,
+            tinySegmentsThreshold,
+            flatVectorsFormat
+        );
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
@@ -64,9 +64,7 @@ public class NativeEngines990KnnVectorsScorer implements FlatVectorsScorer {
         return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
     }
 
-    private static SimdVectorComputeService.SimilarityFunctionType getNativeFunctionType(
-        final VectorSimilarityFunction similarityFunction
-    ) {
+    public static SimdVectorComputeService.SimilarityFunctionType getNativeFunctionType(final VectorSimilarityFunction similarityFunction) {
         return switch (similarityFunction) {
             case MAXIMUM_INNER_PRODUCT -> SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT;
             case EUCLIDEAN -> SimdVectorComputeService.SimilarityFunctionType.FP16_L2;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import lombok.Getter;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.IndexInput;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ public class MMapFloatVectorValues extends FloatVectorValues implements MMapVect
     // addressAndSize[3] has the size of the second mapped region.
     @Getter
     private final long[] addressAndSize;
+    @Getter
     private final FloatVectorValues delegate;
 
     public MMapFloatVectorValues(final FloatVectorValues delegate, final long[] addressAndSize) {
@@ -68,6 +70,21 @@ public class MMapFloatVectorValues extends FloatVectorValues implements MMapVect
     @Override
     public int getVectorByteLength() {
         return delegate.getVectorByteLength();
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+        return delegate.ordToDoc(ord);
+    }
+
+    @Override
+    public VectorScorer scorer(float[] target) throws IOException {
+        return delegate.scorer(target);
     }
 
     @Override

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -14,3 +14,5 @@ org.opensearch.knn.index.codec.KNN1040Codec.Faiss1040ScalarQuantizedKnnVectorsFo
 org.opensearch.knn.index.codec.KNN9120Codec.KNN9120HnswBinaryVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HnswScalarQuantizedVectorsFormat
+org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat
+org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HnswHalfFloatVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormatTests.java
@@ -1,0 +1,608 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import org.apache.lucene.index.Sorter;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KNN1040HalfFloatFlatVectorsFormatTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_vector";
+    private static final int DIMENSION = 8;
+    private static final int NUM_VECTORS = 10;
+
+    @SneakyThrows
+    public void testFormatName() {
+        KNN1040HalfFloatFlatVectorsFormat format = new KNN1040HalfFloatFlatVectorsFormat();
+        assertEquals("KNN1040HalfFloatFlatVectorsFormat", format.getClass().getSimpleName());
+    }
+
+    @SneakyThrows
+    public void testGetMaxDimensions() {
+        KNN1040HalfFloatFlatVectorsFormat format = new KNN1040HalfFloatFlatVectorsFormat();
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("test-field"));
+    }
+
+    @SneakyThrows
+    public void testWriteAndRead_roundTrip() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertNotNull(values);
+                assertEquals(DIMENSION, values.dimension());
+                assertEquals(NUM_VECTORS, values.size());
+
+                for (int i = 0; i < NUM_VECTORS; i++) {
+                    float[] actual = values.vectorValue(i);
+                    assertNotNull(actual);
+                    assertEquals(DIMENSION, actual.length);
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expected = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                        assertEquals("Vector " + i + " dim " + d, expected, actual[d], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testWriteAndRead_cachedVectorValue() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(5, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                float[] first = values.vectorValue(2);
+                float[] second = values.vectorValue(2);
+                assertSame(first, second);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testWriteAndRead_vectorByteLength() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(3, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertEquals(DIMENSION * Short.BYTES, values.getVectorByteLength());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetByteVectorValues_throws() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(3, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                expectThrows(UnsupportedOperationException.class, () -> reader.getByteVectorValues(FIELD_NAME));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_unknownField_throws() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(3, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> reader.getFloatVectorValues("nonexistent"));
+                assertTrue(e.getMessage().contains("nonexistent"));
+            }
+        }
+    }
+
+    private SegmentReadState writeVectors(Directory dir, float[][] vectors) throws Exception {
+        return writeVectors(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private SegmentReadState writeVectors(Directory dir, float[][] vectors, VectorSimilarityFunction similarity) throws Exception {
+        FieldInfo fieldInfo = createFieldInfo(similarity);
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+
+        SegmentInfo segmentInfo = new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "_0",
+            vectors.length,
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            new HashMap<>(),
+            null
+        );
+        SegmentWriteState writeState = new SegmentWriteState(InfoStream.NO_OUTPUT, dir, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+
+        KNN1040HalfFloatFlatVectorsFormat format = new KNN1040HalfFloatFlatVectorsFormat();
+        try (FlatVectorsWriter writer = format.fieldsWriter(writeState)) {
+            @SuppressWarnings("unchecked")
+            FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+
+            for (int i = 0; i < vectors.length; i++) {
+                fieldWriter.addValue(i, vectors[i]);
+            }
+
+            writer.flush(vectors.length, null);
+            writer.finish();
+        }
+
+        return new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+    }
+
+    @SneakyThrows
+    public void testWriteWithSortMap_writesReorderedData() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = {
+                { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f },
+                { 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f } };
+
+            FieldInfo fieldInfo = createFieldInfo();
+            FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+
+            SegmentInfo segmentInfo = new SegmentInfo(
+                dir,
+                Version.LATEST,
+                Version.LATEST,
+                "_0",
+                2,
+                false,
+                false,
+                null,
+                Collections.emptyMap(),
+                StringHelper.randomId(),
+                new HashMap<>(),
+                null
+            );
+            SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                dir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
+
+            Sorter.DocMap sortMap = new Sorter.DocMap() {
+                @Override
+                public int oldToNew(int docID) {
+                    return docID == 0 ? 1 : 0;
+                }
+
+                @Override
+                public int newToOld(int docID) {
+                    return docID == 0 ? 1 : 0;
+                }
+
+                @Override
+                public int size() {
+                    return 2;
+                }
+            };
+
+            KNN1040HalfFloatFlatVectorsFormat format = new KNN1040HalfFloatFlatVectorsFormat();
+            try (FlatVectorsWriter writer = format.fieldsWriter(writeState)) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                fieldWriter.addValue(0, vectors[0]);
+                fieldWriter.addValue(1, vectors[1]);
+                writer.flush(2, sortMap);
+                writer.finish();
+            }
+
+            // Verify writer completes without error and creates files
+            SegmentReadState readState = new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+            try (FlatVectorsReader reader = format.fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertEquals(2, values.size());
+                assertNotNull(values.vectorValue(0));
+                assertNotNull(values.vectorValue(1));
+            }
+        }
+    }
+
+    private FieldInfo createFieldInfo() {
+        return createFieldInfo(VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private FieldInfo createFieldInfo(VectorSimilarityFunction similarity) {
+        return new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            DIMENSION,
+            VectorEncoding.FLOAT32,
+            similarity,
+            false,
+            false
+        );
+    }
+
+    @SneakyThrows
+    public void testScorer_nonMmapDirectory_matchesExpectedSimilarity() {
+        // ByteBuffersDirectory does not back onto mmap'd memory, so getFloatVectorValues() returns
+        // the plain (non-MMapFloatVectorValues-wrapped) KNN1040HalfFloatFlatVectorsValues. This uses the
+        // scorer() fallback path (used when native mmap addresses are unavailable)
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertFalse("Expected non-mmap-backed values for this test", values instanceof MMapFloatVectorValues);
+
+                float[] query = generateVectors(1, DIMENSION)[0];
+                VectorScorer scorer = values.scorer(query);
+                assertNotNull(scorer);
+
+                for (int i = 0; i < NUM_VECTORS; i++) {
+                    assertTrue(scorer.iterator().nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, scorer.score(), 1e-3);
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testScorerBulk_nonMmapDirectory_matchesExpectedSimilarity() {
+        // Exercises VectorScorer.bulk(), which is what the reader's exhaustive search() path uses.
+        // With mmap unavailable, this goes through KNN1040HalfFloatRandomVectorScorer.bulkScore() when SIMD
+        // is supported, or the pure-Java fallback (via the default Bulk implementation) otherwise.
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertFalse("Expected non-mmap-backed values for this test", values instanceof MMapFloatVectorValues);
+
+                float[] query = generateVectors(1, DIMENSION)[0];
+                VectorScorer scorer = values.scorer(query);
+                assertNotNull(scorer);
+
+                VectorScorer.Bulk bulk = scorer.bulk(null);
+                DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
+                float maxScore = bulk.nextDocsAndScores(NUM_VECTORS, null, buffer);
+                assertEquals(NUM_VECTORS, buffer.size);
+
+                float expectedMax = Float.NEGATIVE_INFINITY;
+                for (int i = 0; i < NUM_VECTORS; i++) {
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, buffer.features[i], 1e-3);
+                    expectedMax = Math.max(expectedMax, expected);
+                }
+                assertEquals(expectedMax, maxScore, 1e-3);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFloatVectorValues_implementsHasIndexSlice() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertNotNull(values);
+
+                // MMapFloatVectorValues wraps KNN1040HalfFloatFlatVectorsValues which implements HasIndexSlice
+                // This enables prefetch in PrefetchableFlatVectorScorer
+                assertTrue("FloatVectorValues should implement HasIndexSlice for prefetch support", values instanceof HasIndexSlice);
+                HasIndexSlice hasSlice = (HasIndexSlice) values;
+                assertNotNull("getSlice() should return non-null IndexInput for mmap-backed values", hasSlice.getSlice());
+            }
+        }
+    }
+
+    /**
+     * Verifies {@code Values.scorer(target)} picks the mmap-backed {@link NativeRandomVectorScorer}
+     * via the shared {@code selectScorer} helper, matching the reader's own selection -- exercised
+     * through {@link MMapFloatVectorValues#scorer}, the path Lucene's filtered exact-search fallback
+     * and rescore use. Guards against silently falling back to the non-mmap scorer when mmap is
+     * available.
+     */
+    @SneakyThrows
+    public void testValuesScorer_mmapDirectory_selectsNativeScorer() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertTrue("expected mmap-backed values for this test", values instanceof MMapFloatVectorValues);
+
+                float[] query = generateVectors(1, DIMENSION)[0];
+                VectorScorer vectorScorer = values.scorer(query);
+                assertNotNull(vectorScorer);
+
+                RandomVectorScorer innerScorer = unwrapCapturedScorer(vectorScorer);
+                RandomVectorScorer.AbstractRandomVectorScorer prefetchDelegate = getPrivateField(
+                    innerScorer,
+                    "delegate",
+                    RandomVectorScorer.AbstractRandomVectorScorer.class
+                );
+                assertTrue(
+                    "scorer() should select the mmap-backed NativeRandomVectorScorer when mmap and a "
+                        + "native similarity type are both available, not fall back to the non-native scorer",
+                    prefetchDelegate instanceof org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer
+                );
+
+                DocIdSetIterator iterator = vectorScorer.iterator();
+                for (int i = 0; i < NUM_VECTORS; i++) {
+                    assertTrue(iterator.nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, vectorScorer.score(), 1e-3);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reflectively unwraps the {@code RandomVectorScorer} captured in the anonymous
+     * {@link VectorScorer} that {@code scorer()} returns (stored as javac's synthetic
+     * {@code val$scorer} field), so production code doesn't need a test-only accessor.
+     */
+    private static RandomVectorScorer unwrapCapturedScorer(VectorScorer vectorScorer) throws Exception {
+        return getPrivateField(vectorScorer, "val$scorer", RandomVectorScorer.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getPrivateField(Object target, String fieldName, Class<T> fieldType) throws Exception {
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(target);
+    }
+
+    @SneakyThrows
+    public void testSearch_cosineWithMmapDirectory_doesNotThrowAndMatchesExpected() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors, VectorSimilarityFunction.COSINE);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                assertTrue(
+                    "expected mmap-backed values for this test",
+                    reader.getFloatVectorValues(FIELD_NAME) instanceof MMapFloatVectorValues
+                );
+
+                float[] query = generateVectors(1, DIMENSION)[0];
+                KnnCollector collector = new TopKnnCollector(NUM_VECTORS, Integer.MAX_VALUE);
+                reader.search(FIELD_NAME, query, collector, AcceptDocs.fromLiveDocs(null, NUM_VECTORS));
+
+                // topDocs() drains the underlying queue, so call it exactly once.
+                ScoreDoc[] scoreDocs = collector.topDocs().scoreDocs;
+                assertEquals(NUM_VECTORS, scoreDocs.length);
+                float expectedBest = bestExpectedScore(vectors, query, VectorSimilarityFunction.COSINE, NUM_VECTORS);
+                assertEquals(expectedBest, scoreDocs[0].score, 1e-3);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_nonMmapDirectory_matchesExpectedSimilarity() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                float[] query = generateVectors(1, DIMENSION)[0];
+                RandomVectorScorer scorer = reader.getRandomVectorScorer(FIELD_NAME, query);
+                assertNotNull(scorer);
+                assertEquals(NUM_VECTORS, scorer.maxOrd());
+
+                for (int i = 0; i < NUM_VECTORS; i++) {
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, scorer.score(i), 1e-3);
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_nonMmapDirectory_collectsAllVectorsWithoutThrowing() {
+        // End-to-end exhaustive search() through the same non-mmap fallback path as the test above,
+        // confirming the reader's own bulk-scoring loop (not just getRandomVectorScorer()) is safe.
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = generateVectors(NUM_VECTORS, DIMENSION);
+            SegmentReadState readState = writeVectors(dir, vectors);
+
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsFormat().fieldsReader(readState)) {
+                float[] query = generateVectors(1, DIMENSION)[0];
+                KnnCollector collector = new TopKnnCollector(NUM_VECTORS, Integer.MAX_VALUE);
+                reader.search(FIELD_NAME, query, collector, AcceptDocs.fromLiveDocs(null, NUM_VECTORS));
+                assertEquals(NUM_VECTORS, collector.topDocs().scoreDocs.length);
+            }
+        }
+    }
+
+    /**
+     * Merges segments under a descending index sort, so later segments land entirely before
+     * earlier ones, and checks every doc still has the right vector.
+     *
+     * <p>A merge that appends {@code docMap.get(doc)} reader-by-reader would emit descending doc
+     * ids at the first reader boundary, tripping {@code DocsWithFieldSet}'s strictly-increasing
+     * check -- a bug {@code testHalfFloatFlatIndex_forceMerge} can't catch, since without a sort
+     * each reader's block is already increasing.
+     */
+    @SneakyThrows
+    public void testMergeWithIndexSort_preservesDocToVectorMapping() {
+        final int docsPerSegment = 5;
+        final int numSegments = 3;
+        final int totalDocs = docsPerSegment * numSegments;
+        final String sortFieldName = "sort_key";
+        final String idFieldName = "id";
+
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            final Codec codec = new Lucene104Codec() {
+                @Override
+                public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                    return new KNN1040HalfFloatFlatVectorsFormat();
+                }
+            };
+
+            final IndexWriterConfig iwc = new IndexWriterConfig().setCodec(codec)
+                .setIndexSort(new Sort(new SortField(sortFieldName, SortField.Type.LONG, true)));
+
+            final float[][] vectors = generateVectors(totalDocs, DIMENSION);
+
+            try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+                for (int i = 0; i < totalDocs; i++) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vectors[i], VectorSimilarityFunction.EUCLIDEAN));
+                    doc.add(new NumericDocValuesField(sortFieldName, i));
+                    doc.add(new StoredField(idFieldName, i));
+                    writer.addDocument(doc);
+                    if ((i + 1) % docsPerSegment == 0) {
+                        writer.commit();
+                    }
+                }
+                writer.forceMerge(1);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals("force merge should leave a single segment", 1, reader.leaves().size());
+                LeafReader leaf = reader.leaves().get(0).reader();
+
+                FloatVectorValues values = leaf.getFloatVectorValues(FIELD_NAME);
+                assertNotNull(values);
+                assertEquals(totalDocs, values.size());
+
+                int seen = 0;
+                int previousId = Integer.MAX_VALUE;
+                KnnVectorValues.DocIndexIterator iterator = values.iterator();
+                for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+                    int id = leaf.storedFields().document(doc).getField(idFieldName).numericValue().intValue();
+
+                    // Descending sort on an ascending key: ids must come back in descending order,
+                    // which is what proves the segments actually interleaved during the merge.
+                    assertTrue("docs should be in descending id order, got " + id + " after " + previousId, id < previousId);
+                    previousId = id;
+
+                    float[] actual = values.vectorValue(iterator.index());
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expected = Float.float16ToFloat(Float.floatToFloat16(vectors[id][d]));
+                        assertEquals("vector mismatch for id=" + id + " dim=" + d, expected, actual[d], 0.0f);
+                    }
+                    seen++;
+                }
+                assertEquals(totalDocs, seen);
+            }
+        }
+    }
+
+    private float bestExpectedScore(float[][] vectors, float[] query, VectorSimilarityFunction similarity, int numVectors) {
+        float best = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < numVectors; i++) {
+            float[] decoded = new float[DIMENSION];
+            for (int d = 0; d < DIMENSION; d++) {
+                decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+            }
+            best = Math.max(best, similarity.compare(query, decoded));
+        }
+        return best;
+    }
+
+    private float[][] generateVectors(int count, int dimension) {
+        float[][] vectors = new float[count][dimension];
+        for (int i = 0; i < count; i++) {
+            for (int d = 0; d < dimension; d++) {
+                vectors[i][d] = (random().nextFloat() * 2 - 1) * 10;
+            }
+        }
+        return vectors;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormatTests.java
@@ -427,11 +427,6 @@ public class KNN1040HalfFloatFlatVectorsFormatTests extends KNNTestCase {
         }
     }
 
-    /**
-     * Reflectively unwraps the {@code RandomVectorScorer} captured in the anonymous
-     * {@link VectorScorer} that {@code scorer()} returns (stored as javac's synthetic
-     * {@code val$scorer} field), so production code doesn't need a test-only accessor.
-     */
     private static RandomVectorScorer unwrapCapturedScorer(VectorScorer vectorScorer) throws Exception {
         return getPrivateField(vectorScorer, "val$scorer", RandomVectorScorer.class);
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -10,6 +10,7 @@ import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.DocsWithFieldSet;
@@ -187,23 +188,145 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testReadFields_unknownFieldNumber_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // FieldInfos only has field number 0 (see createFieldInfo); recording 99 in meta instead
+            // triggers readFields()'s own "Invalid field number" check, before FieldEntry ever exists.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaFieldNumber(99).build()
+            );
+            CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Invalid field number"));
+        }
+    }
+
+    @SneakyThrows
+    public void testReadSimilarityFunction_outOfRangeOrdinal_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // 99 is out of SIMILARITY_FUNCTIONS' range - caught by readSimilarityFunction() itself,
+            // distinct from testFieldEntry_similarityMismatch_throws's in-range-but-wrong value.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaSimilarityOrdinal(99).build()
+            );
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("invalid distance function"));
+        }
+    }
+
+    @SneakyThrows
+    public void testReadVectorEncoding_outOfRangeOrdinal_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // 99 is out of VectorEncoding.values()' range - caught by readVectorEncoding() itself,
+            // distinct from testFieldEntry_encodingMismatch_throws's in-range-but-wrong value.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaEncodingOrdinal(99).build()
+            );
+            CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Invalid vector encoding id"));
+        }
+    }
+
+    @SneakyThrows
+    public void testSparseDocs_ordToDocMappingUsesDirectMonotonicReader() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f }, { 9f, 10f, 11f, 12f } };
+            int[] docIds = { 0, 3, 7 };
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                vectors,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().docIds(docIds).maxDoc(10).build()
+            );
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                for (int ord = 0; ord < docIds.length; ord++) {
+                    assertEquals(docIds[ord], values.ordToDoc(ord));
+                }
+                FloatVectorValues.DocIndexIterator iterator = values.iterator();
+                int ord = 0;
+                for (int doc = iterator.nextDoc(); doc != org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS; doc = iterator
+                    .nextDoc()) {
+                    assertEquals(docIds[ord], doc);
+                    assertEquals(ord, iterator.index());
+                    ord++;
+                }
+                assertEquals(docIds.length, ord);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetMergeInstance_returnsUsableReaderThenFinishMergeRestoresIt() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FlatVectorsReader mergeInstance = reader.getMergeInstance();
+                assertSame(reader, mergeInstance);
+                assertEquals(1, mergeInstance.getFloatVectorValues(FIELD_NAME).size());
+                mergeInstance.finishMerge();
+                assertEquals(1, reader.getFloatVectorValues(FIELD_NAME).size());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testOpenDataInput_truncatedVectorDataFile_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+            dir.deleteFile(vectorDataFileName);
+            // Too short for even the codec header - checkIndexHeader() fails before any of our own
+            // validation runs, exercising openDataInput()'s own success==false cleanup path.
+            try (IndexOutput truncated = dir.createOutput(vectorDataFileName, IOContext.DEFAULT)) {
+                truncated.writeByte((byte) 0);
+            }
+            expectThrows(Exception.class, () -> newReader(readState));
+        }
+    }
+
     private FlatVectorsReader newReader(SegmentReadState readState) throws Exception {
         FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
         return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);
     }
 
-    /** Optional per-field overrides used to write a deliberately corrupted fixture. */
     private static final class Overrides {
         private final Integer metaDimension;
         private final Integer metaSimilarityOrdinal;
         private final Integer metaEncodingOrdinal;
         private final Long metaVectorDataLength;
+        private final Integer metaFieldNumber;
+        private final int[] docIds;
+        private final Integer maxDoc;
 
-        private Overrides(Integer metaDimension, Integer metaSimilarityOrdinal, Integer metaEncodingOrdinal, Long metaVectorDataLength) {
+        private Overrides(
+            Integer metaDimension,
+            Integer metaSimilarityOrdinal,
+            Integer metaEncodingOrdinal,
+            Long metaVectorDataLength,
+            Integer metaFieldNumber,
+            int[] docIds,
+            Integer maxDoc
+        ) {
             this.metaDimension = metaDimension;
             this.metaSimilarityOrdinal = metaSimilarityOrdinal;
             this.metaEncodingOrdinal = metaEncodingOrdinal;
             this.metaVectorDataLength = metaVectorDataLength;
+            this.metaFieldNumber = metaFieldNumber;
+            this.docIds = docIds;
+            this.maxDoc = maxDoc;
         }
 
         static Builder builder() {
@@ -215,6 +338,9 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
             private Integer metaSimilarityOrdinal;
             private Integer metaEncodingOrdinal;
             private Long metaVectorDataLength;
+            private Integer metaFieldNumber;
+            private int[] docIds;
+            private Integer maxDoc;
 
             Builder metaDimension(int v) {
                 this.metaDimension = v;
@@ -236,8 +362,31 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
                 return this;
             }
 
+            Builder metaFieldNumber(int v) {
+                this.metaFieldNumber = v;
+                return this;
+            }
+
+            Builder docIds(int[] v) {
+                this.docIds = v;
+                return this;
+            }
+
+            Builder maxDoc(int v) {
+                this.maxDoc = v;
+                return this;
+            }
+
             Overrides build() {
-                return new Overrides(metaDimension, metaSimilarityOrdinal, metaEncodingOrdinal, metaVectorDataLength);
+                return new Overrides(
+                    metaDimension,
+                    metaSimilarityOrdinal,
+                    metaEncodingOrdinal,
+                    metaVectorDataLength,
+                    metaFieldNumber,
+                    docIds,
+                    maxDoc
+                );
             }
         }
     }
@@ -246,26 +395,17 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
         return writeRawSegment(dir, vectors, similarity, Overrides.builder().build());
     }
 
-    /**
-     * Hand-writes a segment's {@code .vemf}/{@code .vec} pair using the same low-level primitives and
-     * on-disk layout as {@link KNN1040HalfFloatFlatVectorsWriter}, without depending on that class.
-     * {@code overrides} lets individual tests corrupt one recorded value to exercise
-     * {@code FieldEntry}'s validation checks.
-     */
-    private SegmentReadState writeRawSegment(
-        Directory dir,
-        float[][] vectors,
-        VectorSimilarityFunction similarity,
-        Overrides overrides
-    ) throws Exception {
+    private SegmentReadState writeRawSegment(Directory dir, float[][] vectors, VectorSimilarityFunction similarity, Overrides overrides)
+        throws Exception {
         FieldInfo fieldInfo = createFieldInfo(similarity);
         FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+        int maxDoc = overrides.maxDoc != null ? overrides.maxDoc : vectors.length;
         SegmentInfo segmentInfo = new SegmentInfo(
             dir,
             Version.LATEST,
             Version.LATEST,
             "_0",
-            vectors.length,
+            maxDoc,
             false,
             false,
             null,
@@ -300,14 +440,14 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
             long vectorDataOffset = vectorData.alignFilePointer(VECTOR_DATA_ALIGNMENT);
             byte[] outputBuffer = new byte[DIMENSION * Short.BYTES];
             DocsWithFieldSet docsWithField = new DocsWithFieldSet();
-            for (int doc = 0; doc < vectors.length; doc++) {
-                KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vectors[doc], outputBuffer, DIMENSION);
+            for (int ord = 0; ord < vectors.length; ord++) {
+                KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vectors[ord], outputBuffer, DIMENSION);
                 vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
-                docsWithField.add(doc);
+                docsWithField.add(overrides.docIds != null ? overrides.docIds[ord] : ord);
             }
             long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
 
-            meta.writeInt(fieldInfo.number);
+            meta.writeInt(overrides.metaFieldNumber != null ? overrides.metaFieldNumber : fieldInfo.number);
             meta.writeInt(overrides.metaEncodingOrdinal != null ? overrides.metaEncodingOrdinal : VectorEncoding.FLOAT32.ordinal());
             meta.writeInt(overrides.metaSimilarityOrdinal != null ? overrides.metaSimilarityOrdinal : similarity.ordinal());
             meta.writeVLong(vectorDataOffset);
@@ -321,7 +461,7 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
                 meta,
                 vectorData,
                 count,
-                vectors.length,
+                maxDoc,
                 docsWithField
             );
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests {@link KNN1040HalfFloatFlatVectorsReader} in isolation, without going through
+ * {@link KNN1040HalfFloatFlatVectorsWriter}. Fixtures are written directly with low-level Lucene
+ * primitives (mirroring the writer's on-disk layout, not calling the writer class itself), so a bug
+ * introduced only in the writer can't mask a bug in the reader, or vice versa.
+ */
+public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_vector";
+    private static final int DIMENSION = 4;
+    private static final int VECTOR_DATA_ALIGNMENT = 64;
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_decodesCorrectly() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f }, { 0.5f, 0.5f, 0.5f, 0.5f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertNotNull(values);
+                assertEquals(DIMENSION, values.dimension());
+                assertEquals(vectors.length, values.size());
+
+                for (int i = 0; i < vectors.length; i++) {
+                    float[] actual = values.vectorValue(i);
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expected = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                        assertEquals("vector " + i + " dim " + d, expected, actual[d], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetByteVectorValues_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                expectThrows(UnsupportedOperationException.class, () -> reader.getByteVectorValues(FIELD_NAME));
+                expectThrows(UnsupportedOperationException.class, () -> reader.getRandomVectorScorer(FIELD_NAME, new byte[] { 1 }));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_unknownField_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> reader.getFloatVectorValues("nope"));
+                assertTrue(e.getMessage().contains("nope"));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testCheckIntegrity_validSegment_succeeds() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                reader.checkIntegrity();
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetOffHeapByteSize_returnsVectorDataLength() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FieldInfo fieldInfo = readState.fieldInfos.fieldInfo(FIELD_NAME);
+                Map<String, Long> offHeap = reader.getOffHeapByteSize(fieldInfo);
+                long expectedBytes = (long) vectors.length * DIMENSION * Short.BYTES;
+                assertEquals(Long.valueOf(expectedBytes), offHeap.get(KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testRamBytesUsed_positive() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                assertTrue(reader.ramBytesUsed() > 0);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_dimensionMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // Meta records DIMENSION+1 vectors' worth of dimension, but FieldInfo (read separately by
+            // the reader) still says DIMENSION - triggers the "Inconsistent vector dimension" check.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaDimension(DIMENSION + 1).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Inconsistent vector dimension"));
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_similarityMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // Meta records COSINE's ordinal, but FieldInfo says EUCLIDEAN - triggers the "Inconsistent
+            // vector similarity function" check.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaSimilarityOrdinal(VectorSimilarityFunction.COSINE.ordinal()).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Inconsistent vector similarity function"));
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_encodingMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaEncodingOrdinal(VectorEncoding.BYTE.ordinal()).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Unexpected vector encoding"));
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_lengthMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaVectorDataLength(1).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Vector data length"));
+        }
+    }
+
+    private FlatVectorsReader newReader(SegmentReadState readState) throws Exception {
+        FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+        return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);
+    }
+
+    /** Optional per-field overrides used to write a deliberately corrupted fixture. */
+    private static final class Overrides {
+        private final Integer metaDimension;
+        private final Integer metaSimilarityOrdinal;
+        private final Integer metaEncodingOrdinal;
+        private final Long metaVectorDataLength;
+
+        private Overrides(Integer metaDimension, Integer metaSimilarityOrdinal, Integer metaEncodingOrdinal, Long metaVectorDataLength) {
+            this.metaDimension = metaDimension;
+            this.metaSimilarityOrdinal = metaSimilarityOrdinal;
+            this.metaEncodingOrdinal = metaEncodingOrdinal;
+            this.metaVectorDataLength = metaVectorDataLength;
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        static final class Builder {
+            private Integer metaDimension;
+            private Integer metaSimilarityOrdinal;
+            private Integer metaEncodingOrdinal;
+            private Long metaVectorDataLength;
+
+            Builder metaDimension(int v) {
+                this.metaDimension = v;
+                return this;
+            }
+
+            Builder metaSimilarityOrdinal(int v) {
+                this.metaSimilarityOrdinal = v;
+                return this;
+            }
+
+            Builder metaEncodingOrdinal(int v) {
+                this.metaEncodingOrdinal = v;
+                return this;
+            }
+
+            Builder metaVectorDataLength(long v) {
+                this.metaVectorDataLength = v;
+                return this;
+            }
+
+            Overrides build() {
+                return new Overrides(metaDimension, metaSimilarityOrdinal, metaEncodingOrdinal, metaVectorDataLength);
+            }
+        }
+    }
+
+    private SegmentReadState writeRawSegment(Directory dir, float[][] vectors, VectorSimilarityFunction similarity) throws Exception {
+        return writeRawSegment(dir, vectors, similarity, Overrides.builder().build());
+    }
+
+    /**
+     * Hand-writes a segment's {@code .vemf}/{@code .vec} pair using the same low-level primitives and
+     * on-disk layout as {@link KNN1040HalfFloatFlatVectorsWriter}, without depending on that class.
+     * {@code overrides} lets individual tests corrupt one recorded value to exercise
+     * {@code FieldEntry}'s validation checks.
+     */
+    private SegmentReadState writeRawSegment(
+        Directory dir,
+        float[][] vectors,
+        VectorSimilarityFunction similarity,
+        Overrides overrides
+    ) throws Exception {
+        FieldInfo fieldInfo = createFieldInfo(similarity);
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+        SegmentInfo segmentInfo = new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "_0",
+            vectors.length,
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            new HashMap<>(),
+            null
+        );
+
+        String metaFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION);
+        String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+
+        try (
+            IndexOutput meta = dir.createOutput(metaFileName, IOContext.DEFAULT);
+            IndexOutput vectorData = dir.createOutput(vectorDataFileName, IOContext.DEFAULT)
+        ) {
+            CodecUtil.writeIndexHeader(
+                meta,
+                KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME,
+                KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                segmentInfo.getId(),
+                ""
+            );
+            CodecUtil.writeIndexHeader(
+                vectorData,
+                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                segmentInfo.getId(),
+                ""
+            );
+
+            long vectorDataOffset = vectorData.alignFilePointer(VECTOR_DATA_ALIGNMENT);
+            byte[] outputBuffer = new byte[DIMENSION * Short.BYTES];
+            DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+            for (int doc = 0; doc < vectors.length; doc++) {
+                KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vectors[doc], outputBuffer, DIMENSION);
+                vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
+                docsWithField.add(doc);
+            }
+            long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+            meta.writeInt(fieldInfo.number);
+            meta.writeInt(overrides.metaEncodingOrdinal != null ? overrides.metaEncodingOrdinal : VectorEncoding.FLOAT32.ordinal());
+            meta.writeInt(overrides.metaSimilarityOrdinal != null ? overrides.metaSimilarityOrdinal : similarity.ordinal());
+            meta.writeVLong(vectorDataOffset);
+            meta.writeVLong(overrides.metaVectorDataLength != null ? overrides.metaVectorDataLength : vectorDataLength);
+            meta.writeVInt(overrides.metaDimension != null ? overrides.metaDimension : DIMENSION);
+
+            int count = docsWithField.cardinality();
+            meta.writeInt(count);
+            OrdToDocDISIReaderConfiguration.writeStoredMeta(
+                KNN1040HalfFloatFlatVectorsFormat.DIRECT_MONOTONIC_BLOCK_SHIFT,
+                meta,
+                vectorData,
+                count,
+                vectors.length,
+                docsWithField
+            );
+
+            meta.writeInt(-1);
+            CodecUtil.writeFooter(meta);
+            CodecUtil.writeFooter(vectorData);
+        }
+
+        return new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+    }
+
+    private FieldInfo createFieldInfo(VectorSimilarityFunction similarity) {
+        return new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            DIMENSION,
+            VectorEncoding.FLOAT32,
+            similarity,
+            false,
+            false
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.jni.SimdFp16;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer} wraps its result in
+ * {@link PrefetchableRandomVectorScorer} - regardless of which inner branch (native SIMD or plain
+ * Java) it takes - so this fallback tier still prefetches ahead of bulk scoring, same as the mmap
+ * tier already gets via {@code KNN1040HalfFloatVectorScorer#getRandomVectorScorer}.
+ */
+public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
+
+    // Only exercises selectFallbackScorer's construction, never .score()/.bulkScore(): the native
+    // branch's constructor makes a real (unmocked) SimdVectorComputeService#saveSearchContext call
+    // with a real target and an empty address array - the same legitimate pattern the byte-copy merge
+    // tier already uses successfully in production - but actually scoring against a mocked/fake
+    // address would risk the native SIGSEGV documented in KNN1040HalfFloatVectorScorerTests.
+    @SneakyThrows
+    public void testSelectFallbackScorer_nativeTierAvailable_isWrappedInPrefetchableScorer() {
+        assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.EUCLIDEAN, true);
+    }
+
+    @SneakyThrows
+    public void testSelectFallbackScorer_noNativeKernel_isStillWrappedInPrefetchableScorer() {
+        // COSINE never reaches the native branch at all (see NativeEngines990KnnVectorsScorer#getNativeFunctionType),
+        // so this exercises the plain-Java anonymous scorer branch instead.
+        assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.COSINE, true);
+    }
+
+    @SneakyThrows
+    private void assertFallbackScorerIsPrefetchable(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        final float[] target = new float[] { 1f, 2f, 3f };
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(simdSupported);
+            RandomVectorScorer scorer = KNN1040HalfFloatFlatVectorsValues.selectFallbackScorer(mockValues, target, similarityFunction);
+            assertTrue(scorer instanceof PrefetchableRandomVectorScorer);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
@@ -16,19 +16,8 @@ import org.opensearch.knn.jni.SimdFp16;
 
 import static org.mockito.Mockito.mock;
 
-/**
- * Verifies {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer} wraps its result in
- * {@link PrefetchableRandomVectorScorer} - regardless of which inner branch (native SIMD or plain
- * Java) it takes - so this fallback tier still prefetches ahead of bulk scoring, same as the mmap
- * tier already gets via {@code KNN1040HalfFloatVectorScorer#getRandomVectorScorer}.
- */
 public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
 
-    // Only exercises selectFallbackScorer's construction, never .score()/.bulkScore(): the native
-    // branch's constructor makes a real (unmocked) SimdVectorComputeService#saveSearchContext call
-    // with a real target and an empty address array - the same legitimate pattern the byte-copy merge
-    // tier already uses successfully in production - but actually scoring against a mocked/fake
-    // address would risk the native SIGSEGV documented in KNN1040HalfFloatVectorScorerTests.
     @SneakyThrows
     public void testSelectFallbackScorer_nativeTierAvailable_isWrappedInPrefetchableScorer() {
         assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.EUCLIDEAN, true);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests {@link KNN1040HalfFloatFlatVectorsWriter} in isolation, without going through
+ * {@link KNN1040HalfFloatFlatVectorsReader}. Correctness of the encoded bytes is verified by decoding
+ * them directly with {@link KNNVectorAsCollectionOfHalfFloatsSerializer} (a shared utility, not part of
+ * the writer/reader pair), rather than by reading the segment back through our own reader.
+ */
+public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_vector";
+    private static final int DIMENSION = 8;
+
+    @SneakyThrows
+    public void testAddField_returnsWorkingFieldWriter() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                FieldInfo fieldInfo = createFieldInfo();
+                FlatFieldVectorsWriter<?> fieldWriter = writer.addField(fieldInfo);
+                assertNotNull(fieldWriter);
+                assertTrue(fieldWriter.getVectors().isEmpty());
+                assertEquals(0, fieldWriter.getDocsWithFieldSet().cardinality());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testAddField_rejectsNonFloat32Encoding() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                FieldInfo byteEncodedField = createFieldInfo(VectorEncoding.BYTE, VectorSimilarityFunction.EUCLIDEAN);
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> writer.addField(byteEncodedField));
+                assertTrue(e.getMessage().contains("FLOAT32"));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldWriter_duplicateDocId_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                fieldWriter.addValue(0, new float[DIMENSION]);
+                IllegalArgumentException e = expectThrows(
+                    IllegalArgumentException.class,
+                    () -> fieldWriter.addValue(0, new float[DIMENSION])
+                );
+                assertTrue(e.getMessage().contains(FIELD_NAME));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldWriter_addValueAfterFinish_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                fieldWriter.finish();
+                assertTrue(fieldWriter.isFinished());
+                expectThrows(IllegalStateException.class, () -> fieldWriter.addValue(0, new float[DIMENSION]));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFinish_calledTwice_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                writer.finish();
+                expectThrows(IllegalStateException.class, writer::finish);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testRamBytesUsed_increasesAsVectorsAreAdded() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                long before = writer.ramBytesUsed();
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                for (int i = 0; i < 5; i++) {
+                    fieldWriter.addValue(i, generateVector());
+                }
+                long after = writer.ramBytesUsed();
+                assertTrue("ramBytesUsed should grow as vectors are added", after > before);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFlush_writesFilesWithExpectedNamesAndHeaders() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            String segmentSuffix = "";
+            FieldInfo fieldInfo = createFieldInfo();
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                fieldWriter.addValue(0, generateVector());
+                writer.flush(1, null);
+                writer.finish();
+            }
+
+            String metaFileName = IndexFileNames.segmentFileName(
+                "_0",
+                segmentSuffix,
+                KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION
+            );
+            String vectorDataFileName = IndexFileNames.segmentFileName(
+                "_0",
+                segmentSuffix,
+                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION
+            );
+            assertTrue(java.util.Arrays.asList(dir.listAll()).contains(metaFileName));
+            assertTrue(java.util.Arrays.asList(dir.listAll()).contains(vectorDataFileName));
+
+            try (IndexInput metaInput = dir.openInput(metaFileName, IOContext.DEFAULT)) {
+                CodecUtil.checksumEntireFile(metaInput);
+            }
+            try (IndexInput vectorDataInput = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checksumEntireFile(vectorDataInput);
+            }
+        }
+    }
+
+    /**
+     * Decodes the written FP16 bytes directly with {@link KNNVectorAsCollectionOfHalfFloatsSerializer},
+     * independent of {@link KNN1040HalfFloatFlatVectorsReader}, to isolate encoding correctness in the
+     * writer from any bugs the reader might share or mask.
+     */
+    @SneakyThrows
+    public void testVectorDataBytes_decodeToExpectedFp16Values() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { generateVector(), generateVector(), generateVector() };
+            FieldInfo fieldInfo = createFieldInfo();
+            SegmentInfo segmentInfo = createSegmentInfo(dir, "_0");
+
+            try (FlatVectorsWriter writer = newWriter(dir, segmentInfo)) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                for (int i = 0; i < vectors.length; i++) {
+                    fieldWriter.addValue(i, vectors[i]);
+                }
+                writer.flush(vectors.length, null);
+                writer.finish();
+            }
+
+            String vectorDataFileName = IndexFileNames.segmentFileName(
+                "_0",
+                "",
+                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION
+            );
+            try (IndexInput input = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checkIndexHeader(
+                    input,
+                    KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    segmentInfo.getId(),
+                    ""
+                );
+                // The writer 64-byte-aligns the start of each field's vector data (including the
+                // first), via IndexOutput#alignFilePointer - mirror that here before reading.
+                final int vectorDataAlignment = 64;
+                long aligned = ((input.getFilePointer() + vectorDataAlignment - 1) / vectorDataAlignment) * vectorDataAlignment;
+                input.seek(aligned);
+
+                int byteSize = DIMENSION * Short.BYTES;
+                byte[] raw = new byte[byteSize];
+                for (float[] expected : vectors) {
+                    input.readBytes(raw, 0, byteSize);
+                    float[] decoded = KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.byteToFloatArray(
+                        new org.apache.lucene.util.BytesRef(raw)
+                    );
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expectedFp16 = Float.float16ToFloat(Float.floatToFloat16(expected[d]));
+                        assertEquals(expectedFp16, decoded[d], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    private FlatVectorsWriter newWriter(Directory dir, String segmentName) throws Exception {
+        return newWriter(dir, createSegmentInfo(dir, segmentName));
+    }
+
+    private FlatVectorsWriter newWriter(Directory dir, SegmentInfo segmentInfo) throws Exception {
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { createFieldInfo() });
+        SegmentWriteState writeState = new SegmentWriteState(InfoStream.NO_OUTPUT, dir, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+        FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+        return new KNN1040HalfFloatFlatVectorsWriter(writeState, scorer);
+    }
+
+    private SegmentInfo createSegmentInfo(Directory dir, String segmentName) {
+        return new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            segmentName,
+            -1,
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            new HashMap<>(),
+            null
+        );
+    }
+
+    private FieldInfo createFieldInfo() {
+        return createFieldInfo(VectorEncoding.FLOAT32, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private FieldInfo createFieldInfo(VectorEncoding encoding, VectorSimilarityFunction similarity) {
+        return new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            DIMENSION,
+            encoding,
+            similarity,
+            false,
+            false
+        );
+    }
+
+    private float[] generateVector() {
+        float[] vector = new float[DIMENSION];
+        for (int d = 0; d < DIMENSION; d++) {
+            vector[d] = (random().nextFloat() * 2 - 1) * 10;
+        }
+        return vector;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
@@ -138,11 +138,7 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
                 writer.finish();
             }
 
-            String metaFileName = IndexFileNames.segmentFileName(
-                "_0",
-                segmentSuffix,
-                KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION
-            );
+            String metaFileName = IndexFileNames.segmentFileName("_0", segmentSuffix, KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION);
             String vectorDataFileName = IndexFileNames.segmentFileName(
                 "_0",
                 segmentSuffix,
@@ -182,11 +178,7 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
                 writer.finish();
             }
 
-            String vectorDataFileName = IndexFileNames.segmentFileName(
-                "_0",
-                "",
-                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION
-            );
+            String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
             try (IndexInput input = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
                 CodecUtil.checkIndexHeader(
                     input,

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies {@link KNN1040HalfFloatVectorScorer#getRandomVectorScorerSupplier} picks the decode-free
+ * native SIMD tier when a native FP16 kernel exists for the similarity function and SIMD is
+ * available, and otherwise falls back to {@link org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer}
+ * - the same crash this class was written to avoid (see class javadoc). This guards against silently
+ * regressing back to the slow/crashing fallback for spaces that should be using native SIMD.
+ */
+public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
+
+    private static final String NATIVE_TIER_CLASS_NAME = "HalfFloatRandomVectorScorerSupplier";
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_euclideanWithSimdSupported_usesNativeTier() {
+        assertNativeTierUsed(VectorSimilarityFunction.EUCLIDEAN, true);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_maximumInnerProductWithSimdSupported_usesNativeTier() {
+        assertNativeTierUsed(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, true);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_cosine_neverUsesNativeTierRegardlessOfSimd() {
+        // No native FP16 kernel exists for COSINE at all - must fall back even when SIMD is available.
+        assertFallbackTierUsed(VectorSimilarityFunction.COSINE, true);
+        assertFallbackTierUsed(VectorSimilarityFunction.COSINE, false);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_euclideanWithoutSimdSupported_usesFallbackTier() {
+        assertFallbackTierUsed(VectorSimilarityFunction.EUCLIDEAN, false);
+    }
+
+    // Deliberately never invokes .scorer()/.score(): SimdVectorComputeService's methods are declared
+    // `native`, and Mockito's mockStatic does not reliably intercept JNI-linked native methods in this
+    // environment - a version of this test that called .score() with a fake address crashed the JVM
+    // with a real SIGSEGV inside the native FP16 SIMD library instead of hitting the mock. Verifying
+    // via reflection that the address is threaded into the supplier (rather than discarded, as before
+    // this change) covers the actual behavior change without touching native code at all.
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_mmapAvailable_threadsAddressIntoSupplier() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        final long[] expectedAddress = new long[] { 123L, 456L };
+        final MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(mockValues, expectedAddress);
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
+
+            RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, mmapValues);
+            assertEquals(NATIVE_TIER_CLASS_NAME, supplier.getClass().getSimpleName());
+
+            Field addressField = supplier.getClass().getDeclaredField("addressAndSize");
+            addressField.setAccessible(true);
+            assertArrayEquals(expectedAddress, (long[]) addressField.get(supplier));
+        }
+    }
+
+    // Same native-call safety note as above: setScoringOrdinal constructs a real HalfFloatRandomVectorScorer
+    // (a legitimate saveSearchContext call with a real target and an empty address array, matching the
+    // byte-copy tier's normal production behavior), but this test never calls .score()/.bulkScore(), so
+    // it never risks dereferencing anything.
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_scorerWrapsDelegateInPrefetchableScorer() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        when(mockValues.vectorValue(anyInt())).thenReturn(new float[] { 1f, 2f, 3f });
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
+
+            RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, mockValues);
+            UpdateableRandomVectorScorer candidateScorer = supplier.scorer();
+            candidateScorer.setScoringOrdinal(0);
+
+            Field prefetchableField = candidateScorer.getClass().getDeclaredField("prefetchableDelegate");
+            prefetchableField.setAccessible(true);
+            assertTrue(prefetchableField.get(candidateScorer) instanceof PrefetchableRandomVectorScorer);
+        }
+    }
+
+    @SneakyThrows
+    private void assertNativeTierUsed(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        RandomVectorScorerSupplier result = getRandomVectorScorerSupplier(similarityFunction, simdSupported);
+        assertEquals(NATIVE_TIER_CLASS_NAME, result.getClass().getSimpleName());
+    }
+
+    @SneakyThrows
+    private void assertFallbackTierUsed(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        RandomVectorScorerSupplier result = getRandomVectorScorerSupplier(similarityFunction, simdSupported);
+        assertNotEquals(NATIVE_TIER_CLASS_NAME, result.getClass().getSimpleName());
+    }
+
+    @SneakyThrows
+    private RandomVectorScorerSupplier getRandomVectorScorerSupplier(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        // Only reached by the fallback tier's DefaultFlatVectorScorer, which validates the encoding.
+        when(mockValues.getEncoding()).thenReturn(VectorEncoding.FLOAT32);
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(simdSupported);
+            return scorer.getRandomVectorScorerSupplier(similarityFunction, mockValues);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -24,13 +24,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Verifies {@link KNN1040HalfFloatVectorScorer#getRandomVectorScorerSupplier} picks the decode-free
- * native SIMD tier when a native FP16 kernel exists for the similarity function and SIMD is
- * available, and otherwise falls back to {@link org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer}
- * - the same crash this class was written to avoid (see class javadoc). This guards against silently
- * regressing back to the slow/crashing fallback for spaces that should be using native SIMD.
- */
 public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
 
     private static final String NATIVE_TIER_CLASS_NAME = "HalfFloatRandomVectorScorerSupplier";
@@ -47,7 +40,7 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
 
     @SneakyThrows
     public void testGetRandomVectorScorerSupplier_cosine_neverUsesNativeTierRegardlessOfSimd() {
-        // No native FP16 kernel exists for COSINE at all - must fall back even when SIMD is available.
+        // No native FP16 kernel exists for COSINE yet so must fall back even when SIMD is available.
         assertFallbackTierUsed(VectorSimilarityFunction.COSINE, true);
         assertFallbackTierUsed(VectorSimilarityFunction.COSINE, false);
     }
@@ -57,12 +50,6 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
         assertFallbackTierUsed(VectorSimilarityFunction.EUCLIDEAN, false);
     }
 
-    // Deliberately never invokes .scorer()/.score(): SimdVectorComputeService's methods are declared
-    // `native`, and Mockito's mockStatic does not reliably intercept JNI-linked native methods in this
-    // environment - a version of this test that called .score() with a fake address crashed the JVM
-    // with a real SIGSEGV inside the native FP16 SIMD library instead of hitting the mock. Verifying
-    // via reflection that the address is threaded into the supplier (rather than discarded, as before
-    // this change) covers the actual behavior change without touching native code at all.
     @SneakyThrows
     public void testGetRandomVectorScorerSupplier_mmapAvailable_threadsAddressIntoSupplier() {
         final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
@@ -85,10 +72,6 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
         }
     }
 
-    // Same native-call safety note as above: setScoringOrdinal constructs a real HalfFloatRandomVectorScorer
-    // (a legitimate saveSearchContext call with a real target and an empty address array, matching the
-    // byte-copy tier's normal production behavior), but this test never calls .score()/.bulkScore(), so
-    // it never risks dereferencing anything.
     @SneakyThrows
     public void testGetRandomVectorScorerSupplier_scorerWrapsDelegateInPrefetchableScorer() {
         final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatVectorsFormatTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.util.concurrent.Executors;
+
+public class KNN1040HnswHalfFloatVectorsFormatTests extends KNNTestCase {
+
+    public void testDefaultConstructor() {
+        KNN1040HnswHalfFloatVectorsFormat format = new KNN1040HnswHalfFloatVectorsFormat();
+        assertNotNull(format);
+        assertEquals("KNN1040HnswHalfFloatVectorsFormat", format.getName());
+    }
+
+    public void testCustomConstructor() {
+        KNN1040HnswHalfFloatVectorsFormat format = new KNN1040HnswHalfFloatVectorsFormat(32, 200, 1, null);
+        assertNotNull(format);
+        assertEquals("KNN1040HnswHalfFloatVectorsFormat", format.getName());
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testGetMaxDimensions_returnsLuceneMax() {
+        KNN1040HnswHalfFloatVectorsFormat format = new KNN1040HnswHalfFloatVectorsFormat();
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testToString_containsParams() {
+        KNN1040HnswHalfFloatVectorsFormat format = new KNN1040HnswHalfFloatVectorsFormat(32, 200, 1, null);
+        String str = format.toString();
+        assertTrue(str.contains("KNN1040HnswHalfFloatVectorsFormat"));
+        assertTrue(str.contains("maxConn=32"));
+        assertTrue(str.contains("beamWidth=200"));
+        assertTrue(str.contains("KNN1040HalfFloatFlatVectorsFormat"));
+    }
+
+    public void testConstructor_invalidMaxConn_thenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new KNN1040HnswHalfFloatVectorsFormat(0, 100, 1, null));
+    }
+
+    public void testConstructor_invalidBeamWidth_thenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> new KNN1040HnswHalfFloatVectorsFormat(16, 0, 1, null));
+    }
+
+    public void testConstructor_singleWorkerWithExecutor_thenThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KNN1040HnswHalfFloatVectorsFormat(16, 100, 1, Executors.newFixedThreadPool(1))
+        );
+    }
+
+    public void testConstructor_whenCustomTinySegmentsThreshold_thenSucceeds() {
+        KNN1040HnswHalfFloatVectorsFormat format = new KNN1040HnswHalfFloatVectorsFormat(16, 100, 1, null, 500);
+        assertNotNull(format);
+        assertEquals("KNN1040HnswHalfFloatVectorsFormat", format.getName());
+    }
+
+    public void testConstructor_whenZeroTinySegmentsThreshold_thenSucceeds() {
+        KNN1040HnswHalfFloatVectorsFormat format = new KNN1040HnswHalfFloatVectorsFormat(16, 100, 1, null, 0);
+        assertNotNull(format);
+        assertEquals("KNN1040HnswHalfFloatVectorsFormat", format.getName());
+    }
+}


### PR DESCRIPTION
### Description
Adds the Lucene codec implementation for half_float (FP16) vector storage. `KNN1040HalfFloatFlatVectorsFormat`/`Reader`/`Writer`/`Values` for flat FP16 storage with a SIMD-accelerated scorer, `KNN1040HalfFloatVectorScorer` for bulk/single-vector scoring, and K`NN1040HnswHalfFloatVectorsFormat`, which reuses the flat format as its HNSW graph's backing storage so graph traversal inherits the same SIMD-accelerated scoring.

This PR is scoped to the codec layer only, it adds no calls into these classes from anywhere else in the plugin, so half_float is not yet reachable through any indexing or query path. Wiring `half_float` into the rest of the plugin is scoped to a follow-up PR.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
