### PR TITLE
[FP16 PR-2] Add FP16 Custom Writer

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
+ * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom
+ * {@link KNN1040HalfFloatFlatVectorsWriter} for storage of half-float vectors.
+ *
+ * <p>The reader side lands in a separate PR; {@link #fieldsReader} is a placeholder until then, so this
+ * format does not yet wrap the writer's scorer in the decode-free {@code KNN1040HalfFloatVectorScorer}
+ * that PR adds - there is nothing to read back yet.
+ */
+public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
+
+    static final String NAME = "KNN1040HalfFloatFlatVectorsFormat";
+    static final String META_CODEC_NAME = "KNN1040HalfFloatFlatVectorsFormatMeta";
+    static final String VECTOR_DATA_CODEC_NAME = "KNN1040HalfFloatFlatVectorsFormatData";
+    static final String META_EXTENSION = "vemf";
+    static final String VECTOR_DATA_EXTENSION = "vec";
+    static final int VERSION_START = 0;
+    static final int VERSION_CURRENT = VERSION_START;
+    static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+
+    private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new PrefetchableFlatVectorScorer(
+        new NativeEngines990KnnVectorsScorer(FlatVectorsScorerProvider.getLucene99FlatVectorsScorer())
+    );
+
+    public KNN1040HalfFloatFlatVectorsFormat() {
+        super(NAME);
+    }
+
+    @Override
+    public FlatVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new KNN1040HalfFloatFlatVectorsWriter(state, KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
+    }
+
+    @Override
+    public FlatVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        throw new UnsupportedOperationException("KNN1040HalfFloatFlatVectorsReader is not yet implemented");
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "%s(scorer=%s)", getClass().getSimpleName(), KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -23,10 +23,6 @@ import java.util.Locale;
  * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
  * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom
  * {@link KNN1040HalfFloatFlatVectorsWriter} for storage of half-float vectors.
- *
- * <p>The reader side lands in a separate PR; {@link #fieldsReader} is a placeholder until then, so this
- * format does not yet wrap the writer's scorer in the decode-free {@code KNN1040HalfFloatVectorScorer}
- * that PR adds - there is nothing to read back yet.
  */
 public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
@@ -14,7 +15,6 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
-import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -36,7 +36,7 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
     static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
 
     private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new PrefetchableFlatVectorScorer(
-        new NativeEngines990KnnVectorsScorer(FlatVectorsScorerProvider.getLucene99FlatVectorsScorer())
+        new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer())
     );
 
     public KNN1040HalfFloatFlatVectorsFormat() {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
@@ -41,12 +41,24 @@ import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVe
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT;
 
 /**
- * Writer for half-precision (FP16) flat vector fields. Encodes incoming FP32 vectors to FP16
- * (2 bytes per dimension) and writes them sequentially to a {@code .vec} file, with per-field
- * metadata stored in a {@code .vemf} file.
+ * Writer for half-precision (FP16) flat vector fields. Only {@link VectorEncoding#FLOAT32} fields
+ * are accepted; vector data goes to a {@code .vec} file (per-field metadata lives separately in
+ * {@code .vemf}), each with a standard Lucene codec header and checksum footer. Within {@code .vec},
+ * each field occupies its own contiguous, {@value #VECTOR_DATA_ALIGNMENT}-byte-aligned block (via
+ * {@link #alignOutput}, including before the first field), written back to back with no gaps.
+ * Vector order depends on the call: {@link #writeField} uses insertion order, {@link
+ * #writeSortingField} remaps to new-doc order first, and {@link #mergeOneFlatVectorField} writes
+ * final merged-segment order via {@link KnnVectorsWriter.MergedVectorValues#mergeFloatVectorValues}
+ * (dropping deletions, applying any index sort). Sparse fields get a trailing doc-id/ordinal
+ * mapping block from {@link OrdToDocDISIReaderConfiguration#writeStoredMeta} appended right after
+ * their vectors; dense and empty fields skip it.
  *
- * The on-disk layout follows the same structural pattern as Lucene's {@code Lucene99FlatVectorsWriter}:
- * Each float dimension is converted to IEEE 754 half-float and stored as 2 bytes in little-endian order.
+ * <p>Each 32-bit {@code float} is converted to a 16-bit IEEE 754 half-precision value and written
+ * as 2 bytes, little-endian, via {@link KNNVectorAsCollectionOfHalfFloatsSerializer#floatToByteArray}
+ * - so a {@code dimension}-length vector takes exactly {@code dimension * 2} bytes, half of
+ * FLOAT32's {@code dimension * 4}. The conversion runs through native SIMD when available
+ * ({@code SimdFp16.encodeFp32ToFp16}), falling back to the equivalent {@code Float.floatToFloat16}
+ * in pure Java; both produce identical bytes.
  */
 public class KNN1040HalfFloatFlatVectorsWriter extends FlatVectorsWriter {
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import org.apache.lucene.util.ArrayUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT;
+
+/**
+ * Writer for half-precision (FP16) flat vector fields. Encodes incoming FP32 vectors to FP16
+ * (2 bytes per dimension) and writes them sequentially to a {@code .vec} file, with per-field
+ * metadata stored in a {@code .vemf} file.
+ *
+ * The on-disk layout follows the same structural pattern as Lucene's {@code Lucene99FlatVectorsWriter}:
+ * Each float dimension is converted to IEEE 754 half-float and stored as 2 bytes in little-endian order.
+ */
+public class KNN1040HalfFloatFlatVectorsWriter extends FlatVectorsWriter {
+
+    private static final long SHALLOW_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(KNN1040HalfFloatFlatVectorsWriter.class);
+
+    private static final int VECTOR_DATA_ALIGNMENT = 64;
+
+    private final SegmentWriteState segmentWriteState;
+    private final IndexOutput meta;
+    private final IndexOutput vectorData;
+    private final List<FieldData> fields = new ArrayList<>();
+    private boolean finished;
+
+    private record FieldData(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo) {
+    }
+
+    /**
+     * Creates a new writer for FP16 flat vectors.
+     *
+     * @param state  the segment write state
+     * @param scorer the flat vectors scorer used for scoring during indexing
+     * @throws IOException if an I/O error occurs while creating output files
+     */
+    public KNN1040HalfFloatFlatVectorsWriter(SegmentWriteState state, FlatVectorsScorer scorer) throws IOException {
+        super(scorer);
+        this.segmentWriteState = state;
+
+        boolean success = false;
+        try {
+            String metaFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, META_EXTENSION);
+            String vectorDataFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, VECTOR_DATA_EXTENSION);
+
+            meta = state.directory.createOutput(metaFileName, state.context);
+            vectorData = state.directory.createOutput(vectorDataFileName, state.context);
+
+            CodecUtil.writeIndexHeader(meta, META_CODEC_NAME, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+            CodecUtil.writeIndexHeader(vectorData, VECTOR_DATA_CODEC_NAME, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    @Override
+    public FlatFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
+        checkFloat32Encoding(fieldInfo);
+        // NOTE: FlatFieldVectorsWriter has no public static create() method.
+        FlatFieldVectorsWriter<?> fieldWriter = new FloatFieldWriter(fieldInfo);
+        fields.add(new FieldData(fieldWriter, fieldInfo));
+        return fieldWriter;
+    }
+
+    private static void checkFloat32Encoding(FieldInfo fieldInfo) {
+        if (fieldInfo.getVectorEncoding() != VectorEncoding.FLOAT32) {
+            throw new IllegalArgumentException(
+                "FP16 flat format only supports FLOAT32 encoding, got ["
+                    + fieldInfo.getVectorEncoding()
+                    + "] for field ["
+                    + fieldInfo.name
+                    + "]"
+            );
+        }
+    }
+
+    /**
+     * Returns the aligned offset for a field's vector data, mirroring {@code
+     * Lucene99FlatVectorsWriter.alignOutput}. Needed because {@link #writeMeta} also writes
+     * ord-to-doc data into {@code .vec}, so a later field would otherwise start unaligned.
+     */
+    private static long alignOutput(IndexOutput output) throws IOException {
+        return output.alignFilePointer(VECTOR_DATA_ALIGNMENT);
+    }
+
+    @Override
+    public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+        for (FieldData field : fields) {
+            if (sortMap == null) {
+                writeField(field.fieldWriter(), field.fieldInfo(), maxDoc);
+            } else {
+                writeSortingField(field.fieldWriter(), field.fieldInfo(), maxDoc, sortMap);
+            }
+            field.fieldWriter().finish();
+        }
+    }
+
+    @Override
+    public void finish() throws IOException {
+        if (finished) {
+            throw new IllegalStateException("already finished");
+        }
+        finished = true;
+        if (meta != null) {
+            meta.writeInt(-1);
+            CodecUtil.writeFooter(meta);
+        }
+        if (vectorData != null) {
+            CodecUtil.writeFooter(vectorData);
+        }
+    }
+
+    @Override
+    public void mergeOneFlatVectorField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+        checkFloat32Encoding(fieldInfo);
+
+        // Delegates to MergedVectorValues so vectors come out in final merged-segment doc order,
+        // with deletions filtered and index sorting applied. A naive per-reader loop can't
+        // reproduce this order: under an index sort, each reader's docs are remapped to
+        // non-contiguous ids interleaved with other readers' docs in the merged segment, not laid
+        // out reader-by-reader.
+        final FloatVectorValues mergedValues = KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
+
+        final long vectorDataOffset = alignOutput(vectorData);
+        final DocsWithFieldSet docsWithField = writeVectorData(vectorData, mergedValues, fieldInfo.getVectorDimension());
+        final long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        writeMeta(fieldInfo, segmentWriteState.segmentInfo.maxDoc(), vectorDataOffset, vectorDataLength, docsWithField);
+    }
+
+    // Encodes vectors to FP16 and writes them, returning the documents that have a vector.
+    private static DocsWithFieldSet writeVectorData(IndexOutput output, FloatVectorValues values, int dimension) throws IOException {
+        final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        final DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+        final KnnVectorValues.DocIndexIterator iterator = values.iterator();
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+            final float[] vector = values.vectorValue(iterator.index());
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vector, outputBuffer, dimension);
+            output.writeBytes(outputBuffer, 0, outputBuffer.length);
+            docsWithField.add(doc);
+        }
+        return docsWithField;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long total = SHALLOW_RAM_BYTES_USED;
+        for (FieldData field : fields) {
+            total += field.fieldWriter().ramBytesUsed();
+        }
+        return total;
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(meta, vectorData);
+    }
+
+    private void writeField(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo, int maxDoc) throws IOException {
+        final int dimension = fieldInfo.getVectorDimension();
+        final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        @SuppressWarnings("unchecked")
+        final List<float[]> vectors = (List<float[]>) fieldWriter.getVectors();
+
+        final long vectorDataOffset = alignOutput(vectorData);
+        for (float[] vector : vectors) {
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vector, outputBuffer, dimension);
+            vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
+        }
+        final long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        writeMeta(fieldInfo, maxDoc, vectorDataOffset, vectorDataLength, fieldWriter.getDocsWithFieldSet());
+    }
+
+    private void writeSortingField(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo, int maxDoc, Sorter.DocMap sortMap)
+        throws IOException {
+        final int dimension = fieldInfo.getVectorDimension();
+        final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        @SuppressWarnings("unchecked")
+        final List<float[]> vectors = (List<float[]>) fieldWriter.getVectors();
+
+        final DocsWithFieldSet docsWithFieldSet = fieldWriter.getDocsWithFieldSet();
+        final int[] ordMap = new int[docsWithFieldSet.cardinality()]; // new ord to old ord
+        final DocsWithFieldSet newDocsWithField = new DocsWithFieldSet();
+        mapOldOrdToNewOrd(docsWithFieldSet, sortMap, null, ordMap, newDocsWithField);
+
+        final long vectorDataOffset = alignOutput(vectorData);
+        for (int ordinal : ordMap) {
+            final float[] vector = vectors.get(ordinal);
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vector, outputBuffer, dimension);
+            vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
+        }
+        final long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        writeMeta(fieldInfo, maxDoc, vectorDataOffset, vectorDataLength, newDocsWithField);
+    }
+
+    private void writeMeta(FieldInfo fieldInfo, int maxDoc, long vectorDataOffset, long vectorDataLength, DocsWithFieldSet docsWithField)
+        throws IOException {
+        meta.writeInt(fieldInfo.number);
+        meta.writeInt(fieldInfo.getVectorEncoding().ordinal());
+        meta.writeInt(fieldInfo.getVectorSimilarityFunction().ordinal());
+        meta.writeVLong(vectorDataOffset);
+        meta.writeVLong(vectorDataLength);
+        meta.writeVInt(fieldInfo.getVectorDimension());
+
+        // write docIDs
+        final int count = docsWithField.cardinality();
+        meta.writeInt(count);
+        OrdToDocDISIReaderConfiguration.writeStoredMeta(DIRECT_MONOTONIC_BLOCK_SHIFT, meta, vectorData, count, maxDoc, docsWithField);
+    }
+
+    /**
+     * Per-field writer that stores {@code float[]} on heap during indexing.
+     */
+    private static class FloatFieldWriter extends FlatFieldVectorsWriter<float[]> {
+        private static final long FIELD_WRITER_SHALLOW_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FloatFieldWriter.class);
+
+        private final FieldInfo fieldInfo;
+        private final List<float[]> vectors = new ArrayList<>();
+        private final DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+        private boolean finished;
+        private int lastDocID = -1;
+
+        FloatFieldWriter(FieldInfo fieldInfo) {
+            this.fieldInfo = fieldInfo;
+        }
+
+        @Override
+        public void addValue(int docID, float[] vectorValue) throws IOException {
+            if (finished) {
+                throw new IllegalStateException("already finished");
+            }
+            if (docID == lastDocID) {
+                throw new IllegalArgumentException("VectorValuesField \"" + fieldInfo.name + "\" appears more than once in this document");
+            }
+            docsWithField.add(docID);
+            vectors.add(copyValue(vectorValue));
+            lastDocID = docID;
+        }
+
+        @Override
+        public float[] copyValue(float[] value) {
+            return ArrayUtil.copyOfSubArray(value, 0, fieldInfo.getVectorDimension());
+        }
+
+        @Override
+        public List<float[]> getVectors() {
+            return vectors;
+        }
+
+        @Override
+        public DocsWithFieldSet getDocsWithFieldSet() {
+            return docsWithField;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            long size = FIELD_WRITER_SHALLOW_RAM_BYTES_USED;
+            if (vectors.isEmpty()) return size;
+            return size + docsWithField.ramBytesUsed() + (long) vectors.size() * (RamUsageEstimator.NUM_BYTES_OBJECT_REF
+                + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER) + (long) vectors.size() * fieldInfo.getVectorDimension() * fieldInfo
+                    .getVectorEncoding().byteSize;
+        }
+
+        @Override
+        public void finish() throws IOException {
+            finished = true;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return finished;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
@@ -210,6 +210,7 @@ public class KNN1040HalfFloatFlatVectorsWriter extends FlatVectorsWriter {
     private void writeField(FlatFieldVectorsWriter<?> fieldWriter, FieldInfo fieldInfo, int maxDoc) throws IOException {
         final int dimension = fieldInfo.getVectorDimension();
         final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        assert fieldWriter instanceof FloatFieldWriter;
         @SuppressWarnings("unchecked")
         final List<float[]> vectors = (List<float[]>) fieldWriter.getVectors();
 
@@ -227,6 +228,7 @@ public class KNN1040HalfFloatFlatVectorsWriter extends FlatVectorsWriter {
         throws IOException {
         final int dimension = fieldInfo.getVectorDimension();
         final byte[] outputBuffer = new byte[dimension * Short.BYTES];
+        assert fieldWriter instanceof FloatFieldWriter;
         @SuppressWarnings("unchecked")
         final List<float[]> vectors = (List<float[]>) fieldWriter.getVectors();
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests {@link KNN1040HalfFloatFlatVectorsWriter} in isolation, without going through
+ * {@link KNN1040HalfFloatFlatVectorsReader}. Correctness of the encoded bytes is verified by decoding
+ * them directly with {@link KNNVectorAsCollectionOfHalfFloatsSerializer} (a shared utility, not part of
+ * the writer/reader pair), rather than by reading the segment back through our own reader.
+ */
+public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_vector";
+    private static final int DIMENSION = 8;
+
+    @SneakyThrows
+    public void testAddField_returnsWorkingFieldWriter() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                FieldInfo fieldInfo = createFieldInfo();
+                FlatFieldVectorsWriter<?> fieldWriter = writer.addField(fieldInfo);
+                assertNotNull(fieldWriter);
+                assertTrue(fieldWriter.getVectors().isEmpty());
+                assertEquals(0, fieldWriter.getDocsWithFieldSet().cardinality());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testAddField_rejectsNonFloat32Encoding() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                FieldInfo byteEncodedField = createFieldInfo(VectorEncoding.BYTE, VectorSimilarityFunction.EUCLIDEAN);
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> writer.addField(byteEncodedField));
+                assertTrue(e.getMessage().contains("FLOAT32"));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldWriter_duplicateDocId_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                fieldWriter.addValue(0, new float[DIMENSION]);
+                IllegalArgumentException e = expectThrows(
+                    IllegalArgumentException.class,
+                    () -> fieldWriter.addValue(0, new float[DIMENSION])
+                );
+                assertTrue(e.getMessage().contains(FIELD_NAME));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldWriter_addValueAfterFinish_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                fieldWriter.finish();
+                assertTrue(fieldWriter.isFinished());
+                expectThrows(IllegalStateException.class, () -> fieldWriter.addValue(0, new float[DIMENSION]));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFinish_calledTwice_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                writer.finish();
+                expectThrows(IllegalStateException.class, writer::finish);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testRamBytesUsed_increasesAsVectorsAreAdded() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                long before = writer.ramBytesUsed();
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                for (int i = 0; i < 5; i++) {
+                    fieldWriter.addValue(i, generateVector());
+                }
+                long after = writer.ramBytesUsed();
+                assertTrue("ramBytesUsed should grow as vectors are added", after > before);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFlush_writesFilesWithExpectedNamesAndHeaders() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            String segmentSuffix = "";
+            FieldInfo fieldInfo = createFieldInfo();
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                fieldWriter.addValue(0, generateVector());
+                writer.flush(1, null);
+                writer.finish();
+            }
+
+            String metaFileName = IndexFileNames.segmentFileName("_0", segmentSuffix, KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION);
+            String vectorDataFileName = IndexFileNames.segmentFileName(
+                "_0",
+                segmentSuffix,
+                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION
+            );
+            assertTrue(java.util.Arrays.asList(dir.listAll()).contains(metaFileName));
+            assertTrue(java.util.Arrays.asList(dir.listAll()).contains(vectorDataFileName));
+
+            try (IndexInput metaInput = dir.openInput(metaFileName, IOContext.DEFAULT)) {
+                CodecUtil.checksumEntireFile(metaInput);
+            }
+            try (IndexInput vectorDataInput = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checksumEntireFile(vectorDataInput);
+            }
+        }
+    }
+
+    /**
+     * Decodes the written FP16 bytes directly with {@link KNNVectorAsCollectionOfHalfFloatsSerializer},
+     * independent of {@link KNN1040HalfFloatFlatVectorsReader}, to isolate encoding correctness in the
+     * writer from any bugs the reader might share or mask.
+     */
+    @SneakyThrows
+    public void testVectorDataBytes_decodeToExpectedFp16Values() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { generateVector(), generateVector(), generateVector() };
+            FieldInfo fieldInfo = createFieldInfo();
+            SegmentInfo segmentInfo = createSegmentInfo(dir, "_0");
+
+            try (FlatVectorsWriter writer = newWriter(dir, segmentInfo)) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                for (int i = 0; i < vectors.length; i++) {
+                    fieldWriter.addValue(i, vectors[i]);
+                }
+                writer.flush(vectors.length, null);
+                writer.finish();
+            }
+
+            String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+            try (IndexInput input = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checkIndexHeader(
+                    input,
+                    KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    segmentInfo.getId(),
+                    ""
+                );
+                // The writer 64-byte-aligns the start of each field's vector data (including the
+                // first), via IndexOutput#alignFilePointer - mirror that here before reading.
+                final int vectorDataAlignment = 64;
+                long aligned = ((input.getFilePointer() + vectorDataAlignment - 1) / vectorDataAlignment) * vectorDataAlignment;
+                input.seek(aligned);
+
+                int byteSize = DIMENSION * Short.BYTES;
+                byte[] raw = new byte[byteSize];
+                for (float[] expected : vectors) {
+                    input.readBytes(raw, 0, byteSize);
+                    float[] decoded = KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.byteToFloatArray(
+                        new org.apache.lucene.util.BytesRef(raw)
+                    );
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expectedFp16 = Float.float16ToFloat(Float.floatToFloat16(expected[d]));
+                        assertEquals(expectedFp16, decoded[d], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    private FlatVectorsWriter newWriter(Directory dir, String segmentName) throws Exception {
+        return newWriter(dir, createSegmentInfo(dir, segmentName));
+    }
+
+    private FlatVectorsWriter newWriter(Directory dir, SegmentInfo segmentInfo) throws Exception {
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { createFieldInfo() });
+        SegmentWriteState writeState = new SegmentWriteState(InfoStream.NO_OUTPUT, dir, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+        FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+        return new KNN1040HalfFloatFlatVectorsWriter(writeState, scorer);
+    }
+
+    private SegmentInfo createSegmentInfo(Directory dir, String segmentName) {
+        return new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            segmentName,
+            -1,
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            new HashMap<>(),
+            null
+        );
+    }
+
+    private FieldInfo createFieldInfo() {
+        return createFieldInfo(VectorEncoding.FLOAT32, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private FieldInfo createFieldInfo(VectorEncoding encoding, VectorSimilarityFunction similarity) {
+        return new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            DIMENSION,
+            encoding,
+            similarity,
+            false,
+            false
+        );
+    }
+
+    private float[] generateVector() {
+        float[] vector = new float[DIMENSION];
+        for (int d = 0; d < DIMENSION; d++) {
+            vector[d] = (random().nextFloat() * 2 - 1) * 10;
+        }
+        return vector;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
@@ -18,6 +18,7 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -204,6 +205,72 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
                     for (int d = 0; d < DIMENSION; d++) {
                         float expectedFp16 = Float.float16ToFloat(Float.floatToFloat16(expected[d]));
                         assertEquals(expectedFp16, decoded[d], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFlush_withSortMap_writesVectorsInNewDocOrder() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { generateVector(), generateVector(), generateVector() };
+            FieldInfo fieldInfo = createFieldInfo();
+            SegmentInfo segmentInfo = createSegmentInfo(dir, "_0");
+            // Reverses doc order: old doc i becomes new doc (vectors.length - 1 - i).
+            Sorter.DocMap sortMap = new Sorter.DocMap() {
+                @Override
+                public int oldToNew(int docID) {
+                    return vectors.length - 1 - docID;
+                }
+
+                @Override
+                public int newToOld(int docID) {
+                    return vectors.length - 1 - docID;
+                }
+
+                @Override
+                public int size() {
+                    return vectors.length;
+                }
+            };
+
+            try (FlatVectorsWriter writer = newWriter(dir, segmentInfo)) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                for (int i = 0; i < vectors.length; i++) {
+                    fieldWriter.addValue(i, vectors[i]);
+                }
+                writer.flush(vectors.length, sortMap);
+                writer.finish();
+            }
+
+            String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+            try (IndexInput input = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checkIndexHeader(
+                    input,
+                    KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    segmentInfo.getId(),
+                    ""
+                );
+                final int vectorDataAlignment = 64;
+                long aligned = ((input.getFilePointer() + vectorDataAlignment - 1) / vectorDataAlignment) * vectorDataAlignment;
+                input.seek(aligned);
+
+                int byteSize = DIMENSION * Short.BYTES;
+                byte[] raw = new byte[byteSize];
+                // New doc order is the reverse of vectors[]: expect vectors[2], vectors[1], vectors[0].
+                for (int newDoc = 0; newDoc < vectors.length; newDoc++) {
+                    input.readBytes(raw, 0, byteSize);
+                    float[] decoded = KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.byteToFloatArray(
+                        new org.apache.lucene.util.BytesRef(raw)
+                    );
+                    float[] expected = vectors[vectors.length - 1 - newDoc];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expectedFp16 = Float.float16ToFloat(Float.floatToFloat16(expected[d]));
+                        assertEquals("newDoc " + newDoc + " dim " + d, expectedFp16, decoded[d], 0.0f);
                     }
                 }
             }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
@@ -14,8 +15,10 @@ import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
@@ -23,14 +26,20 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
 import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import java.io.IOException;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -277,6 +286,241 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
         }
     }
 
+    // Forces the second createOutput() call (vectorData) to fail after the first (meta) already
+    // succeeded, exercising the constructor's `if (!success) IOUtils.closeWhileHandlingException(this)`
+    // cleanup path.
+    @SneakyThrows
+    public void testConstructor_directoryFailsCreatingVectorData_cleansUpAndPropagatesOriginalException() {
+        try (Directory baseDir = new ByteBuffersDirectory()) {
+            Directory failingDir = new FilterDirectory(baseDir) {
+                @Override
+                public IndexOutput createOutput(String name, IOContext context) throws IOException {
+                    if (name.endsWith(KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION)) {
+                        throw new IOException("simulated failure creating vector data output");
+                    }
+                    return super.createOutput(name, context);
+                }
+            };
+
+            SegmentInfo segmentInfo = createSegmentInfo(failingDir, "_0");
+            FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { createFieldInfo() });
+            SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                failingDir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
+            FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+
+            IOException e = expectThrows(IOException.class, () -> new KNN1040HalfFloatFlatVectorsWriter(writeState, scorer));
+            assertEquals("simulated failure creating vector data output", e.getMessage());
+        }
+    }
+
+    @SneakyThrows
+    public void testFlush_multipleFields_writesEachFieldWithCorrectAlignment() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            FieldInfo fieldInfo1 = createFieldInfo("field_one", 0);
+            FieldInfo fieldInfo2 = createFieldInfo("field_two", 1);
+            SegmentInfo segmentInfo = createSegmentInfo(dir, "_0");
+            FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo1, fieldInfo2 });
+            SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                dir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
+            FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+
+            float[][] vectors1 = { generateVector(), generateVector() };
+            float[][] vectors2 = { generateVector() };
+
+            try (FlatVectorsWriter writer = new KNN1040HalfFloatFlatVectorsWriter(writeState, scorer)) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter1 = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo1);
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter2 = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo2);
+                for (int i = 0; i < vectors1.length; i++) {
+                    fieldWriter1.addValue(i, vectors1[i]);
+                }
+                for (int i = 0; i < vectors2.length; i++) {
+                    fieldWriter2.addValue(i, vectors2[i]);
+                }
+                writer.flush(Math.max(vectors1.length, vectors2.length), null);
+                writer.finish();
+            }
+
+            String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+            try (IndexInput input = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checkIndexHeader(
+                    input,
+                    KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    segmentInfo.getId(),
+                    ""
+                );
+                int byteSize = DIMENSION * Short.BYTES;
+                byte[] raw = new byte[byteSize];
+
+                assertVectorsAtAlignedOffset(input, vectors1, raw, byteSize);
+                assertVectorsAtAlignedOffset(input, vectors2, raw, byteSize);
+            }
+        }
+    }
+
+    private void assertVectorsAtAlignedOffset(IndexInput input, float[][] vectors, byte[] raw, int byteSize) throws IOException {
+        final int vectorDataAlignment = 64;
+        long aligned = ((input.getFilePointer() + vectorDataAlignment - 1) / vectorDataAlignment) * vectorDataAlignment;
+        input.seek(aligned);
+        for (float[] expected : vectors) {
+            input.readBytes(raw, 0, byteSize);
+            float[] decoded = KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.byteToFloatArray(new BytesRef(raw));
+            for (int d = 0; d < DIMENSION; d++) {
+                float expectedFp16 = Float.float16ToFloat(Float.floatToFloat16(expected[d]));
+                assertEquals(expectedFp16, decoded[d], 0.0f);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldWriter_ramBytesUsed_emptyFieldReturnsShallowSizeOnly() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (FlatVectorsWriter writer = newWriter(dir, "_0")) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(createFieldInfo());
+                long empty = fieldWriter.ramBytesUsed();
+                assertTrue(empty > 0);
+
+                fieldWriter.addValue(0, generateVector());
+                assertTrue("adding a vector should grow past the empty-field shallow size", fieldWriter.ramBytesUsed() > empty);
+            }
+        }
+    }
+
+    /**
+     * Exercises {@code mergeOneFlatVectorField}, which delegates to
+     * {@code KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues} to combine several source
+     * readers' vectors in final merged-segment doc order. The source readers are hand-built (mocked
+     * {@link KnnVectorsReader}s backed by plain in-memory {@link FloatVectorValues}) rather than real
+     * {@code KNN1040HalfFloatFlatVectorsReader} instances, since the reader side isn't part of this PR.
+     */
+    @SneakyThrows
+    public void testMergeOneFlatVectorField_mergesVectorsFromMultipleSourceReadersInOrder() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] source1Vectors = { generateVector(), generateVector() };
+            float[][] source2Vectors = { generateVector() };
+
+            FieldInfo fieldInfo = createFieldInfo();
+            // maxDoc is set here directly since SegmentInfo#setMaxDoc is package-private to Lucene -
+            // the real merge machinery (MergeState's CodecReader-based constructor) calls it as it
+            // tallies docs across source readers; the raw-arrays constructor used below does not.
+            SegmentInfo segmentInfo = createSegmentInfo(dir, "_merged", source1Vectors.length + source2Vectors.length);
+            FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+            SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                dir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
+            FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+
+            KnnVectorsReader reader1 = Mockito.mock(KnnVectorsReader.class);
+            Mockito.when(reader1.getFloatVectorValues(FIELD_NAME)).thenReturn(wrapAsFloatVectorValues(source1Vectors));
+            KnnVectorsReader reader2 = Mockito.mock(KnnVectorsReader.class);
+            Mockito.when(reader2.getFloatVectorValues(FIELD_NAME)).thenReturn(wrapAsFloatVectorValues(source2Vectors));
+
+            // reader1's docs (0, 1) map straight through; reader2's single doc lands after them (doc 2)
+            // in the merged segment - a stand-in for however the real doc-remapping worked out.
+            MergeState.DocMap[] docMaps = { docID -> docID, docID -> source1Vectors.length + docID };
+
+            MergeState mergeState = new MergeState(
+                docMaps,
+                segmentInfo,
+                fieldInfos,
+                null,
+                null,
+                null,
+                null,
+                new FieldInfos[] { fieldInfos, fieldInfos },
+                new Bits[] { null, null },
+                null,
+                null,
+                new KnnVectorsReader[] { reader1, reader2 },
+                new int[] { source1Vectors.length, source2Vectors.length },
+                InfoStream.NO_OUTPUT,
+                null,
+                false,
+                null
+            );
+
+            try (FlatVectorsWriter writer = new KNN1040HalfFloatFlatVectorsWriter(writeState, scorer)) {
+                writer.mergeOneFlatVectorField(fieldInfo, mergeState);
+                writer.finish();
+            }
+
+            String vectorDataFileName = IndexFileNames.segmentFileName(
+                "_merged",
+                "",
+                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION
+            );
+            try (IndexInput input = dir.openInput(vectorDataFileName, IOContext.DEFAULT)) {
+                CodecUtil.checkIndexHeader(
+                    input,
+                    KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                    segmentInfo.getId(),
+                    ""
+                );
+                int byteSize = DIMENSION * Short.BYTES;
+                byte[] raw = new byte[byteSize];
+                float[][] expectedInOrder = { source1Vectors[0], source1Vectors[1], source2Vectors[0] };
+                assertVectorsAtAlignedOffset(input, expectedInOrder, raw, byteSize);
+            }
+        }
+    }
+
+    private FloatVectorValues wrapAsFloatVectorValues(float[][] vectors) {
+        return new FloatVectorValues() {
+            @Override
+            public int dimension() {
+                return DIMENSION;
+            }
+
+            @Override
+            public int size() {
+                return vectors.length;
+            }
+
+            @Override
+            public float[] vectorValue(int ord) {
+                return vectors[ord];
+            }
+
+            @Override
+            public FloatVectorValues copy() {
+                return this;
+            }
+
+            @Override
+            public VectorEncoding getEncoding() {
+                return VectorEncoding.FLOAT32;
+            }
+
+            @Override
+            public DocIndexIterator iterator() {
+                return createDenseIterator();
+            }
+        };
+    }
+
     private FlatVectorsWriter newWriter(Directory dir, String segmentName) throws Exception {
         return newWriter(dir, createSegmentInfo(dir, segmentName));
     }
@@ -289,12 +533,16 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
     }
 
     private SegmentInfo createSegmentInfo(Directory dir, String segmentName) {
+        return createSegmentInfo(dir, segmentName, -1);
+    }
+
+    private SegmentInfo createSegmentInfo(Directory dir, String segmentName, int maxDoc) {
         return new SegmentInfo(
             dir,
             Version.LATEST,
             Version.LATEST,
             segmentName,
-            -1,
+            maxDoc,
             false,
             false,
             null,
@@ -310,9 +558,17 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
     }
 
     private FieldInfo createFieldInfo(VectorEncoding encoding, VectorSimilarityFunction similarity) {
+        return createFieldInfo(FIELD_NAME, 0, encoding, similarity);
+    }
+
+    private FieldInfo createFieldInfo(String name, int number) {
+        return createFieldInfo(name, number, VectorEncoding.FLOAT32, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private FieldInfo createFieldInfo(String name, int number, VectorEncoding encoding, VectorSimilarityFunction similarity) {
         return new FieldInfo(
-            FIELD_NAME,
-            0,
+            name,
+            number,
             false,
             false,
             false,

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriterTests.java
@@ -320,6 +320,36 @@ public class KNN1040HalfFloatFlatVectorsWriterTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testConstructor_directoryFailsCreatingMeta_cleansUpAndPropagatesOriginalException() {
+        try (Directory baseDir = new ByteBuffersDirectory()) {
+            Directory failingDir = new FilterDirectory(baseDir) {
+                @Override
+                public IndexOutput createOutput(String name, IOContext context) throws IOException {
+                    if (name.endsWith(KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION)) {
+                        throw new IOException("simulated failure creating meta output");
+                    }
+                    return super.createOutput(name, context);
+                }
+            };
+
+            SegmentInfo segmentInfo = createSegmentInfo(failingDir, "_0");
+            FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { createFieldInfo() });
+            SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                failingDir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
+            FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+
+            IOException e = expectThrows(IOException.class, () -> new KNN1040HalfFloatFlatVectorsWriter(writeState, scorer));
+            assertEquals("simulated failure creating meta output", e.getMessage());
+        }
+    }
+
+    @SneakyThrows
     public void testFlush_multipleFields_writesEachFieldWithCorrectAlignment() {
         try (Directory dir = new ByteBuffersDirectory()) {
             FieldInfo fieldInfo1 = createFieldInfo("field_one", 0);


### PR DESCRIPTION
### Description
Adds the write path for FP16 half-float flat vector fields: `KNN1040HalfFloatFlatVectorsWriter`, which converts incoming FP32 vectors to FP16( 2 bytes/dimension) and writes them to a .vec file with per-field metadata in a .vemf file, following the same structural layout as Lucene's `Lucene99FlatVectorsWriter`. 

**Note:** `KNN1040HalfFloatFlatVectorsFormat#fieldsReader` is a temporary `UnsupportedOperationException` stub here, replaced with the real reader once the companion writer PR merges, so this PR can be reviewed and merged independently of it. The two will be wired together in the follow-up FP16 Flat and HNSW formats PR. The tests for the Format will be added in the follow-up PR.

### Related Issues
Resolves #3438 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
