### PR TITLE
[FP16 PR-3] Add FP16 Custom Reader and Scorer

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -13,6 +13,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -34,6 +35,7 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
     static final int VERSION_START = 0;
     static final int VERSION_CURRENT = VERSION_START;
     static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+    static final int BULK_SCORE_BATCH_SIZE = 64;
 
     private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new KNN1040HalfFloatVectorScorer(
         new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 
 /**
  * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
- * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom {@link KNN1040HalfFloatFlatVectorsWriter}
+ * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom KNN1040HalfFloatFlatVectorsWriter
  * and {@link KNN1040HalfFloatFlatVectorsReader} for storage and retrieval of half-float vectors.
  */
 public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -21,8 +21,8 @@ import java.util.Locale;
 
 /**
  * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
- * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom
- * {@link KNN1040HalfFloatFlatVectorsWriter} for storage of half-float vectors.
+ * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom {@link KNN1040HalfFloatFlatVectorsWriter}
+ * and {@link KNN1040HalfFloatFlatVectorsReader} for storage and retrieval of half-float vectors.
  */
 public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
 
@@ -35,8 +35,8 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
     static final int VERSION_CURRENT = VERSION_START;
     static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
 
-    private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new PrefetchableFlatVectorScorer(
-        new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer())
+    private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new KNN1040HalfFloatVectorScorer(
+        new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))
     );
 
     public KNN1040HalfFloatFlatVectorsFormat() {
@@ -50,7 +50,7 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
 
     @Override
     public FlatVectorsReader fieldsReader(SegmentReadState state) throws IOException {
-        throw new UnsupportedOperationException("KNN1040HalfFloatFlatVectorsReader is not yet implemented");
+        return new KNN1040HalfFloatFlatVectorsReader(state, KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -36,8 +36,8 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
     static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
     static final int BULK_SCORE_BATCH_SIZE = 64;
 
-    private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new KNN1040HalfFloatVectorScorer(
-        new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))
+    private static final FlatVectorsScorer KNN_1040_HALF_FLOAT_FLAT_VECTORS_SCORER = new PrefetchableFlatVectorScorer(
+        new KNN1040HalfFloatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))
     );
 
     public KNN1040HalfFloatFlatVectorsFormat() {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -13,7 +13,6 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
-import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -22,7 +21,7 @@ import java.util.Locale;
 
 /**
  * Custom {@link FlatVectorsFormat} implementation to support half-float vectors. This class is mostly identical to
- * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom KNN1040HalfFloatFlatVectorsWriter
+ * {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}, however we use the custom {@link KNN1040HalfFloatFlatVectorsWriter}
  * and {@link KNN1040HalfFloatFlatVectorsReader} for storage and retrieval of half-float vectors.
  */
 public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -40,10 +40,12 @@ import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.BULK_SCORE_BATCH_SIZE;
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION;
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME;
@@ -63,7 +65,6 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(KNN1040HalfFloatFlatVectorsReader.class);
 
-    private static final int BULK_SCORE_BATCH_SIZE = 64;
     private static final String VECTOR_VALUES_SLICE = "KNN1040HalfFloatFlatVectorsValuesSlice";
 
     private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
@@ -119,7 +120,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
             );
             if (versionMeta != versionVectorData) {
                 throw new CorruptIndexException(
-                    "Format versions mismatch: meta=" + versionMeta + ", " + codecName + "=" + versionVectorData,
+                    String.format(Locale.ROOT, "Format versions mismatch: meta=%d, %s=%d", versionMeta, codecName, versionVectorData),
                     in
                 );
             }
@@ -180,7 +181,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
     private static VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
         int i = input.readInt();
         if (i < 0 || i >= SIMILARITY_FUNCTIONS.size()) {
-            throw new IllegalArgumentException("invalid distance function: " + i);
+            throw new CorruptIndexException("invalid distance function: " + i, input);
         }
         return SIMILARITY_FUNCTIONS.get(i);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.internal.hppc.IntObjectHashMap;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.DataAccessHint;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.FileDataHint;
+import org.apache.lucene.store.FileTypeHint;
+import org.apache.lucene.store.IOContext.FileOpenHint;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT;
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.VERSION_START;
+
+/**
+ * Reader for half-precision (FP16) flat vector fields, reading vectors from {@code .vec} and
+ * per-field metadata from {@code .vemf}.
+ *
+ * With mmap and a native SIMD type, scoring goes through {@code NativeEngines990KnnVectorsScorer}
+ * and {@code NativeRandomVectorScorer}; otherwise {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer}.
+ */
+@Log4j2
+public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
+
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(KNN1040HalfFloatFlatVectorsReader.class);
+
+    private static final int BULK_SCORE_BATCH_SIZE = 64;
+    private static final String VECTOR_VALUES_SLICE = "KNN1040HalfFloatFlatVectorsValuesSlice";
+
+    private final IntObjectHashMap<FieldEntry> fields = new IntObjectHashMap<>();
+    private final IndexInput vectorData;
+    private final FieldInfos fieldInfos;
+    private final FlatVectorsScorer scorer;
+    private final IOContext dataContext;
+
+    public KNN1040HalfFloatFlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer) throws IOException {
+        this(state, scorer, DataAccessHint.RANDOM);
+    }
+
+    public KNN1040HalfFloatFlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer, DataAccessHint accessHint)
+        throws IOException {
+        super();
+        this.scorer = scorer;
+        this.fieldInfos = state.fieldInfos;
+        final FileOpenHint[] hints = Stream.of(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint)
+            .filter(Objects::nonNull)
+            .toArray(FileOpenHint[]::new);
+        this.dataContext = state.context.withHints(hints);
+
+        boolean success = false;
+        try {
+            int versionMeta = readMetadata(state);
+            vectorData = openDataInput(state, versionMeta, VECTOR_DATA_EXTENSION, VECTOR_DATA_CODEC_NAME, dataContext);
+            success = true;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    private static IndexInput openDataInput(
+        SegmentReadState state,
+        int versionMeta,
+        String fileExtension,
+        String codecName,
+        IOContext context
+    ) throws IOException {
+        String fileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
+        IndexInput in = state.directory.openInput(fileName, context);
+        boolean success = false;
+        try {
+            int versionVectorData = CodecUtil.checkIndexHeader(
+                in,
+                codecName,
+                VERSION_START,
+                VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            if (versionMeta != versionVectorData) {
+                throw new CorruptIndexException(
+                    "Format versions mismatch: meta=" + versionMeta + ", " + codecName + "=" + versionVectorData,
+                    in
+                );
+            }
+            CodecUtil.retrieveChecksum(in);
+            success = true;
+            return in;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(in);
+            }
+        }
+    }
+
+    private int readMetadata(SegmentReadState state) throws IOException {
+        String metaFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, META_EXTENSION);
+        int versionMeta;
+        try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName)) {
+            Throwable priorE = null;
+            try {
+                versionMeta = CodecUtil.checkIndexHeader(
+                    meta,
+                    META_CODEC_NAME,
+                    VERSION_START,
+                    VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                readFields(meta);
+            } catch (Throwable t) {
+                priorE = t;
+                throw t;
+            } finally {
+                CodecUtil.checkFooter(meta, priorE);
+            }
+        }
+        return versionMeta;
+    }
+
+    private void readFields(ChecksumIndexInput meta) throws IOException {
+        for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
+            FieldInfo info = fieldInfos.fieldInfo(fieldNumber);
+            if (info == null) {
+                throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
+            }
+            fields.put(info.number, FieldEntry.create(meta, info));
+        }
+    }
+
+    // Order must match Lucene94FieldInfosFormat#SIMILARITY_FUNCTIONS; listed explicitly so the
+    // on-disk ordinal does not depend on VectorSimilarityFunction's declaration order.
+    private static final List<VectorSimilarityFunction> SIMILARITY_FUNCTIONS = List.of(
+        VectorSimilarityFunction.EUCLIDEAN,
+        VectorSimilarityFunction.DOT_PRODUCT,
+        VectorSimilarityFunction.COSINE,
+        VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+    );
+
+    private static VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
+        int i = input.readInt();
+        if (i < 0 || i >= SIMILARITY_FUNCTIONS.size()) {
+            throw new IllegalArgumentException("invalid distance function: " + i);
+        }
+        return SIMILARITY_FUNCTIONS.get(i);
+    }
+
+    private static VectorEncoding readVectorEncoding(DataInput input) throws IOException {
+        int encodingId = input.readInt();
+        if (encodingId < 0 || encodingId >= VectorEncoding.values().length) {
+            throw new CorruptIndexException("Invalid vector encoding id: " + encodingId, input);
+        }
+        return VectorEncoding.values()[encodingId];
+    }
+
+    private FieldEntry getFieldEntryOrThrow(String field) {
+        final FieldInfo info = fieldInfos.fieldInfo(field);
+        final FieldEntry entry;
+        if (info == null || (entry = fields.get(info.number)) == null) {
+            throw new IllegalArgumentException("field=\"" + field + "\" not found");
+        }
+        return entry;
+    }
+
+    private FieldEntry getFieldEntry(String field, VectorEncoding expectedEncoding) {
+        final FieldEntry fieldEntry = getFieldEntryOrThrow(field);
+        if (fieldEntry.vectorEncoding != expectedEncoding) {
+            throw new IllegalArgumentException(
+                "field=\"" + field + "\" is encoded as: " + fieldEntry.vectorEncoding + " expected: " + expectedEncoding
+            );
+        }
+        return fieldEntry;
+    }
+
+    /**
+     * Builds a fresh {@link KNN1040HalfFloatFlatVectorsValues} over {@code entry}'s slice of the
+     * {@code .vec} file.
+     */
+    private KNN1040HalfFloatFlatVectorsValues newVectorValues(FieldEntry entry) throws IOException {
+        IndexInput slice = vectorData.slice(VECTOR_VALUES_SLICE, entry.vectorDataOffset, entry.vectorDataLength);
+        DirectMonotonicReader ordToDocReader = entry.ordToDoc.isDense() ? null : entry.ordToDoc.getDirectMonotonicReader(vectorData);
+        return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, scorer, entry.similarity);
+    }
+
+    @Override
+    public FloatVectorValues getFloatVectorValues(String field) throws IOException {
+        final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
+        KNN1040HalfFloatFlatVectorsValues base = newVectorValues(entry);
+        long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(base.getSlice(), 0, base.getSlice().length());
+        return addressAndSize != null ? new MMapFloatVectorValues(base, addressAndSize) : base;
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(String field, float[] target) throws IOException {
+        final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
+        KNN1040HalfFloatFlatVectorsValues base = newVectorValues(entry);
+        // Empty segment: search() relies on a null scorer to mean "nothing to collect".
+        if (base.size() == 0) {
+            return null;
+        }
+        return KNN1040HalfFloatFlatVectorsValues.selectScorer(base, target, entry.similarity);
+    }
+
+    // Exhaustive brute-force search over all FP16 vectors, scoring ords in batches.
+    @Override
+    public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        RandomVectorScorer randomScorer = getRandomVectorScorer(field, target);
+        if (randomScorer == null) {
+            return;
+        }
+
+        int numVectors = randomScorer.maxOrd();
+        if (numVectors == 0 || knnCollector.k() == 0) {
+            return;
+        }
+
+        final Bits acceptedOrds = randomScorer.getAcceptOrds(acceptDocs.bits());
+        int[] ords = new int[BULK_SCORE_BATCH_SIZE];
+        float[] scores = new float[BULK_SCORE_BATCH_SIZE];
+        int numOrds = 0;
+
+        for (int i = 0; i < numVectors; i++) {
+            if (knnCollector.earlyTerminated()) {
+                break;
+            }
+            if (acceptedOrds == null || acceptedOrds.get(i)) {
+                ords[numOrds++] = i;
+                if (numOrds == BULK_SCORE_BATCH_SIZE) {
+                    collectBatch(randomScorer, knnCollector, ords, scores, numOrds);
+                    numOrds = 0;
+                }
+            }
+        }
+
+        if (numOrds > 0) {
+            collectBatch(randomScorer, knnCollector, ords, scores, numOrds);
+        }
+    }
+
+    private void collectBatch(RandomVectorScorer scorer, KnnCollector knnCollector, int[] ords, float[] scores, int numOrds)
+        throws IOException {
+        knnCollector.incVisitedCount(numOrds);
+        if (scorer.bulkScore(ords, scores, numOrds) > knnCollector.minCompetitiveSimilarity()) {
+            for (int j = 0; j < numOrds; j++) {
+                knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+            }
+        }
+    }
+
+    @Override
+    public ByteVectorValues getByteVectorValues(String field) throws IOException {
+        throw new UnsupportedOperationException("FP16 format does not support byte vectors");
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(String field, byte[] target) throws IOException {
+        throw new UnsupportedOperationException("FP16 format does not support byte vector scoring");
+    }
+
+    @Override
+    public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+        return scorer;
+    }
+
+    @Override
+    public FlatVectorsReader getMergeInstance() throws IOException {
+        vectorData.updateIOContext(dataContext.withHints(DataAccessHint.SEQUENTIAL));
+        return this;
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        CodecUtil.checksumEntireFile(vectorData);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return KNN1040HalfFloatFlatVectorsReader.SHALLOW_SIZE + fields.ramBytesUsed();
+    }
+
+    @Override
+    public Map<String, Long> getOffHeapByteSize(FieldInfo fieldInfo) {
+        final FieldEntry entry = getFieldEntryOrThrow(fieldInfo.name);
+        return Map.of(VECTOR_DATA_EXTENSION, entry.vectorDataLength());
+    }
+
+    @Override
+    public void finishMerge() throws IOException {
+        // Revert the sequential access hint applied by getMergeInstance().
+        vectorData.updateIOContext(dataContext);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(vectorData);
+    }
+
+    private record FieldEntry(VectorSimilarityFunction similarity, VectorEncoding vectorEncoding, long vectorDataOffset,
+        long vectorDataLength, int dimension, int size, OrdToDocDISIReaderConfiguration ordToDoc, FieldInfo info) {
+
+        FieldEntry {
+            if (vectorEncoding != VectorEncoding.FLOAT32) {
+                throw new IllegalStateException(
+                    "Unexpected vector encoding for field=\"" + info.name + "\"; expected FLOAT32, got " + vectorEncoding
+                );
+            }
+            if (similarity != info.getVectorSimilarityFunction()) {
+                throw new IllegalStateException(
+                    "Inconsistent vector similarity function for field=\""
+                        + info.name
+                        + "\"; "
+                        + similarity
+                        + " != "
+                        + info.getVectorSimilarityFunction()
+                );
+            }
+            int infoVectorDimension = info.getVectorDimension();
+            if (infoVectorDimension != dimension) {
+                throw new IllegalStateException(
+                    "Inconsistent vector dimension for field=\"" + info.name + "\"; " + infoVectorDimension + " != " + dimension
+                );
+            }
+
+            // FP16: 2 bytes per dimension, where Lucene's flat format uses encoding.byteSize.
+            final int byteSize = Short.BYTES;
+            long vectorBytes = Math.multiplyExact((long) infoVectorDimension, byteSize);
+            long numBytes = Math.multiplyExact(vectorBytes, size);
+            if (numBytes != vectorDataLength) {
+                throw new IllegalStateException(
+                    "Vector data length "
+                        + vectorDataLength
+                        + " not matching size="
+                        + size
+                        + " * dim="
+                        + dimension
+                        + " * byteSize="
+                        + byteSize
+                        + " = "
+                        + numBytes
+                );
+            }
+        }
+
+        static FieldEntry create(IndexInput input, FieldInfo info) throws IOException {
+            final VectorEncoding vectorEncoding = readVectorEncoding(input);
+            final VectorSimilarityFunction similarityFunction = readSimilarityFunction(input);
+            final var vectorDataOffset = input.readVLong();
+            final var vectorDataLength = input.readVLong();
+            final var dimension = input.readVInt();
+            final var size = input.readInt();
+            final var ordToDoc = OrdToDocDISIReaderConfiguration.fromStoredMeta(input, size);
+            return new FieldEntry(similarityFunction, vectorEncoding, vectorDataOffset, vectorDataLength, dimension, size, ordToDoc, info);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -39,10 +39,8 @@ import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.io.IOException;
-import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.BULK_SCORE_BATCH_SIZE;
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
@@ -172,26 +170,6 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         }
     }
 
-    // A whitelist, not a decode table: readSimilarityFunction decodes via VectorSimilarityFunction
-    // .values()[i] directly (the same ordinal the writer persists), then checks membership here so an
-    // ordinal for a similarity function this codec hasn't validated FP16 scoring for is rejected
-    // instead of silently accepted.
-    private static final Set<VectorSimilarityFunction> SUPPORTED_SIMILARITY_FUNCTIONS = EnumSet.of(
-        VectorSimilarityFunction.EUCLIDEAN,
-        VectorSimilarityFunction.DOT_PRODUCT,
-        VectorSimilarityFunction.COSINE,
-        VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-    );
-
-    private static VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
-        int i = input.readInt();
-        VectorSimilarityFunction[] values = VectorSimilarityFunction.values();
-        if (i < 0 || i >= values.length || !SUPPORTED_SIMILARITY_FUNCTIONS.contains(values[i])) {
-            throw new CorruptIndexException("invalid distance function: " + i, input);
-        }
-        return values[i];
-    }
-
     private static VectorEncoding readVectorEncoding(DataInput input) throws IOException {
         int encodingId = input.readInt();
         if (encodingId < 0 || encodingId >= VectorEncoding.values().length) {
@@ -227,7 +205,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         IndexInput slice = vectorData.slice(VECTOR_VALUES_SLICE, entry.vectorDataOffset, entry.vectorDataLength);
         boolean needsOrdToDocReader = entry.ordToDoc.isDense() == false && entry.ordToDoc.isEmpty() == false;
         DirectMonotonicReader ordToDocReader = needsOrdToDocReader ? entry.ordToDoc.getDirectMonotonicReader(vectorData) : null;
-        return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, entry.similarity);
+        return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, entry.similarity());
     }
 
     @Override
@@ -238,6 +216,8 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         return addressAndSize != null ? new MMapFloatVectorValues(base, addressAndSize) : base;
     }
 
+    // Flat/exhaustive search only (see #search below) - HNSW graph traversal never calls this,
+    // it goes through getFlatVectorScorer's supplier instead.
     @Override
     public RandomVectorScorer getRandomVectorScorer(String field, float[] target) throws IOException {
         final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
@@ -245,7 +225,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         if (base.size() == 0) {
             return null;
         }
-        return KNN1040HalfFloatFlatVectorsValues.selectScorer(base, target, entry.similarity);
+        return KNN1040HalfFloatFlatVectorsValues.selectScorer(base, target, entry.similarity());
     }
 
     // Exhaustive brute-force search over all FP16 vectors, scoring ords in batches.
@@ -304,6 +284,8 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         throw new UnsupportedOperationException("FP16 format does not support byte vector scoring");
     }
 
+    // Consumed only by Lucene's own HNSW graph build/search machinery (via its supplier);
+    // flat/exhaustive search above never calls this, it uses selectScorer directly.
     @Override
     public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
         getFieldEntryOrThrow(field);
@@ -342,23 +324,17 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         IOUtils.close(vectorData);
     }
 
-    private record FieldEntry(VectorSimilarityFunction similarity, VectorEncoding vectorEncoding, long vectorDataOffset,
-        long vectorDataLength, int dimension, int size, OrdToDocDISIReaderConfiguration ordToDoc, FieldInfo info) {
+    private record FieldEntry(VectorEncoding vectorEncoding, long vectorDataOffset, long vectorDataLength, int dimension, int size,
+        OrdToDocDISIReaderConfiguration ordToDoc, FieldInfo info) {
+
+        VectorSimilarityFunction similarity() {
+            return info.getVectorSimilarityFunction();
+        }
 
         FieldEntry {
             if (vectorEncoding != VectorEncoding.FLOAT32) {
                 throw new IllegalStateException(
                     "Unexpected vector encoding for field=\"" + info.name + "\"; expected FLOAT32, got " + vectorEncoding
-                );
-            }
-            if (similarity != info.getVectorSimilarityFunction()) {
-                throw new IllegalStateException(
-                    "Inconsistent vector similarity function for field=\""
-                        + info.name
-                        + "\"; "
-                        + similarity
-                        + " != "
-                        + info.getVectorSimilarityFunction()
                 );
             }
             int infoVectorDimension = info.getVectorDimension();
@@ -389,13 +365,12 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
 
         static FieldEntry create(IndexInput input, FieldInfo info) throws IOException {
             final VectorEncoding vectorEncoding = readVectorEncoding(input);
-            final VectorSimilarityFunction similarityFunction = readSimilarityFunction(input);
             final var vectorDataOffset = input.readVLong();
             final var vectorDataLength = input.readVLong();
             final var dimension = input.readVInt();
             final var size = input.readInt();
             final var ordToDoc = OrdToDocDISIReaderConfiguration.fromStoredMeta(input, size);
-            return new FieldEntry(similarityFunction, vectorEncoding, vectorDataOffset, vectorDataLength, dimension, size, ordToDoc, info);
+            return new FieldEntry(vectorEncoding, vectorDataOffset, vectorDataLength, dimension, size, ordToDoc, info);
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -42,8 +42,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.BULK_SCORE_BATCH_SIZE;
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
@@ -77,15 +75,18 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         this(state, scorer, DataAccessHint.RANDOM);
     }
 
+    private static FileOpenHint[] buildFileOpenHints(DataAccessHint accessHint) {
+        return accessHint == null
+            ? new FileOpenHint[] { FileTypeHint.DATA, FileDataHint.KNN_VECTORS }
+            : new FileOpenHint[] { FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint };
+    }
+
     public KNN1040HalfFloatFlatVectorsReader(SegmentReadState state, FlatVectorsScorer scorer, DataAccessHint accessHint)
         throws IOException {
         super();
         this.scorer = scorer;
         this.fieldInfos = state.fieldInfos;
-        final FileOpenHint[] hints = Stream.of(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, accessHint)
-            .filter(Objects::nonNull)
-            .toArray(FileOpenHint[]::new);
-        this.dataContext = state.context.withHints(hints);
+        this.dataContext = state.context.withHints(buildFileOpenHints(accessHint));
 
         boolean success = false;
         try {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -218,7 +218,8 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
      */
     private KNN1040HalfFloatFlatVectorsValues newVectorValues(FieldEntry entry) throws IOException {
         IndexInput slice = vectorData.slice(VECTOR_VALUES_SLICE, entry.vectorDataOffset, entry.vectorDataLength);
-        DirectMonotonicReader ordToDocReader = entry.ordToDoc.isDense() ? null : entry.ordToDoc.getDirectMonotonicReader(vectorData);
+        boolean needsOrdToDocReader = entry.ordToDoc.isDense() == false && entry.ordToDoc.isEmpty() == false;
+        DirectMonotonicReader ordToDocReader = needsOrdToDocReader ? entry.ordToDoc.getDirectMonotonicReader(vectorData) : null;
         return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, scorer, entry.similarity);
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -55,8 +55,9 @@ import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVe
  * Reader for half-precision (FP16) flat vector fields, reading vectors from {@code .vec} and
  * per-field metadata from {@code .vemf}.
  *
- * With mmap and a native SIMD type, scoring goes through {@code NativeEngines990KnnVectorsScorer}
- * and {@code NativeRandomVectorScorer}; otherwise {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer}.
+ * Scoring is selected by {@link KNN1040HalfFloatFlatVectorsValues#selectScorer}: native SIMD
+ * (mmap zero-copy when available, else a heap-buffer copy) when the similarity has a native type,
+ * otherwise a plain Java fallback.
  */
 @Log4j2
 public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
@@ -222,7 +223,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         IndexInput slice = vectorData.slice(VECTOR_VALUES_SLICE, entry.vectorDataOffset, entry.vectorDataLength);
         boolean needsOrdToDocReader = entry.ordToDoc.isDense() == false && entry.ordToDoc.isEmpty() == false;
         DirectMonotonicReader ordToDocReader = needsOrdToDocReader ? entry.ordToDoc.getDirectMonotonicReader(vectorData) : null;
-        return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, scorer, entry.similarity);
+        return new KNN1040HalfFloatFlatVectorsValues(entry.dimension, entry.size, slice, ordToDocReader, entry.similarity);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -39,9 +39,10 @@ import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.BULK_SCORE_BATCH_SIZE;
 import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME;
@@ -171,9 +172,11 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         }
     }
 
-    // Order must match Lucene94FieldInfosFormat#SIMILARITY_FUNCTIONS; listed explicitly so the
-    // on-disk ordinal does not depend on VectorSimilarityFunction's declaration order.
-    private static final List<VectorSimilarityFunction> SIMILARITY_FUNCTIONS = List.of(
+    // A whitelist, not a decode table: readSimilarityFunction decodes via VectorSimilarityFunction
+    // .values()[i] directly (the same ordinal the writer persists), then checks membership here so an
+    // ordinal for a similarity function this codec hasn't validated FP16 scoring for is rejected
+    // instead of silently accepted.
+    private static final Set<VectorSimilarityFunction> SUPPORTED_SIMILARITY_FUNCTIONS = EnumSet.of(
         VectorSimilarityFunction.EUCLIDEAN,
         VectorSimilarityFunction.DOT_PRODUCT,
         VectorSimilarityFunction.COSINE,
@@ -182,10 +185,11 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
 
     private static VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
         int i = input.readInt();
-        if (i < 0 || i >= SIMILARITY_FUNCTIONS.size()) {
+        VectorSimilarityFunction[] values = VectorSimilarityFunction.values();
+        if (i < 0 || i >= values.length || !SUPPORTED_SIMILARITY_FUNCTIONS.contains(values[i])) {
             throw new CorruptIndexException("invalid distance function: " + i, input);
         }
-        return SIMILARITY_FUNCTIONS.get(i);
+        return values[i];
     }
 
     private static VectorEncoding readVectorEncoding(DataInput input) throws IOException {
@@ -302,6 +306,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
 
     @Override
     public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+        getFieldEntryOrThrow(field);
         return scorer;
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -234,7 +234,6 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
     public RandomVectorScorer getRandomVectorScorer(String field, float[] target) throws IOException {
         final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
         KNN1040HalfFloatFlatVectorsValues base = newVectorValues(entry);
-        // Empty segment: search() relies on a null scorer to mean "nothing to collect".
         if (base.size() == 0) {
             return null;
         }
@@ -326,7 +325,6 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
 
     @Override
     public void finishMerge() throws IOException {
-        // Revert the sequential access hint applied by getMergeInstance().
         vectorData.updateIOContext(dataContext);
     }
 
@@ -361,7 +359,6 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
                 );
             }
 
-            // FP16: 2 bytes per dimension, where Lucene's flat format uses encoding.byteSize.
             final int byteSize = Short.BYTES;
             long vectorBytes = Math.multiplyExact((long) infoVectorDimension, byteSize);
             long numBytes = Math.multiplyExact(vectorBytes, size);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReader.java
@@ -213,7 +213,7 @@ public class KNN1040HalfFloatFlatVectorsReader extends FlatVectorsReader {
         final FieldEntry entry = getFieldEntry(field, VectorEncoding.FLOAT32);
         KNN1040HalfFloatFlatVectorsValues base = newVectorValues(entry);
         long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(base.getSlice(), 0, base.getSlice().length());
-        return addressAndSize != null ? new MMapFloatVectorValues(base, addressAndSize) : base;
+        return addressAndSize != null && addressAndSize.length > 0 ? new MMapFloatVectorValues(base, addressAndSize) : base;
     }
 
     // Flat/exhaustive search only (see #search below) - HNSW graph traversal never calls this,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  *
  * Implements {@link HasIndexSlice} so that {@link org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues}
  * can expose the underlying slice for I/O prefetching. Callers must not hand an instance of this
- * class directly to Lucene's own flat vector scorer factoryß ({@code Lucene99FlatVectorsScorer}):
+ * class directly to Lucene's own flat vector scorer factory ({@code Lucene99FlatVectorsScorer}):
  * that factory independently detects {@code HasIndexSlice} and reads the raw slice assuming
  * 4 bytes/dimension (float32), which silently overreads past the buffer on this FP16 (2 bytes/dimension)
  * data. Use {@link #selectFallbackScorer(KNN1040HalfFloatFlatVectorsValues, float[], VectorSimilarityFunction)}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  *
  * Implements {@link HasIndexSlice} so that {@link org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues}
  * can expose the underlying slice for I/O prefetching. Callers must not hand an instance of this
- * class directly to Lucene's own flat vector scorer factory ({@code Lucene99FlatVectorsScorer}):
+ * class directly to Lucene's own flat vector scorer factoryß ({@code Lucene99FlatVectorsScorer}):
  * that factory independently detects {@code HasIndexSlice} and reads the raw slice assuming
  * 4 bytes/dimension (float32), which silently overreads past the buffer on this FP16 (2 bytes/dimension)
  * data. Use {@link #selectFallbackScorer(KNN1040HalfFloatFlatVectorsValues, float[], VectorSimilarityFunction)}
@@ -167,13 +167,10 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
         );
         SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
         if (addressAndSize != null && nativeType != null) {
-            // Safe only with both mmap and a native type: the chain then builds
-            // NativeRandomVectorScorer directly and never reaches Lucene's delegate.
             MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(values, addressAndSize);
             return values.flatVectorsScorer.getRandomVectorScorer(similarity, mmapValues, target);
         }
-        // Never hand `values` to the shared chain: Lucene's delegate would read its HasIndexSlice
-        // slice as float32 and overrun this FP16 data.
+
         return selectFallbackScorer(values, target, similarity);
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -6,7 +6,6 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -21,7 +20,6 @@ import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSeri
 import org.opensearch.knn.jni.SimdFp16;
 import org.opensearch.knn.jni.SimdVectorComputeService;
 import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
-import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.io.IOException;
 
@@ -33,8 +31,8 @@ import java.io.IOException;
  * class directly to Lucene's own flat vector scorer factory ({@code Lucene99FlatVectorsScorer}):
  * that factory independently detects {@code HasIndexSlice} and reads the raw slice assuming
  * 4 bytes/dimension (float32), which silently overreads past the buffer on this FP16 (2 bytes/dimension)
- * data. Use {@link #selectFallbackScorer(KNN1040HalfFloatFlatVectorsValues, float[], VectorSimilarityFunction)}
- * instead whenever mmap addresses are unavailable, or the similarity function has no native SIMD type.
+ * data. Use {@link #selectNativeOrJavaScorer} instead, which never hands {@code values} to a
+ * {@code FlatVectorsScorer} delegate chain.
  */
 @Log4j2
 class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements HasIndexSlice {
@@ -45,7 +43,6 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
     private final float[] value;
     private final byte[] rawBytes;
     private final DirectMonotonicReader ordToDocReader;
-    private final FlatVectorsScorer flatVectorsScorer;
     private final VectorSimilarityFunction similarity;
     private int lastOrd = -1;
 
@@ -54,7 +51,6 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
         int size,
         IndexInput slice,
         DirectMonotonicReader ordToDocReader,
-        FlatVectorsScorer flatVectorsScorer,
         VectorSimilarityFunction similarity
     ) {
         this.dimension = dimension;
@@ -64,7 +60,6 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
         this.value = new float[dimension];
         this.rawBytes = new byte[byteSize];
         this.ordToDocReader = ordToDocReader;
-        this.flatVectorsScorer = flatVectorsScorer;
         this.similarity = similarity;
     }
 
@@ -153,14 +148,13 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
 
     @Override
     public KNN1040HalfFloatFlatVectorsValues copy() throws IOException {
-        return new KNN1040HalfFloatFlatVectorsValues(dimension, size, slice.clone(), ordToDocReader, flatVectorsScorer, similarity);
+        return new KNN1040HalfFloatFlatVectorsValues(dimension, size, slice.clone(), ordToDocReader, similarity);
     }
 
     /**
-     * Selects the fastest available scorer for {@code values}: mmap-backed native SIMD
-     * when address extraction succeeds and the similarity has a native type, otherwise
-     * {@link #selectFallbackScorer}. Shared by both the reader's {@code getRandomVectorScorer} and
-     * this class's {@link #scorer(float[])}.
+     * Extracts the mmap address for {@code values} (if available) and delegates the actual scorer
+     * choice to {@link #selectNativeOrJavaScorer}. Shared by both the reader's
+     * {@code getRandomVectorScorer} and this class's {@link #scorer(float[])}.
      */
     static RandomVectorScorer selectScorer(KNN1040HalfFloatFlatVectorsValues values, float[] target, VectorSimilarityFunction similarity)
         throws IOException {
@@ -169,33 +163,35 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
             0,
             values.getSlice().length()
         );
-        SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
-        if (addressAndSize != null && nativeType != null) {
-            log.debug("Selected mmap native SIMD scorer for similarity [{}], nativeType [{}]", similarity, nativeType);
-            MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(values, addressAndSize);
-            return values.flatVectorsScorer.getRandomVectorScorer(similarity, mmapValues, target);
-        }
-
-        return selectFallbackScorer(values, target, similarity);
+        return selectNativeOrJavaScorer(values, target, similarity, addressAndSize);
     }
 
     /**
-     * Builds a {@link RandomVectorScorer} that never exposes {@code values} to Lucene's own flat
-     * vector scorer factory. Used whenever mmap address extraction fails, or the similarity
-     * function has no native SIMD type. Wrapped in {@link PrefetchableRandomVectorScorer} - same as
-     * {@link #selectScorer}'s mmap tier gets via {@code KNN1040HalfFloatVectorScorer#getRandomVectorScorer} -
-     * so this tier still prefetches ahead of bulk scoring during graph traversal.
+     * Picks between native SIMD and plain-Java scoring for {@code values}, and never routes it
+     * through a {@code FlatVectorsScorer} delegate chain (see this class's javadoc for why). Native
+     * scoring is used whenever the similarity has a native type and either {@code addressAndSize} is
+     * available (mmap zero-copy) or {@link SimdFp16#isSIMDSupported()} (heap-buffer copy); either way
+     * {@link KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer} picks the right one internally
+     * based on whether {@code addressAndSize} is non-null. Falls back to a plain Java scorer otherwise.
+     * Wrapped in {@link PrefetchableRandomVectorScorer} either way, so this still prefetches ahead of
+     * bulk scoring during graph traversal.
      */
-    static RandomVectorScorer selectFallbackScorer(
+    static RandomVectorScorer selectNativeOrJavaScorer(
         KNN1040HalfFloatFlatVectorsValues values,
         float[] target,
-        VectorSimilarityFunction similarity
+        VectorSimilarityFunction similarity,
+        long[] addressAndSize
     ) {
         SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
         RandomVectorScorer.AbstractRandomVectorScorer scorer;
-        if (nativeType != null && SimdFp16.isSIMDSupported()) {
-            log.debug("Selected byte-copy SIMD scorer for similarity [{}], nativeType [{}]", similarity, nativeType);
-            scorer = new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(values, target, nativeType, null);
+        if (nativeType != null && (addressAndSize != null || SimdFp16.isSIMDSupported())) {
+            log.debug(
+                "Selected native SIMD scorer for similarity [{}], nativeType [{}], mmap [{}]",
+                similarity,
+                nativeType,
+                addressAndSize != null
+            );
+            scorer = new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
         } else {
             log.debug(
                 "Selected Java fallback scorer for similarity [{}]; nativeType [{}], simdSupported [{}]",

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -171,6 +171,7 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
         );
         SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
         if (addressAndSize != null && nativeType != null) {
+            log.debug("Selected mmap native SIMD scorer for similarity [{}], nativeType [{}]", similarity, nativeType);
             MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(values, addressAndSize);
             return values.flatVectorsScorer.getRandomVectorScorer(similarity, mmapValues, target);
         }
@@ -193,8 +194,15 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
         SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
         RandomVectorScorer.AbstractRandomVectorScorer scorer;
         if (nativeType != null && SimdFp16.isSIMDSupported()) {
+            log.debug("Selected byte-copy SIMD scorer for similarity [{}], nativeType [{}]", similarity, nativeType);
             scorer = new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(values, target, nativeType, null);
         } else {
+            log.debug(
+                "Selected Java fallback scorer for similarity [{}]; nativeType [{}], simdSupported [{}]",
+                similarity,
+                nativeType,
+                SimdFp16.isSIMDSupported()
+            );
             scorer = new RandomVectorScorer.AbstractRandomVectorScorer(values) {
                 @Override
                 public float score(int node) throws IOException {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import java.io.IOException;
+
+/**
+ * Decodes FP16 (2 bytes/dimension) vector bytes to {@code float[]} on access.
+ *
+ * Implements {@link HasIndexSlice} so that {@link org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues}
+ * can expose the underlying slice for I/O prefetching. Callers must not hand an instance of this
+ * class directly to Lucene's own flat vector scorer factory ({@code Lucene99FlatVectorsScorer}):
+ * that factory independently detects {@code HasIndexSlice} and reads the raw slice assuming
+ * 4 bytes/dimension (float32), which silently overreads past the buffer on this FP16 (2 bytes/dimension)
+ * data. Use {@link #selectFallbackScorer(KNN1040HalfFloatFlatVectorsValues, float[], VectorSimilarityFunction)}
+ * instead whenever mmap addresses are unavailable, or the similarity function has no native SIMD type.
+ */
+class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements HasIndexSlice {
+    private final int dimension;
+    private final int size;
+    private final IndexInput slice;
+    private final int byteSize;
+    private final float[] value;
+    private final byte[] rawBytes;
+    private final DirectMonotonicReader ordToDocReader;
+    private final FlatVectorsScorer flatVectorsScorer;
+    private final VectorSimilarityFunction similarity;
+    private int lastOrd = -1;
+
+    KNN1040HalfFloatFlatVectorsValues(
+        int dimension,
+        int size,
+        IndexInput slice,
+        DirectMonotonicReader ordToDocReader,
+        FlatVectorsScorer flatVectorsScorer,
+        VectorSimilarityFunction similarity
+    ) {
+        this.dimension = dimension;
+        this.size = size;
+        this.slice = slice;
+        this.byteSize = dimension * Short.BYTES;
+        this.value = new float[dimension];
+        this.rawBytes = new byte[byteSize];
+        this.ordToDocReader = ordToDocReader;
+        this.flatVectorsScorer = flatVectorsScorer;
+        this.similarity = similarity;
+    }
+
+    @Override
+    public IndexInput getSlice() {
+        return slice;
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public int getVectorByteLength() {
+        return byteSize;
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+        return ordToDocReader == null ? createDenseIterator() : createSparseIterator();
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+        return ordToDocReader == null ? ord : (int) ordToDocReader.get(ord);
+    }
+
+    @Override
+    public float[] vectorValue(int ord) throws IOException {
+        if (ord == lastOrd) {
+            return value;
+        }
+        lastOrd = ord;
+        readRawVectorBytes(ord, rawBytes, 0);
+        KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.byteToFloatArray(rawBytes, value, dimension, 0);
+        return value;
+    }
+
+    /**
+     * Reads the raw FP16 bytes for {@code ord} into {@code dest}, starting at
+     * {@code destOffset}. Used by {@link KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer} to feed native SIMD
+     * scoring without a Java-side FP16-to-FP32 decode.
+     */
+    void readRawVectorBytes(int ord, byte[] dest, int destOffset) throws IOException {
+        slice.seek((long) ord * byteSize);
+        slice.readBytes(dest, destOffset, byteSize);
+    }
+
+    int byteSize() {
+        return byteSize;
+    }
+
+    @Override
+    public VectorScorer scorer(float[] target) throws IOException {
+        if (size() == 0) {
+            return null;
+        }
+        KNN1040HalfFloatFlatVectorsValues copy = copy();
+        DocIndexIterator iterator = copy.iterator();
+        RandomVectorScorer scorer = selectScorer(copy, target, similarity);
+        return new VectorScorer() {
+            @Override
+            public float score() throws IOException {
+                return scorer.score(iterator.index());
+            }
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return iterator;
+            }
+
+            @Override
+            public Bulk bulk(DocIdSetIterator matchingDocs) {
+                return Bulk.fromRandomScorerSparse(scorer, iterator, matchingDocs);
+            }
+        };
+    }
+
+    @Override
+    public KNN1040HalfFloatFlatVectorsValues copy() throws IOException {
+        return new KNN1040HalfFloatFlatVectorsValues(dimension, size, slice.clone(), ordToDocReader, flatVectorsScorer, similarity);
+    }
+
+    /**
+     * Selects the fastest available scorer for {@code values}: mmap-backed native SIMD
+     * when address extraction succeeds and the similarity has a native type, otherwise
+     * {@link #selectFallbackScorer}. Shared by both the reader's {@code getRandomVectorScorer} and
+     * this class's {@link #scorer(float[])}.
+     */
+    static RandomVectorScorer selectScorer(KNN1040HalfFloatFlatVectorsValues values, float[] target, VectorSimilarityFunction similarity)
+        throws IOException {
+        long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(
+            values.getSlice(),
+            0,
+            values.getSlice().length()
+        );
+        SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
+        if (addressAndSize != null && nativeType != null) {
+            // Safe only with both mmap and a native type: the chain then builds
+            // NativeRandomVectorScorer directly and never reaches Lucene's delegate.
+            MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(values, addressAndSize);
+            return values.flatVectorsScorer.getRandomVectorScorer(similarity, mmapValues, target);
+        }
+        // Never hand `values` to the shared chain: Lucene's delegate would read its HasIndexSlice
+        // slice as float32 and overrun this FP16 data.
+        return selectFallbackScorer(values, target, similarity);
+    }
+
+    /**
+     * Builds a {@link RandomVectorScorer} that never exposes {@code values} to Lucene's own flat
+     * vector scorer factory. Used whenever mmap address extraction fails, or the similarity
+     * function has no native SIMD type. Wrapped in {@link PrefetchableRandomVectorScorer} - same as
+     * {@link #selectScorer}'s mmap tier gets via {@code KNN1040HalfFloatVectorScorer#getRandomVectorScorer} -
+     * so this tier still prefetches ahead of bulk scoring during graph traversal.
+     */
+    static RandomVectorScorer selectFallbackScorer(
+        KNN1040HalfFloatFlatVectorsValues values,
+        float[] target,
+        VectorSimilarityFunction similarity
+    ) {
+        SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
+        RandomVectorScorer.AbstractRandomVectorScorer scorer;
+        if (nativeType != null && SimdFp16.isSIMDSupported()) {
+            scorer = new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(values, target, nativeType, null);
+        } else {
+            scorer = new RandomVectorScorer.AbstractRandomVectorScorer(values) {
+                @Override
+                public float score(int node) throws IOException {
+                    return similarity.compare(target, values.vectorValue(node));
+                }
+            };
+        }
+        return new PrefetchableRandomVectorScorer(scorer);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
@@ -35,6 +36,7 @@ import java.io.IOException;
  * data. Use {@link #selectFallbackScorer(KNN1040HalfFloatFlatVectorsValues, float[], VectorSimilarityFunction)}
  * instead whenever mmap addresses are unavailable, or the similarity function has no native SIMD type.
  */
+@Log4j2
 class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements HasIndexSlice {
     private final int dimension;
     private final int size;
@@ -124,11 +126,13 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
     @Override
     public VectorScorer scorer(float[] target) throws IOException {
         if (size() == 0) {
+            log.debug("No vectors present; returning null scorer from scorer(float[])");
             return null;
         }
         KNN1040HalfFloatFlatVectorsValues copy = copy();
         DocIndexIterator iterator = copy.iterator();
         RandomVectorScorer scorer = selectScorer(copy, target, similarity);
+        log.debug("Selected scorer [{}] for similarity [{}]", scorer.getClass().getSimpleName(), similarity);
         return new VectorScorer() {
             @Override
             public float score() throws IOException {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -154,7 +154,9 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
     /**
      * Extracts the mmap address for {@code values} (if available) and delegates the actual scorer
      * choice to {@link #selectNativeOrJavaScorer}. Shared by both the reader's
-     * {@code getRandomVectorScorer} and this class's {@link #scorer(float[])}.
+     * {@code getRandomVectorScorer} and this class's {@link #scorer(float[])} - both flat/exact-search
+     * paths, never called during HNSW graph traversal (that goes through
+     * {@link KNN1040HalfFloatVectorScorer#getRandomVectorScorerSupplier} instead).
      */
     static RandomVectorScorer selectScorer(KNN1040HalfFloatFlatVectorsValues values, float[] target, VectorSimilarityFunction similarity)
         throws IOException {
@@ -167,14 +169,13 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
     }
 
     /**
-     * Picks between native SIMD and plain-Java scoring for {@code values}, and never routes it
-     * through a {@code FlatVectorsScorer} delegate chain (see this class's javadoc for why). Native
-     * scoring is used whenever the similarity has a native type and either {@code addressAndSize} is
-     * available (mmap zero-copy) or {@link SimdFp16#isSIMDSupported()} (heap-buffer copy); either way
-     * {@link KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer} picks the right one internally
-     * based on whether {@code addressAndSize} is non-null. Falls back to a plain Java scorer otherwise.
-     * Wrapped in {@link PrefetchableRandomVectorScorer} either way, so this still prefetches ahead of
-     * bulk scoring during graph traversal.
+     * Picks native SIMD or plain-Java scoring for {@code values} (never a {@code FlatVectorsScorer}
+     * delegate chain - see this class's javadoc for why). See
+     * {@link KNN1040HalfFloatVectorScorer#usesNativeScorer} for how native-vs-fallback is decided.
+     * Shared with {@link KNN1040HalfFloatVectorScorer#getRandomVectorScorerSupplier} (HNSW graph
+     * build/search) so the two entry points can't drift apart. Wrapped in
+     * {@link PrefetchableRandomVectorScorer} either way, so this still prefetches ahead of bulk
+     * scoring during graph traversal.
      */
     static RandomVectorScorer selectNativeOrJavaScorer(
         KNN1040HalfFloatFlatVectorsValues values,
@@ -184,7 +185,7 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
     ) {
         SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(similarity);
         RandomVectorScorer.AbstractRandomVectorScorer scorer;
-        if (nativeType != null && (addressAndSize != null || SimdFp16.isSIMDSupported())) {
+        if (KNN1040HalfFloatVectorScorer.usesNativeScorer(nativeType, addressAndSize)) {
             log.debug(
                 "Selected native SIMD scorer for similarity [{}], nativeType [{}], mmap [{}]",
                 similarity,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValues.java
@@ -106,7 +106,7 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
 
     /**
      * Reads the raw FP16 bytes for {@code ord} into {@code dest}, starting at
-     * {@code destOffset}. Used by {@link KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer} to feed native SIMD
+     * {@code destOffset}. Used by {@link KNN1040HalfFloatVectorScorer.NativeHalfFloatRandomVectorScorer} to feed native SIMD
      * scoring without a Java-side FP16-to-FP32 decode.
      */
     void readRawVectorBytes(int ord, byte[] dest, int destOffset) throws IOException {
@@ -192,7 +192,7 @@ class KNN1040HalfFloatFlatVectorsValues extends FloatVectorValues implements Has
                 nativeType,
                 addressAndSize != null
             );
-            scorer = new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
+            scorer = new KNN1040HalfFloatVectorScorer.NativeHalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
         } else {
             log.debug(
                 "Selected Java fallback scorer for similarity [{}]; nativeType [{}], simdSupported [{}]",

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsWriter.java
@@ -252,7 +252,6 @@ public class KNN1040HalfFloatFlatVectorsWriter extends FlatVectorsWriter {
         throws IOException {
         meta.writeInt(fieldInfo.number);
         meta.writeInt(fieldInfo.getVectorEncoding().ordinal());
-        meta.writeInt(fieldInfo.getVectorSimilarityFunction().ordinal());
         meta.writeVLong(vectorDataOffset);
         meta.writeVLong(vectorDataLength);
         meta.writeVInt(fieldInfo.getVectorDimension());

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * Wraps a {@link FlatVectorsScorer} to give HNSW graph construction (flush's incremental build and
  * merge's graph rebuild) a decode-free scorer supplier for FP16 values, matching the decode-free path
- * search already gets via {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer}. Without
+ * search already gets via {@link KNN1040HalfFloatFlatVectorsValues#selectNativeOrJavaScorer}. Without
  * this, {@code getRandomVectorScorerSupplier} has no SIMD-aware path and decodes on every graph-edge
  * comparison instead of once per vector.
  *

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -171,6 +171,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         private final KNN1040HalfFloatFlatVectorsValues values;
         private final SimdVectorComputeService.SimilarityFunctionType nativeFunctionType;
         private final long[] addressAndSize;
+        private final boolean usesMmapAddress;
         private byte[] vectorBytesBuffer;
         private final float[] singleScoreBuffer = new float[1];
         private final int[] singleVectorId = new int[] { 0 };
@@ -186,14 +187,11 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
             this.values = values;
             this.nativeFunctionType = nativeFunctionType;
             this.addressAndSize = addressAndSize;
-            if (!usesMmapAddress()) {
+            this.usesMmapAddress = addressAndSize != null && addressAndSize.length > 0;
+            if (!usesMmapAddress) {
                 this.vectorBytesBuffer = new byte[values.byteSize() * BULK_SCORE_BATCH_SIZE];
             }
             setTarget(target);
-        }
-
-        private boolean usesMmapAddress() {
-            return addressAndSize != null && addressAndSize.length > 0;
         }
 
         // Repoints the native search context at a new target vector, reusing this scorer's buffers -
@@ -202,14 +200,14 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         void setTarget(float[] target) {
             SimdVectorComputeService.saveSearchContext(
                 target,
-                usesMmapAddress() ? addressAndSize : new long[0],
+                usesMmapAddress ? addressAndSize : new long[0],
                 nativeFunctionType.ordinal()
             );
         }
 
         @Override
         public float score(int node) throws IOException {
-            if (usesMmapAddress()) {
+            if (usesMmapAddress) {
                 return SimdVectorComputeService.scoreSimilarity(node);
             }
             values.readRawVectorBytes(node, vectorBytesBuffer, 0);
@@ -219,7 +217,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
 
         @Override
         public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
-            if (usesMmapAddress()) {
+            if (usesMmapAddress) {
                 return SimdVectorComputeService.scoreSimilarityInBulk(nodes, scores, numNodes);
             }
             int byteSize = values.byteSize();

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -45,10 +45,8 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         KnnVectorValues vectorValues
     ) throws IOException {
         FloatVectorValues bottomValues = WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues);
-        // MMapFloatVectorValues doesn't extend WrappedFloatVectorValues, so the unwrap above stops at
-        // it rather than reaching the FP16 values it wraps - unwrap that one extra layer here. Keep its
-        // address around: when present, candidate scoring can read straight from mapped memory instead
-        // of copying each candidate's bytes out of the IndexInput slice first.
+        // The unwrap above stops at MMapFloatVectorValues; unwrap one more layer and keep its address
+        // for zero-copy scoring straight off mapped memory.
         long[] addressAndSize = null;
         if (bottomValues instanceof MMapFloatVectorValues mmapValues) {
             addressAndSize = mmapValues.getAddressAndSize();
@@ -61,16 +59,8 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
             if (nativeType != null && SimdFp16.isSIMDSupported()) {
                 return new HalfFloatRandomVectorScorerSupplier(halfFloatValues, nativeType, addressAndSize);
             }
-            // No native FP16 kernel for this similarity function (e.g. COSINE - see
-            // NativeEngines990KnnVectorsScorer#getNativeFunctionType), or SIMD isn't available. Must
-            // still never hand `halfFloatValues` to `delegate` below: that's Lucene's *optimized*
-            // scorer chain, which detects HasIndexSlice and reads the raw slice assuming 4
-            // bytes/dimension (float32), corrupting/crashing on this FP16 (2 bytes/dimension) data -
-            // the same danger `KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer` already avoids
-            // for search. DefaultFlatVectorScorer is Lucene's plain, non-accelerated scorer: it only
-            // ever calls FloatVectorValues#vectorValue(ord) - our own correct FP16 decode - and never
-            // does any HasIndexSlice/memory-segment detection, so it's safe here even though the
-            // values also implement HasIndexSlice for the (separate, guarded) mmap-native path above.
+            // No native kernel or SIMD unavailable: never hand halfFloatValues to delegate, which
+            // assumes 4 bytes/dimension and would overread this FP16 (2-byte) data.
             return DefaultFlatVectorScorer.INSTANCE.getRandomVectorScorerSupplier(similarityFunction, halfFloatValues);
         }
         return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
@@ -106,7 +96,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
      * {@link UpdateableRandomVectorScorer#setScoringOrdinal} is decoded once (via
      * {@link KNN1040HalfFloatFlatVectorsValues#vectorValue}) to build the native search context;
      * every subsequent candidate comparison against it stays fully byte-based - one decode per graph
-     * node instead of one per graph edge, versus the generic Lucene fallback this replaces.
+     * node instead of one per graph edge.
      */
     private static final class HalfFloatRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
         private final KNN1040HalfFloatFlatVectorsValues values;
@@ -129,10 +119,6 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         public UpdateableRandomVectorScorer scorer() {
             return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
                 private HalfFloatRandomVectorScorer delegate;
-                // Wraps `delegate` once it exists, prefetching candidate bytes ahead of each bulkScore
-                // call - same PrefetchableRandomVectorScorer used for search's mmap tier and the flat
-                // fallback tier. Built once alongside `delegate` and reused across setScoringOrdinal
-                // calls, same as the buffer/native-context reuse below.
                 private PrefetchableRandomVectorScorer prefetchableDelegate;
 
                 @Override
@@ -142,8 +128,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
                         delegate = new HalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
                         prefetchableDelegate = new PrefetchableRandomVectorScorer(delegate);
                     } else {
-                        // Reuse the existing scorer/buffer instead of allocating a fresh one for every
-                        // graph node - only the native search context needs to change.
+                        // Reuse the existing scorer/buffer instead of allocating a fresh one for every graph node
                         delegate.setTarget(target);
                     }
                 }
@@ -173,17 +158,11 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
     }
 
     /**
-     * Scores FP16 vectors via native SIMD. When {@code addressAndSize} is available (the segment
-     * being read from is mmap-backed), candidates are scored directly off mapped memory by ordinal -
-     * the same zero-copy mechanism {@link org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer}
-     * uses for search - via {@link SimdVectorComputeService#scoreSimilarity}/{@code scoreSimilarityInBulk}.
-     * Otherwise candidates are read one at a time from the segment's {@link org.apache.lucene.store.IndexInput}
-     * slice into a heap buffer before scoring via {@link SimdVectorComputeService#scoreSimilarityInBulkFromFp16Bytes}.
-     *
-     * The search context (query buffer + similarity function, plus the mmap address when present) is
-     * saved once per target in {@link #setTarget}, since the "current" graph node being scored against
-     * changes on every {@link UpdateableRandomVectorScorer#setScoringOrdinal} call during HNSW graph
-     * build - unlike search's fixed-for-the-scorer's-lifetime query.
+     * Scores FP16 vectors via native SIMD: directly off mapped memory when {@code addressAndSize} is
+     * present (mmap-backed, zero-copy), otherwise by reading candidates into a heap buffer first.
+     * {@link #setTarget} re-saves the native search context on every
+     * {@link UpdateableRandomVectorScorer#setScoringOrdinal} call, since HNSW graph build scores
+     * against a new "current" node each time, unlike search's fixed query.
      */
     static class HalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
         // Matches KNN1040HalfFloatFlatVectorsReader's bulk batch size, so the non-mmap buffer is
@@ -195,7 +174,6 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         private byte[] vectorBytesBuffer;
         private final float[] singleScoreBuffer = new float[1];
         private final int[] singleVectorId = new int[] { 0 };
-        // Positional ids of the vectors packed into vectorBytesBuffer - only used without an mmap address
         private int[] identityIds = new int[0];
 
         HalfFloatRandomVectorScorer(

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
+
+import java.io.IOException;
+
+/**
+ * Wraps a {@link FlatVectorsScorer} to give HNSW graph construction (flush's incremental build and
+ * merge's graph rebuild) a decode-free scorer supplier for FP16 values, matching the decode-free path
+ * search already gets via {@link KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer}. Without
+ * this, {@code getRandomVectorScorerSupplier} has no SIMD-aware path and decodes on every graph-edge
+ * comparison instead of once per vector.
+ *
+ * <p>Delegates everything else unchanged, so it's safe to wrap any existing scorer chain - this class
+ * only touches the one method, and only activates for our own {@link KNN1040HalfFloatFlatVectorsValues}.
+ */
+public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
+    private final FlatVectorsScorer delegate;
+
+    public KNN1040HalfFloatVectorScorer(FlatVectorsScorer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues
+    ) throws IOException {
+        FloatVectorValues bottomValues = WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues);
+        // MMapFloatVectorValues doesn't extend WrappedFloatVectorValues, so the unwrap above stops at
+        // it rather than reaching the FP16 values it wraps - unwrap that one extra layer here. Keep its
+        // address around: when present, candidate scoring can read straight from mapped memory instead
+        // of copying each candidate's bytes out of the IndexInput slice first.
+        long[] addressAndSize = null;
+        if (bottomValues instanceof MMapFloatVectorValues mmapValues) {
+            addressAndSize = mmapValues.getAddressAndSize();
+            bottomValues = mmapValues.getDelegate();
+        }
+        if (bottomValues instanceof KNN1040HalfFloatFlatVectorsValues halfFloatValues) {
+            final SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(
+                similarityFunction
+            );
+            if (nativeType != null && SimdFp16.isSIMDSupported()) {
+                return new HalfFloatRandomVectorScorerSupplier(halfFloatValues, nativeType, addressAndSize);
+            }
+            // No native FP16 kernel for this similarity function (e.g. COSINE - see
+            // NativeEngines990KnnVectorsScorer#getNativeFunctionType), or SIMD isn't available. Must
+            // still never hand `halfFloatValues` to `delegate` below: that's Lucene's *optimized*
+            // scorer chain, which detects HasIndexSlice and reads the raw slice assuming 4
+            // bytes/dimension (float32), corrupting/crashing on this FP16 (2 bytes/dimension) data -
+            // the same danger `KNN1040HalfFloatFlatVectorsValues#selectFallbackScorer` already avoids
+            // for search. DefaultFlatVectorScorer is Lucene's plain, non-accelerated scorer: it only
+            // ever calls FloatVectorValues#vectorValue(ord) - our own correct FP16 decode - and never
+            // does any HasIndexSlice/memory-segment detection, so it's safe here even though the
+            // values also implement HasIndexSlice for the (separate, guarded) mmap-native path above.
+            return DefaultFlatVectorScorer.INSTANCE.getRandomVectorScorerSupplier(similarityFunction, halfFloatValues);
+        }
+        return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        float[] target
+    ) throws IOException {
+        return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        byte[] target
+    ) throws IOException {
+        return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+    }
+
+    @Override
+    public String toString() {
+        return "KNN1040HalfFloatVectorScorer(delegate=" + delegate + ")";
+    }
+
+    /**
+     * Builds {@link UpdateableRandomVectorScorer}s for HNSW graph construction that read raw FP16
+     * bytes directly for candidate comparisons via {@link HalfFloatRandomVectorScorer} - the
+     * same decode-free path search already uses. The "current" graph node set via
+     * {@link UpdateableRandomVectorScorer#setScoringOrdinal} is decoded once (via
+     * {@link KNN1040HalfFloatFlatVectorsValues#vectorValue}) to build the native search context;
+     * every subsequent candidate comparison against it stays fully byte-based - one decode per graph
+     * node instead of one per graph edge, versus the generic Lucene fallback this replaces.
+     */
+    private static final class HalfFloatRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
+        private final KNN1040HalfFloatFlatVectorsValues values;
+        private final KNN1040HalfFloatFlatVectorsValues targetValues;
+        private final SimdVectorComputeService.SimilarityFunctionType nativeType;
+        private final long[] addressAndSize;
+
+        HalfFloatRandomVectorScorerSupplier(
+            KNN1040HalfFloatFlatVectorsValues values,
+            SimdVectorComputeService.SimilarityFunctionType nativeType,
+            long[] addressAndSize
+        ) throws IOException {
+            this.values = values;
+            this.targetValues = values.copy();
+            this.nativeType = nativeType;
+            this.addressAndSize = addressAndSize;
+        }
+
+        @Override
+        public UpdateableRandomVectorScorer scorer() {
+            return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
+                private HalfFloatRandomVectorScorer delegate;
+                // Wraps `delegate` once it exists, prefetching candidate bytes ahead of each bulkScore
+                // call - same PrefetchableRandomVectorScorer used for search's mmap tier and the flat
+                // fallback tier. Built once alongside `delegate` and reused across setScoringOrdinal
+                // calls, same as the buffer/native-context reuse below.
+                private PrefetchableRandomVectorScorer prefetchableDelegate;
+
+                @Override
+                public void setScoringOrdinal(int node) throws IOException {
+                    float[] target = targetValues.vectorValue(node);
+                    if (delegate == null) {
+                        delegate = new HalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
+                        prefetchableDelegate = new PrefetchableRandomVectorScorer(delegate);
+                    } else {
+                        // Reuse the existing scorer/buffer instead of allocating a fresh one for every
+                        // graph node - only the native search context needs to change.
+                        delegate.setTarget(target);
+                    }
+                }
+
+                @Override
+                public float score(int node) throws IOException {
+                    if (prefetchableDelegate == null) {
+                        throw new IllegalStateException("setScoringOrdinal must be called before score");
+                    }
+                    return prefetchableDelegate.score(node);
+                }
+
+                @Override
+                public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                    if (prefetchableDelegate == null) {
+                        throw new IllegalStateException("setScoringOrdinal must be called before bulkScore");
+                    }
+                    return prefetchableDelegate.bulkScore(nodes, scores, numNodes);
+                }
+            };
+        }
+
+        @Override
+        public RandomVectorScorerSupplier copy() throws IOException {
+            return new HalfFloatRandomVectorScorerSupplier(values.copy(), nativeType, addressAndSize);
+        }
+    }
+
+    /**
+     * Scores FP16 vectors via native SIMD. When {@code addressAndSize} is available (the segment
+     * being read from is mmap-backed), candidates are scored directly off mapped memory by ordinal -
+     * the same zero-copy mechanism {@link org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer}
+     * uses for search - via {@link SimdVectorComputeService#scoreSimilarity}/{@code scoreSimilarityInBulk}.
+     * Otherwise candidates are read one at a time from the segment's {@link org.apache.lucene.store.IndexInput}
+     * slice into a heap buffer before scoring via {@link SimdVectorComputeService#scoreSimilarityInBulkFromFp16Bytes}.
+     *
+     * The search context (query buffer + similarity function, plus the mmap address when present) is
+     * saved once per target in {@link #setTarget}, since the "current" graph node being scored against
+     * changes on every {@link UpdateableRandomVectorScorer#setScoringOrdinal} call during HNSW graph
+     * build - unlike search's fixed-for-the-scorer's-lifetime query.
+     */
+    static class HalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+        // Matches KNN1040HalfFloatFlatVectorsReader's bulk batch size, so the non-mmap buffer is
+        // pre-sized for a typical bulkScore() call instead of reallocating on the first one.
+        private static final int BULK_SCORE_BATCH_SIZE = 64;
+        private final KNN1040HalfFloatFlatVectorsValues values;
+        private final SimdVectorComputeService.SimilarityFunctionType nativeFunctionType;
+        private final long[] addressAndSize;
+        private byte[] vectorBytesBuffer;
+        private final float[] singleScoreBuffer = new float[1];
+        private final int[] singleVectorId = new int[] { 0 };
+        // Positional ids of the vectors packed into vectorBytesBuffer - only used without an mmap address
+        private int[] identityIds = new int[0];
+
+        HalfFloatRandomVectorScorer(
+            KNN1040HalfFloatFlatVectorsValues values,
+            float[] target,
+            SimdVectorComputeService.SimilarityFunctionType nativeFunctionType,
+            long[] addressAndSize
+        ) {
+            super(values);
+            this.values = values;
+            this.nativeFunctionType = nativeFunctionType;
+            this.addressAndSize = addressAndSize;
+            if (!usesMmapAddress()) {
+                this.vectorBytesBuffer = new byte[values.byteSize() * BULK_SCORE_BATCH_SIZE];
+            }
+            setTarget(target);
+        }
+
+        private boolean usesMmapAddress() {
+            return addressAndSize != null && addressAndSize.length > 0;
+        }
+
+        // Repoints the native search context at a new target vector, reusing this scorer's buffers -
+        // lets callers that score against many targets in sequence (e.g. HNSW graph build) avoid
+        // allocating a fresh scorer per target.
+        void setTarget(float[] target) {
+            SimdVectorComputeService.saveSearchContext(
+                target,
+                usesMmapAddress() ? addressAndSize : new long[0],
+                nativeFunctionType.ordinal()
+            );
+        }
+
+        @Override
+        public float score(int node) throws IOException {
+            if (usesMmapAddress()) {
+                return SimdVectorComputeService.scoreSimilarity(node);
+            }
+            values.readRawVectorBytes(node, vectorBytesBuffer, 0);
+            SimdVectorComputeService.scoreSimilarityInBulkFromFp16Bytes(vectorBytesBuffer, 1, singleVectorId, singleScoreBuffer);
+            return singleScoreBuffer[0];
+        }
+
+        @Override
+        public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+            if (usesMmapAddress()) {
+                return SimdVectorComputeService.scoreSimilarityInBulk(nodes, scores, numNodes);
+            }
+            int byteSize = values.byteSize();
+            int requiredBytes = numNodes * byteSize;
+            if (vectorBytesBuffer.length < requiredBytes) {
+                vectorBytesBuffer = new byte[requiredBytes];
+            }
+            for (int i = 0; i < numNodes; i++) {
+                values.readRawVectorBytes(nodes[i], vectorBytesBuffer, i * byteSize);
+            }
+            growIdentityIds(numNodes);
+            return SimdVectorComputeService.scoreSimilarityInBulkFromFp16Bytes(vectorBytesBuffer, numNodes, identityIds, scores);
+        }
+
+        private void growIdentityIds(int numNodes) {
+            int previousLength = identityIds.length;
+            if (previousLength >= numNodes) {
+                return;
+            }
+            identityIds = new int[numNodes];
+            for (int i = 0; i < numNodes; i++) {
+                identityIds[i] = i;
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -20,6 +20,8 @@ import org.opensearch.knn.jni.SimdVectorComputeService;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
 
+import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat.BULK_SCORE_BATCH_SIZE;
+
 import java.io.IOException;
 
 /**
@@ -178,9 +180,6 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
      * against a new "current" node each time, unlike search's fixed query.
      */
     static class HalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
-        // Matches KNN1040HalfFloatFlatVectorsReader's bulk batch size, so the non-mmap buffer is
-        // pre-sized for a typical bulkScore() call instead of reallocating on the first one.
-        private static final int BULK_SCORE_BATCH_SIZE = 64;
         private final KNN1040HalfFloatFlatVectorsValues values;
         private final SimdVectorComputeService.SimilarityFunctionType nativeFunctionType;
         private final long[] addressAndSize;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -25,11 +25,14 @@ import static org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVe
 import java.io.IOException;
 
 /**
- * Wraps a {@link FlatVectorsScorer} to give HNSW graph construction (flush's incremental build and
- * merge's graph rebuild) a decode-free scorer supplier for FP16 values, matching the decode-free path
- * search already gets via {@link KNN1040HalfFloatFlatVectorsValues#selectNativeOrJavaScorer}. Without
- * this, {@code getRandomVectorScorerSupplier} has no SIMD-aware path and decodes on every graph-edge
- * comparison instead of once per vector.
+ * Wraps a {@link FlatVectorsScorer} to give HNSW graph rebuild during merge a decode-free scorer
+ * supplier for FP16 values, matching the decode-free path search already gets via
+ * {@link KNN1040HalfFloatFlatVectorsValues#selectNativeOrJavaScorer}. Only applies during merge -
+ * flush's initial graph build scores against an in-memory {@code float[]} buffer that was never
+ * FP16-encoded to begin with, so it never reaches our {@link KNN1040HalfFloatFlatVectorsValues}
+ * check below and falls through to {@code delegate} instead. Without this class,
+ * {@code getRandomVectorScorerSupplier} has no SIMD-aware path during merge and decodes on every
+ * graph-edge comparison instead of once per vector.
  *
  * <p>Delegates everything else unchanged, so it's safe to wrap any existing scorer chain - this class
  * only touches the one method, and only activates for our own {@link KNN1040HalfFloatFlatVectorsValues}.
@@ -41,6 +44,8 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         this.delegate = delegate;
     }
 
+    // HNSW graph build/search only - reached via the reader's getFlatVectorScorer, never by the
+    // flat/exact-search path (which calls KNN1040HalfFloatFlatVectorsValues#selectScorer directly).
     @Override
     public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
         VectorSimilarityFunction similarityFunction,
@@ -58,14 +63,31 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
             final SimdVectorComputeService.SimilarityFunctionType nativeType = NativeEngines990KnnVectorsScorer.getNativeFunctionType(
                 similarityFunction
             );
-            if (nativeType != null && SimdFp16.isSIMDSupported()) {
+            if (usesNativeScorer(nativeType, addressAndSize)) {
                 return new HalfFloatRandomVectorScorerSupplier(halfFloatValues, nativeType, addressAndSize);
             }
-            // No native kernel or SIMD unavailable: never hand halfFloatValues to delegate, which
-            // assumes 4 bytes/dimension and would overread this FP16 (2-byte) data.
+            // No usable native path: never hand halfFloatValues to delegate, which assumes 4
+            // bytes/dimension and would overread this FP16 (2-byte) data.
             return DefaultFlatVectorScorer.INSTANCE.getRandomVectorScorerSupplier(similarityFunction, halfFloatValues);
         }
         return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
+    }
+
+    /**
+     * True when native scoring should be used for {@code nativeType}. Mmap ({@code addressAndSize}
+     * non-null and non-empty) is enough on its own - zero-copy scoring uses its own native call path
+     * and doesn't need {@link SimdFp16#isSIMDSupported()} to be true (that flag only matters for the
+     * heap-buffer copy path below). Without mmap, falls back to whatever
+     * {@link SimdFp16#isSIMDSupported()} says.
+     */
+    static boolean usesNativeScorer(SimdVectorComputeService.SimilarityFunctionType nativeType, long[] addressAndSize) {
+        if (nativeType == null) {
+            return false;
+        }
+        if (addressAndSize != null && addressAndSize.length > 0) {
+            return true;
+        }
+        return SimdFp16.isSIMDSupported();
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -99,33 +99,34 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
      * node instead of one per graph edge.
      */
     private static final class HalfFloatRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
-        private final KNN1040HalfFloatFlatVectorsValues values;
-        private final KNN1040HalfFloatFlatVectorsValues targetValues;
+        // Used for both raw-byte candidate reads (readRawVectorBytes) and decoding the "current"
+        // graph node into a float[] target (vectorValue, in setScoringOrdinal below) - safe to share
+        // since both always seek explicitly before reading, and only the target side ever decodes.
+        private final KNN1040HalfFloatFlatVectorsValues vectorValues;
         private final SimdVectorComputeService.SimilarityFunctionType nativeType;
         private final long[] addressAndSize;
 
         HalfFloatRandomVectorScorerSupplier(
-            KNN1040HalfFloatFlatVectorsValues values,
+            KNN1040HalfFloatFlatVectorsValues vectorValues,
             SimdVectorComputeService.SimilarityFunctionType nativeType,
             long[] addressAndSize
-        ) throws IOException {
-            this.values = values;
-            this.targetValues = values.copy();
+        ) {
+            this.vectorValues = vectorValues;
             this.nativeType = nativeType;
             this.addressAndSize = addressAndSize;
         }
 
         @Override
         public UpdateableRandomVectorScorer scorer() {
-            return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(values) {
+            return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(vectorValues) {
                 private HalfFloatRandomVectorScorer delegate;
                 private PrefetchableRandomVectorScorer prefetchableDelegate;
 
                 @Override
                 public void setScoringOrdinal(int node) throws IOException {
-                    float[] target = targetValues.vectorValue(node);
+                    float[] target = vectorValues.vectorValue(node);
                     if (delegate == null) {
-                        delegate = new HalfFloatRandomVectorScorer(values, target, nativeType, addressAndSize);
+                        delegate = new HalfFloatRandomVectorScorer(vectorValues, target, nativeType, addressAndSize);
                         prefetchableDelegate = new PrefetchableRandomVectorScorer(delegate);
                     } else {
                         // Reuse the existing scorer/buffer instead of allocating a fresh one for every graph node
@@ -133,27 +134,39 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
                     }
                 }
 
+                /**
+                 * Scores {@code node} against whatever target {@link #setScoringOrdinal} last set,
+                 * via the byte-based {@link HalfFloatRandomVectorScorer} built above - no decode here.
+                 */
                 @Override
                 public float score(int node) throws IOException {
-                    if (prefetchableDelegate == null) {
-                        throw new IllegalStateException("setScoringOrdinal must be called before score");
-                    }
-                    return prefetchableDelegate.score(node);
+                    return requireDelegate().score(node);
                 }
 
+                /**
+                 * Scores {@code numNodes} candidates from {@code nodes} against the current target in
+                 * one call, returning the maximum score. {@code requireDelegate()} returns the
+                 * {@link PrefetchableRandomVectorScorer} wrapper, so this also issues an I/O prefetch
+                 * for the candidates' backing bytes before the real scoring happens - see the
+                 * prefetch note on {@link #setScoringOrdinal} above.
+                 */
                 @Override
                 public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+                    return requireDelegate().bulkScore(nodes, scores, numNodes);
+                }
+
+                private PrefetchableRandomVectorScorer requireDelegate() {
                     if (prefetchableDelegate == null) {
-                        throw new IllegalStateException("setScoringOrdinal must be called before bulkScore");
+                        throw new IllegalStateException("setScoringOrdinal must be called before scoring");
                     }
-                    return prefetchableDelegate.bulkScore(nodes, scores, numNodes);
+                    return prefetchableDelegate;
                 }
             };
         }
 
         @Override
         public RandomVectorScorerSupplier copy() throws IOException {
-            return new HalfFloatRandomVectorScorerSupplier(values.copy(), nativeType, addressAndSize);
+            return new HalfFloatRandomVectorScorerSupplier(vectorValues.copy(), nativeType, addressAndSize);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorer.java
@@ -64,7 +64,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
                 similarityFunction
             );
             if (usesNativeScorer(nativeType, addressAndSize)) {
-                return new HalfFloatRandomVectorScorerSupplier(halfFloatValues, nativeType, addressAndSize);
+                return new NativeHalfFloatRandomVectorScorerSupplier(halfFloatValues, nativeType, addressAndSize);
             }
             // No usable native path: never hand halfFloatValues to delegate, which assumes 4
             // bytes/dimension and would overread this FP16 (2-byte) data.
@@ -115,14 +115,14 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
 
     /**
      * Builds {@link UpdateableRandomVectorScorer}s for HNSW graph construction that read raw FP16
-     * bytes directly for candidate comparisons via {@link HalfFloatRandomVectorScorer} - the
+     * bytes directly for candidate comparisons via {@link NativeHalfFloatRandomVectorScorer} - the
      * same decode-free path search already uses. The "current" graph node set via
      * {@link UpdateableRandomVectorScorer#setScoringOrdinal} is decoded once (via
      * {@link KNN1040HalfFloatFlatVectorsValues#vectorValue}) to build the native search context;
      * every subsequent candidate comparison against it stays fully byte-based - one decode per graph
      * node instead of one per graph edge.
      */
-    private static final class HalfFloatRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
+    private static final class NativeHalfFloatRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
         // Used for both raw-byte candidate reads (readRawVectorBytes) and decoding the "current"
         // graph node into a float[] target (vectorValue, in setScoringOrdinal below) - safe to share
         // since both always seek explicitly before reading, and only the target side ever decodes.
@@ -130,7 +130,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         private final SimdVectorComputeService.SimilarityFunctionType nativeType;
         private final long[] addressAndSize;
 
-        HalfFloatRandomVectorScorerSupplier(
+        NativeHalfFloatRandomVectorScorerSupplier(
             KNN1040HalfFloatFlatVectorsValues vectorValues,
             SimdVectorComputeService.SimilarityFunctionType nativeType,
             long[] addressAndSize
@@ -143,14 +143,14 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         @Override
         public UpdateableRandomVectorScorer scorer() {
             return new UpdateableRandomVectorScorer.AbstractUpdateableRandomVectorScorer(vectorValues) {
-                private HalfFloatRandomVectorScorer delegate;
+                private NativeHalfFloatRandomVectorScorer delegate;
                 private PrefetchableRandomVectorScorer prefetchableDelegate;
 
                 @Override
                 public void setScoringOrdinal(int node) throws IOException {
                     float[] target = vectorValues.vectorValue(node);
                     if (delegate == null) {
-                        delegate = new HalfFloatRandomVectorScorer(vectorValues, target, nativeType, addressAndSize);
+                        delegate = new NativeHalfFloatRandomVectorScorer(vectorValues, target, nativeType, addressAndSize);
                         prefetchableDelegate = new PrefetchableRandomVectorScorer(delegate);
                     } else {
                         // Reuse the existing scorer/buffer instead of allocating a fresh one for every graph node
@@ -160,7 +160,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
 
                 /**
                  * Scores {@code node} against whatever target {@link #setScoringOrdinal} last set,
-                 * via the byte-based {@link HalfFloatRandomVectorScorer} built above - no decode here.
+                 * via the byte-based {@link NativeHalfFloatRandomVectorScorer} built above - no decode here.
                  */
                 @Override
                 public float score(int node) throws IOException {
@@ -190,7 +190,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
 
         @Override
         public RandomVectorScorerSupplier copy() throws IOException {
-            return new HalfFloatRandomVectorScorerSupplier(vectorValues.copy(), nativeType, addressAndSize);
+            return new NativeHalfFloatRandomVectorScorerSupplier(vectorValues.copy(), nativeType, addressAndSize);
         }
     }
 
@@ -201,7 +201,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
      * {@link UpdateableRandomVectorScorer#setScoringOrdinal} call, since HNSW graph build scores
      * against a new "current" node each time, unlike search's fixed query.
      */
-    static class HalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+    static class NativeHalfFloatRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
         private final KNN1040HalfFloatFlatVectorsValues values;
         private final SimdVectorComputeService.SimilarityFunctionType nativeFunctionType;
         private final long[] addressAndSize;
@@ -211,7 +211,7 @@ public class KNN1040HalfFloatVectorScorer implements FlatVectorsScorer {
         private final int[] singleVectorId = new int[] { 0 };
         private int[] identityIds = new int[0];
 
-        HalfFloatRandomVectorScorer(
+        NativeHalfFloatRandomVectorScorer(
             KNN1040HalfFloatFlatVectorsValues values,
             float[] target,
             SimdVectorComputeService.SimilarityFunctionType nativeFunctionType,

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
@@ -64,9 +64,7 @@ public class NativeEngines990KnnVectorsScorer implements FlatVectorsScorer {
         return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
     }
 
-    private static SimdVectorComputeService.SimilarityFunctionType getNativeFunctionType(
-        final VectorSimilarityFunction similarityFunction
-    ) {
+    public static SimdVectorComputeService.SimilarityFunctionType getNativeFunctionType(final VectorSimilarityFunction similarityFunction) {
         return switch (similarityFunction) {
             case MAXIMUM_INNER_PRODUCT -> SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT;
             case EUCLIDEAN -> SimdVectorComputeService.SimilarityFunctionType.FP16_L2;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import lombok.Getter;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.IndexInput;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ public class MMapFloatVectorValues extends FloatVectorValues implements MMapVect
     // addressAndSize[3] has the size of the second mapped region.
     @Getter
     private final long[] addressAndSize;
+    @Getter
     private final FloatVectorValues delegate;
 
     public MMapFloatVectorValues(final FloatVectorValues delegate, final long[] addressAndSize) {
@@ -68,6 +70,21 @@ public class MMapFloatVectorValues extends FloatVectorValues implements MMapVect
     @Override
     public int getVectorByteLength() {
         return delegate.getVectorByteLength();
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+        return delegate.ordToDoc(ord);
+    }
+
+    @Override
+    public VectorScorer scorer(float[] target) throws IOException {
+        return delegate.scorer(target);
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -472,6 +472,74 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testSearch_collectorRequestsZeroResults_returnsImmediatelyWithoutCollecting() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                KnnCollector mockCollector = Mockito.mock(KnnCollector.class);
+                Mockito.when(mockCollector.k()).thenReturn(0);
+
+                reader.search(FIELD_NAME, new float[] { 1f, 1f, 1f, 1f }, mockCollector, AcceptDocs.fromLiveDocs(null, vectors.length));
+
+                Mockito.verify(mockCollector, Mockito.never()).collect(Mockito.anyInt(), Mockito.anyFloat());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_earlyTerminationMidLoop_stopsCollectingRemainingVectors() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f }, { 9f, 10f, 11f, 12f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                KnnCollector mockCollector = Mockito.mock(KnnCollector.class);
+                Mockito.when(mockCollector.k()).thenReturn(5);
+                // False for the first vector (loop proceeds), true from then on (loop breaks).
+                Mockito.when(mockCollector.earlyTerminated()).thenReturn(false, true);
+
+                reader.search(FIELD_NAME, new float[] { 1f, 1f, 1f, 1f }, mockCollector, AcceptDocs.fromLiveDocs(null, vectors.length));
+
+                Mockito.verify(mockCollector, Mockito.atMost(1)).incVisitedCount(Mockito.anyInt());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_moreVectorsThanBulkBatchSize_flushesFullBatchMidLoop() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            int numVectors = 70; // exceeds the reader's internal BULK_SCORE_BATCH_SIZE of 64
+            float[][] vectors = new float[numVectors][DIMENSION];
+            for (int i = 0; i < numVectors; i++) {
+                for (int d = 0; d < DIMENSION; d++) {
+                    vectors[i][d] = i + d;
+                }
+            }
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                KnnCollector collector = new TopKnnCollector(numVectors, Integer.MAX_VALUE);
+                reader.search(FIELD_NAME, new float[] { 1f, 1f, 1f, 1f }, collector, AcceptDocs.fromLiveDocs(null, numVectors));
+
+                assertEquals(numVectors, collector.topDocs().scoreDocs.length);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFlatVectorScorer_returnsInjectedScorerInstance() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+            try (FlatVectorsReader reader = new KNN1040HalfFloatFlatVectorsReader(readState, scorer)) {
+                assertSame(scorer, reader.getFlatVectorScorer(FIELD_NAME));
+            }
+        }
+    }
+
     private FlatVectorsReader newReader(SegmentReadState readState) throws Exception {
         FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
         return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
@@ -40,7 +41,6 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
-import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.util.Collections;
@@ -147,20 +147,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testFieldEntry_similarityMismatch_throws() {
-        try (Directory dir = new ByteBuffersDirectory()) {
-            SegmentReadState readState = writeRawSegment(
-                dir,
-                new float[][] { { 1f, 2f, 3f, 4f } },
-                VectorSimilarityFunction.EUCLIDEAN,
-                Overrides.builder().metaSimilarityOrdinal(VectorSimilarityFunction.COSINE.ordinal()).build()
-            );
-            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
-            assertTrue(e.getMessage().contains("Inconsistent vector similarity function"));
-        }
-    }
-
-    @SneakyThrows
     public void testFieldEntry_encodingMismatch_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
             SegmentReadState readState = writeRawSegment(
@@ -199,20 +185,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
             );
             CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
             assertTrue(e.getMessage().contains("Invalid field number"));
-        }
-    }
-
-    @SneakyThrows
-    public void testReadSimilarityFunction_outOfRangeOrdinal_throws() {
-        try (Directory dir = new ByteBuffersDirectory()) {
-            SegmentReadState readState = writeRawSegment(
-                dir,
-                new float[][] { { 1f, 2f, 3f, 4f } },
-                VectorSimilarityFunction.EUCLIDEAN,
-                Overrides.builder().metaSimilarityOrdinal(99).build()
-            );
-            CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
-            assertTrue(e.getMessage().contains("invalid distance function"));
         }
     }
 
@@ -551,15 +523,14 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
      * {@code KNN1040HalfFloatFlatVectorsValues#selectScorer}) end-to-end instead of a mocked result.
      */
     private FlatVectorsReader newReaderWithRealScorer(SegmentReadState readState) throws Exception {
-        FlatVectorsScorer scorer = new KNN1040HalfFloatVectorScorer(
-            new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorsScorerProvider.getLucene99FlatVectorsScorer()))
+        FlatVectorsScorer scorer = new PrefetchableFlatVectorScorer(
+            new KNN1040HalfFloatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))
         );
         return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);
     }
 
     private static final class Overrides {
         private final Integer metaDimension;
-        private final Integer metaSimilarityOrdinal;
         private final Integer metaEncodingOrdinal;
         private final Long metaVectorDataLength;
         private final Integer metaFieldNumber;
@@ -568,7 +539,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
         private Overrides(
             Integer metaDimension,
-            Integer metaSimilarityOrdinal,
             Integer metaEncodingOrdinal,
             Long metaVectorDataLength,
             Integer metaFieldNumber,
@@ -576,7 +546,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
             Integer maxDoc
         ) {
             this.metaDimension = metaDimension;
-            this.metaSimilarityOrdinal = metaSimilarityOrdinal;
             this.metaEncodingOrdinal = metaEncodingOrdinal;
             this.metaVectorDataLength = metaVectorDataLength;
             this.metaFieldNumber = metaFieldNumber;
@@ -590,7 +559,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
         static final class Builder {
             private Integer metaDimension;
-            private Integer metaSimilarityOrdinal;
             private Integer metaEncodingOrdinal;
             private Long metaVectorDataLength;
             private Integer metaFieldNumber;
@@ -599,11 +567,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
             Builder metaDimension(int v) {
                 this.metaDimension = v;
-                return this;
-            }
-
-            Builder metaSimilarityOrdinal(int v) {
-                this.metaSimilarityOrdinal = v;
                 return this;
             }
 
@@ -633,15 +596,7 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
             }
 
             Overrides build() {
-                return new Overrides(
-                    metaDimension,
-                    metaSimilarityOrdinal,
-                    metaEncodingOrdinal,
-                    metaVectorDataLength,
-                    metaFieldNumber,
-                    docIds,
-                    maxDoc
-                );
+                return new Overrides(metaDimension, metaEncodingOrdinal, metaVectorDataLength, metaFieldNumber, docIds, maxDoc);
             }
         }
     }
@@ -704,7 +659,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
             meta.writeInt(overrides.metaFieldNumber != null ? overrides.metaFieldNumber : fieldInfo.number);
             meta.writeInt(overrides.metaEncodingOrdinal != null ? overrides.metaEncodingOrdinal : VectorEncoding.FLOAT32.ordinal());
-            meta.writeInt(overrides.metaSimilarityOrdinal != null ? overrides.metaSimilarityOrdinal : similarity.ordinal());
             meta.writeVLong(vectorDataOffset);
             meta.writeVLong(overrides.metaVectorDataLength != null ? overrides.metaVectorDataLength : vectorDataLength);
             meta.writeVInt(overrides.metaDimension != null ? overrides.metaDimension : DIMENSION);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.lucene95.OrdToDocDISIReaderConfiguration;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests {@link KNN1040HalfFloatFlatVectorsReader} in isolation, without going through
+ * {@link KNN1040HalfFloatFlatVectorsWriter}. Fixtures are written directly with low-level Lucene
+ * primitives (mirroring the writer's on-disk layout, not calling the writer class itself), so a bug
+ * introduced only in the writer can't mask a bug in the reader, or vice versa.
+ */
+public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_vector";
+    private static final int DIMENSION = 4;
+    private static final int VECTOR_DATA_ALIGNMENT = 64;
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_decodesCorrectly() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f }, { 0.5f, 0.5f, 0.5f, 0.5f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertNotNull(values);
+                assertEquals(DIMENSION, values.dimension());
+                assertEquals(vectors.length, values.size());
+
+                for (int i = 0; i < vectors.length; i++) {
+                    float[] actual = values.vectorValue(i);
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expected = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                        assertEquals("vector " + i + " dim " + d, expected, actual[d], 0.0f);
+                    }
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetByteVectorValues_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                expectThrows(UnsupportedOperationException.class, () -> reader.getByteVectorValues(FIELD_NAME));
+                expectThrows(UnsupportedOperationException.class, () -> reader.getRandomVectorScorer(FIELD_NAME, new byte[] { 1 }));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_unknownField_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> reader.getFloatVectorValues("nope"));
+                assertTrue(e.getMessage().contains("nope"));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testCheckIntegrity_validSegment_succeeds() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                reader.checkIntegrity();
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetOffHeapByteSize_returnsVectorDataLength() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FieldInfo fieldInfo = readState.fieldInfos.fieldInfo(FIELD_NAME);
+                Map<String, Long> offHeap = reader.getOffHeapByteSize(fieldInfo);
+                long expectedBytes = (long) vectors.length * DIMENSION * Short.BYTES;
+                assertEquals(Long.valueOf(expectedBytes), offHeap.get(KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testRamBytesUsed_positive() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            try (FlatVectorsReader reader = newReader(readState)) {
+                assertTrue(reader.ramBytesUsed() > 0);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_dimensionMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // Meta records DIMENSION+1 vectors' worth of dimension, but FieldInfo (read separately by
+            // the reader) still says DIMENSION - triggers the "Inconsistent vector dimension" check.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaDimension(DIMENSION + 1).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Inconsistent vector dimension"));
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_similarityMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // Meta records COSINE's ordinal, but FieldInfo says EUCLIDEAN - triggers the "Inconsistent
+            // vector similarity function" check.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaSimilarityOrdinal(VectorSimilarityFunction.COSINE.ordinal()).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Inconsistent vector similarity function"));
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_encodingMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaEncodingOrdinal(VectorEncoding.BYTE.ordinal()).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Unexpected vector encoding"));
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldEntry_lengthMismatch_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaVectorDataLength(1).build()
+            );
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Vector data length"));
+        }
+    }
+
+    @SneakyThrows
+    public void testReadFields_unknownFieldNumber_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // FieldInfos only has field number 0 (see createFieldInfo); recording 99 in meta instead
+            // triggers readFields()'s own "Invalid field number" check, before FieldEntry ever exists.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaFieldNumber(99).build()
+            );
+            CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Invalid field number"));
+        }
+    }
+
+    @SneakyThrows
+    public void testReadSimilarityFunction_outOfRangeOrdinal_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // 99 is out of SIMILARITY_FUNCTIONS' range - caught by readSimilarityFunction() itself,
+            // distinct from testFieldEntry_similarityMismatch_throws's in-range-but-wrong value.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaSimilarityOrdinal(99).build()
+            );
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("invalid distance function"));
+        }
+    }
+
+    @SneakyThrows
+    public void testReadVectorEncoding_outOfRangeOrdinal_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            // 99 is out of VectorEncoding.values()' range - caught by readVectorEncoding() itself,
+            // distinct from testFieldEntry_encodingMismatch_throws's in-range-but-wrong value.
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[][] { { 1f, 2f, 3f, 4f } },
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().metaEncodingOrdinal(99).build()
+            );
+            CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
+            assertTrue(e.getMessage().contains("Invalid vector encoding id"));
+        }
+    }
+
+    @SneakyThrows
+    public void testSparseDocs_ordToDocMappingUsesDirectMonotonicReader() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f }, { 9f, 10f, 11f, 12f } };
+            int[] docIds = { 0, 3, 7 };
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                vectors,
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().docIds(docIds).maxDoc(10).build()
+            );
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                for (int ord = 0; ord < docIds.length; ord++) {
+                    assertEquals(docIds[ord], values.ordToDoc(ord));
+                }
+                FloatVectorValues.DocIndexIterator iterator = values.iterator();
+                int ord = 0;
+                for (int doc = iterator.nextDoc(); doc != org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS; doc = iterator
+                    .nextDoc()) {
+                    assertEquals(docIds[ord], doc);
+                    assertEquals(ord, iterator.index());
+                    ord++;
+                }
+                assertEquals(docIds.length, ord);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetMergeInstance_returnsUsableReaderThenFinishMergeRestoresIt() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1f, 2f, 3f, 4f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FlatVectorsReader mergeInstance = reader.getMergeInstance();
+                assertSame(reader, mergeInstance);
+                assertEquals(1, mergeInstance.getFloatVectorValues(FIELD_NAME).size());
+                mergeInstance.finishMerge();
+                assertEquals(1, reader.getFloatVectorValues(FIELD_NAME).size());
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testOpenDataInput_truncatedVectorDataFile_throws() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
+            String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+            dir.deleteFile(vectorDataFileName);
+            // Too short for even the codec header - checkIndexHeader() fails before any of our own
+            // validation runs, exercising openDataInput()'s own success==false cleanup path.
+            try (IndexOutput truncated = dir.createOutput(vectorDataFileName, IOContext.DEFAULT)) {
+                truncated.writeByte((byte) 0);
+            }
+            expectThrows(Exception.class, () -> newReader(readState));
+        }
+    }
+
+    private FlatVectorsReader newReader(SegmentReadState readState) throws Exception {
+        FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+        return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);
+    }
+
+    private static final class Overrides {
+        private final Integer metaDimension;
+        private final Integer metaSimilarityOrdinal;
+        private final Integer metaEncodingOrdinal;
+        private final Long metaVectorDataLength;
+        private final Integer metaFieldNumber;
+        private final int[] docIds;
+        private final Integer maxDoc;
+
+        private Overrides(
+            Integer metaDimension,
+            Integer metaSimilarityOrdinal,
+            Integer metaEncodingOrdinal,
+            Long metaVectorDataLength,
+            Integer metaFieldNumber,
+            int[] docIds,
+            Integer maxDoc
+        ) {
+            this.metaDimension = metaDimension;
+            this.metaSimilarityOrdinal = metaSimilarityOrdinal;
+            this.metaEncodingOrdinal = metaEncodingOrdinal;
+            this.metaVectorDataLength = metaVectorDataLength;
+            this.metaFieldNumber = metaFieldNumber;
+            this.docIds = docIds;
+            this.maxDoc = maxDoc;
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        static final class Builder {
+            private Integer metaDimension;
+            private Integer metaSimilarityOrdinal;
+            private Integer metaEncodingOrdinal;
+            private Long metaVectorDataLength;
+            private Integer metaFieldNumber;
+            private int[] docIds;
+            private Integer maxDoc;
+
+            Builder metaDimension(int v) {
+                this.metaDimension = v;
+                return this;
+            }
+
+            Builder metaSimilarityOrdinal(int v) {
+                this.metaSimilarityOrdinal = v;
+                return this;
+            }
+
+            Builder metaEncodingOrdinal(int v) {
+                this.metaEncodingOrdinal = v;
+                return this;
+            }
+
+            Builder metaVectorDataLength(long v) {
+                this.metaVectorDataLength = v;
+                return this;
+            }
+
+            Builder metaFieldNumber(int v) {
+                this.metaFieldNumber = v;
+                return this;
+            }
+
+            Builder docIds(int[] v) {
+                this.docIds = v;
+                return this;
+            }
+
+            Builder maxDoc(int v) {
+                this.maxDoc = v;
+                return this;
+            }
+
+            Overrides build() {
+                return new Overrides(
+                    metaDimension,
+                    metaSimilarityOrdinal,
+                    metaEncodingOrdinal,
+                    metaVectorDataLength,
+                    metaFieldNumber,
+                    docIds,
+                    maxDoc
+                );
+            }
+        }
+    }
+
+    private SegmentReadState writeRawSegment(Directory dir, float[][] vectors, VectorSimilarityFunction similarity) throws Exception {
+        return writeRawSegment(dir, vectors, similarity, Overrides.builder().build());
+    }
+
+    private SegmentReadState writeRawSegment(Directory dir, float[][] vectors, VectorSimilarityFunction similarity, Overrides overrides)
+        throws Exception {
+        FieldInfo fieldInfo = createFieldInfo(similarity);
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+        int maxDoc = overrides.maxDoc != null ? overrides.maxDoc : vectors.length;
+        SegmentInfo segmentInfo = new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "_0",
+            maxDoc,
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            new HashMap<>(),
+            null
+        );
+
+        String metaFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.META_EXTENSION);
+        String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
+
+        try (
+            IndexOutput meta = dir.createOutput(metaFileName, IOContext.DEFAULT);
+            IndexOutput vectorData = dir.createOutput(vectorDataFileName, IOContext.DEFAULT)
+        ) {
+            CodecUtil.writeIndexHeader(
+                meta,
+                KNN1040HalfFloatFlatVectorsFormat.META_CODEC_NAME,
+                KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                segmentInfo.getId(),
+                ""
+            );
+            CodecUtil.writeIndexHeader(
+                vectorData,
+                KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                KNN1040HalfFloatFlatVectorsFormat.VERSION_CURRENT,
+                segmentInfo.getId(),
+                ""
+            );
+
+            long vectorDataOffset = vectorData.alignFilePointer(VECTOR_DATA_ALIGNMENT);
+            byte[] outputBuffer = new byte[DIMENSION * Short.BYTES];
+            DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+            for (int ord = 0; ord < vectors.length; ord++) {
+                KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(vectors[ord], outputBuffer, DIMENSION);
+                vectorData.writeBytes(outputBuffer, 0, outputBuffer.length);
+                docsWithField.add(overrides.docIds != null ? overrides.docIds[ord] : ord);
+            }
+            long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+            meta.writeInt(overrides.metaFieldNumber != null ? overrides.metaFieldNumber : fieldInfo.number);
+            meta.writeInt(overrides.metaEncodingOrdinal != null ? overrides.metaEncodingOrdinal : VectorEncoding.FLOAT32.ordinal());
+            meta.writeInt(overrides.metaSimilarityOrdinal != null ? overrides.metaSimilarityOrdinal : similarity.ordinal());
+            meta.writeVLong(vectorDataOffset);
+            meta.writeVLong(overrides.metaVectorDataLength != null ? overrides.metaVectorDataLength : vectorDataLength);
+            meta.writeVInt(overrides.metaDimension != null ? overrides.metaDimension : DIMENSION);
+
+            int count = docsWithField.cardinality();
+            meta.writeInt(count);
+            OrdToDocDISIReaderConfiguration.writeStoredMeta(
+                KNN1040HalfFloatFlatVectorsFormat.DIRECT_MONOTONIC_BLOCK_SHIFT,
+                meta,
+                vectorData,
+                count,
+                maxDoc,
+                docsWithField
+            );
+
+            meta.writeInt(-1);
+            CodecUtil.writeFooter(meta);
+            CodecUtil.writeFooter(vectorData);
+        }
+
+        return new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+    }
+
+    private FieldInfo createFieldInfo(VectorSimilarityFunction similarity) {
+        return new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            DIMENSION,
+            VectorEncoding.FLOAT32,
+            similarity,
+            false,
+            false
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -547,9 +547,8 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
     /**
      * Like {@link #newReader}, but with the real {@link KNN1040HalfFloatVectorScorer} chain instead of
-     * a mock. {@code selectScorer}'s mmap-native branch calls {@code flatVectorsScorer.getRandomVectorScorer}
-     * directly (unlike the non-mmap fallback branch, which never touches the injected scorer), so a
-     * mock would return null there instead of exercising real scoring.
+     * a mock, so mmap-directory tests exercise real native SIMD scoring (via
+     * {@code KNN1040HalfFloatFlatVectorsValues#selectScorer}) end-to-end instead of a mocked result.
      */
     private FlatVectorsReader newReaderWithRealScorer(SegmentReadState readState) throws Exception {
         FlatVectorsScorer scorer = new KNN1040HalfFloatVectorScorer(

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -37,12 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Tests {@link KNN1040HalfFloatFlatVectorsReader} in isolation, without going through
- * {@link KNN1040HalfFloatFlatVectorsWriter}. Fixtures are written directly with low-level Lucene
- * primitives (mirroring the writer's on-disk layout, not calling the writer class itself), so a bug
- * introduced only in the writer can't mask a bug in the reader, or vice versa.
- */
 public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
     private static final String FIELD_NAME = "fp16_vector";
@@ -131,8 +125,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testFieldEntry_dimensionMismatch_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
-            // Meta records DIMENSION+1 vectors' worth of dimension, but FieldInfo (read separately by
-            // the reader) still says DIMENSION - triggers the "Inconsistent vector dimension" check.
             SegmentReadState readState = writeRawSegment(
                 dir,
                 new float[][] { { 1f, 2f, 3f, 4f } },
@@ -147,8 +139,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testFieldEntry_similarityMismatch_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
-            // Meta records COSINE's ordinal, but FieldInfo says EUCLIDEAN - triggers the "Inconsistent
-            // vector similarity function" check.
             SegmentReadState readState = writeRawSegment(
                 dir,
                 new float[][] { { 1f, 2f, 3f, 4f } },
@@ -191,8 +181,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testReadFields_unknownFieldNumber_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
-            // FieldInfos only has field number 0 (see createFieldInfo); recording 99 in meta instead
-            // triggers readFields()'s own "Invalid field number" check, before FieldEntry ever exists.
             SegmentReadState readState = writeRawSegment(
                 dir,
                 new float[][] { { 1f, 2f, 3f, 4f } },
@@ -207,8 +195,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testReadSimilarityFunction_outOfRangeOrdinal_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
-            // 99 is out of SIMILARITY_FUNCTIONS' range - caught by readSimilarityFunction() itself,
-            // distinct from testFieldEntry_similarityMismatch_throws's in-range-but-wrong value.
             SegmentReadState readState = writeRawSegment(
                 dir,
                 new float[][] { { 1f, 2f, 3f, 4f } },
@@ -223,8 +209,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testReadVectorEncoding_outOfRangeOrdinal_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
-            // 99 is out of VectorEncoding.values()' range - caught by readVectorEncoding() itself,
-            // distinct from testFieldEntry_encodingMismatch_throws's in-range-but-wrong value.
             SegmentReadState readState = writeRawSegment(
                 dir,
                 new float[][] { { 1f, 2f, 3f, 4f } },
@@ -288,8 +272,6 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
             SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
             String vectorDataFileName = IndexFileNames.segmentFileName("_0", "", KNN1040HalfFloatFlatVectorsFormat.VECTOR_DATA_EXTENSION);
             dir.deleteFile(vectorDataFileName);
-            // Too short for even the codec header - checkIndexHeader() fails before any of our own
-            // validation runs, exercising openDataInput()'s own success==false cleanup path.
             try (IndexOutput truncated = dir.createOutput(vectorDataFileName, IOContext.DEFAULT)) {
                 truncated.writeByte((byte) 0);
             }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -23,15 +23,25 @@ import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -267,6 +277,189 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testGetRandomVectorScorer_nonMmapDirectory_matchesExpectedSimilarity() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f }, { 0.5f, 0.5f, 0.5f, 0.5f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                float[] query = { 1f, 1f, 1f, 1f };
+                RandomVectorScorer scorer = reader.getRandomVectorScorer(FIELD_NAME, query);
+                assertNotNull(scorer);
+                assertEquals(vectors.length, scorer.maxOrd());
+
+                for (int i = 0; i < vectors.length; i++) {
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, scorer.score(i), 1e-3f);
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_emptySegment_returnsNull() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[0][0],
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().maxDoc(5).build()
+            );
+            try (FlatVectorsReader reader = newReader(readState)) {
+                assertNull(reader.getRandomVectorScorer(FIELD_NAME, new float[] { 1f, 1f, 1f, 1f }));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_nonMmapDirectory_collectsAllVectorsWithoutThrowing() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f }, { 0.5f, 0.5f, 0.5f, 0.5f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                float[] query = { 1f, 1f, 1f, 1f };
+                KnnCollector collector = new TopKnnCollector(vectors.length, Integer.MAX_VALUE);
+                reader.search(FIELD_NAME, query, collector, AcceptDocs.fromLiveDocs(null, vectors.length));
+
+                // topDocs() drains the underlying queue, so call it exactly once.
+                ScoreDoc[] scoreDocs = collector.topDocs().scoreDocs;
+                assertEquals(vectors.length, scoreDocs.length);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_emptySegment_collectsNothingWithoutThrowing() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(
+                dir,
+                new float[0][0],
+                VectorSimilarityFunction.EUCLIDEAN,
+                Overrides.builder().maxDoc(5).build()
+            );
+            try (FlatVectorsReader reader = newReader(readState)) {
+                KnnCollector collector = new TopKnnCollector(5, Integer.MAX_VALUE);
+                reader.search(FIELD_NAME, new float[] { 1f, 1f, 1f, 1f }, collector, AcceptDocs.fromLiveDocs(null, 5));
+                assertEquals(0, collector.topDocs().scoreDocs.length);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_mmapDirectory_wrapsInMMapFloatVectorValuesAndDecodesCorrectly() {
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                assertTrue("expected mmap-backed values for this test", values instanceof MMapFloatVectorValues);
+                assertEquals(DIMENSION, values.dimension());
+                assertEquals(vectors.length, values.size());
+
+                for (int i = 0; i < vectors.length; i++) {
+                    float[] actual = values.vectorValue(i);
+                    for (int d = 0; d < DIMENSION; d++) {
+                        float expected = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                        assertEquals("vector " + i + " dim " + d, expected, actual[d], 0.0f);
+                    }
+                }
+
+                // Exercises MMapFloatVectorValues' iterator()/ordToDoc() pass-throughs directly.
+                FloatVectorValues.DocIndexIterator iterator = values.iterator();
+                int ord = 0;
+                for (int doc = iterator.nextDoc(); doc != org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS; doc = iterator
+                    .nextDoc()) {
+                    assertEquals(ord, doc);
+                    assertEquals(ord, values.ordToDoc(ord));
+                    ord++;
+                }
+                assertEquals(vectors.length, ord);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_mmapDirectory_matchesExpectedSimilarity() {
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f }, { 0.5f, 0.5f, 0.5f, 0.5f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReaderWithRealScorer(readState)) {
+                float[] query = { 1f, 1f, 1f, 1f };
+                RandomVectorScorer scorer = reader.getRandomVectorScorer(FIELD_NAME, query);
+                assertNotNull(scorer);
+
+                for (int i = 0; i < vectors.length; i++) {
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.EUCLIDEAN.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, scorer.score(i), 1e-3f);
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_mmapDirectory_collectsAllVectorsWithoutThrowing() {
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f }, { 0.5f, 0.5f, 0.5f, 0.5f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReaderWithRealScorer(readState)) {
+                KnnCollector collector = new TopKnnCollector(vectors.length, Integer.MAX_VALUE);
+                reader.search(FIELD_NAME, new float[] { 1f, 1f, 1f, 1f }, collector, AcceptDocs.fromLiveDocs(null, vectors.length));
+                assertEquals(vectors.length, collector.topDocs().scoreDocs.length);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_cosineSimilarity_usesPureJavaFallbackAndMatchesExpected() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.COSINE);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                float[] query = { 1f, 1f, 1f, 1f };
+                RandomVectorScorer scorer = reader.getRandomVectorScorer(FIELD_NAME, query);
+                assertNotNull(scorer);
+
+                for (int i = 0; i < vectors.length; i++) {
+                    float[] decoded = new float[DIMENSION];
+                    for (int d = 0; d < DIMENSION; d++) {
+                        decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[i][d]));
+                    }
+                    float expected = VectorSimilarityFunction.COSINE.compare(query, decoded);
+                    assertEquals("Vector " + i, expected, scorer.score(i), 1e-3f);
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_repeatedOrdinal_hitsCacheAndReturnsSameArray() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            float[][] vectors = { { 1.5f, -2.5f, 3.25f, 0.0f }, { -1.0f, 2.0f, -3.0f, 4.0f } };
+            SegmentReadState readState = writeRawSegment(dir, vectors, VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+                float[] first = values.vectorValue(0);
+                float[] second = values.vectorValue(0);
+                assertSame("repeated access to the same ordinal should hit the cache", first, second);
+            }
+        }
+    }
+
+    @SneakyThrows
     public void testOpenDataInput_truncatedVectorDataFile_throws() {
         try (Directory dir = new ByteBuffersDirectory()) {
             SegmentReadState readState = writeRawSegment(dir, new float[][] { { 1f, 2f, 3f, 4f } }, VectorSimilarityFunction.EUCLIDEAN);
@@ -281,6 +474,19 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
 
     private FlatVectorsReader newReader(SegmentReadState readState) throws Exception {
         FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
+        return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);
+    }
+
+    /**
+     * Like {@link #newReader}, but with the real {@link KNN1040HalfFloatVectorScorer} chain instead of
+     * a mock. {@code selectScorer}'s mmap-native branch calls {@code flatVectorsScorer.getRandomVectorScorer}
+     * directly (unlike the non-mmap fallback branch, which never touches the injected scorer), so a
+     * mock would return null there instead of exercising real scoring.
+     */
+    private FlatVectorsReader newReaderWithRealScorer(SegmentReadState readState) throws Exception {
+        FlatVectorsScorer scorer = new KNN1040HalfFloatVectorScorer(
+            new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorsScorerProvider.getLucene99FlatVectorsScorer()))
+        );
         return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -211,7 +211,7 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
                 VectorSimilarityFunction.EUCLIDEAN,
                 Overrides.builder().metaSimilarityOrdinal(99).build()
             );
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newReader(readState));
+            CorruptIndexException e = expectThrows(CorruptIndexException.class, () -> newReader(readState));
             assertTrue(e.getMessage().contains("invalid distance function"));
         }
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsReaderTests.java
@@ -512,6 +512,37 @@ public class KNN1040HalfFloatFlatVectorsReaderTests extends KNNTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testGetFloatVectorValues_whenFieldHasNoVectorsOnMmap_thenReturnsEmptyUnmappedValues() {
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            SegmentReadState readState = writeRawSegment(dir, new float[0][], VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+
+                assertNotNull(values);
+                assertEquals(0, values.size());
+                assertFalse("there is nothing to map for an empty field", values instanceof MMapFloatVectorValues);
+                assertNull(reader.getRandomVectorScorer(FIELD_NAME, new float[DIMENSION]));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetFloatVectorValues_whenFieldHasNoVectorsOnHeap_thenReturnsEmptyValues() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            SegmentReadState readState = writeRawSegment(dir, new float[0][], VectorSimilarityFunction.EUCLIDEAN);
+
+            try (FlatVectorsReader reader = newReader(readState)) {
+                FloatVectorValues values = reader.getFloatVectorValues(FIELD_NAME);
+
+                assertNotNull(values);
+                assertEquals(0, values.size());
+                assertNull(reader.getRandomVectorScorer(FIELD_NAME, new float[DIMENSION]));
+            }
+        }
+    }
+
     private FlatVectorsReader newReader(SegmentReadState readState) throws Exception {
         FlatVectorsScorer scorer = Mockito.mock(FlatVectorsScorer.class);
         return new KNN1040HalfFloatFlatVectorsReader(readState, scorer);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
@@ -6,7 +6,6 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
-import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -29,15 +28,15 @@ import static org.mockito.Mockito.mock;
 public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
 
     @SneakyThrows
-    public void testSelectFallbackScorer_nativeTierAvailable_isWrappedInPrefetchableScorer() {
-        assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.EUCLIDEAN, true);
+    public void testSelectNativeOrJavaScorer_nativeTierAvailable_isWrappedInPrefetchableScorer() {
+        assertNativeOrJavaScorerIsPrefetchable(VectorSimilarityFunction.EUCLIDEAN, true);
     }
 
     @SneakyThrows
-    public void testSelectFallbackScorer_noNativeKernel_isStillWrappedInPrefetchableScorer() {
+    public void testSelectNativeOrJavaScorer_noNativeKernel_isStillWrappedInPrefetchableScorer() {
         // COSINE never reaches the native branch at all (see NativeEngines990KnnVectorsScorer#getNativeFunctionType),
         // so this exercises the plain-Java anonymous scorer branch instead.
-        assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.COSINE, true);
+        assertNativeOrJavaScorerIsPrefetchable(VectorSimilarityFunction.COSINE, true);
     }
 
     @SneakyThrows
@@ -52,7 +51,6 @@ public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
                     0,
                     in,
                     null,
-                    mock(FlatVectorsScorer.class),
                     VectorSimilarityFunction.EUCLIDEAN
                 );
                 assertNull(values.scorer(new float[] { 1f, 1f, 1f, 1f }));
@@ -75,7 +73,7 @@ public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
 
             try (IndexInput in = dir.openInput("vals.vec", IOContext.DEFAULT)) {
                 try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
-                    // Forces the plain-Java fallback branch inside selectFallbackScorer, avoiding any
+                    // Forces the plain-Java fallback branch inside selectNativeOrJavaScorer, avoiding any
                     // dependency on whether the native SIMD lib happens to be loaded in this test run.
                     mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(false);
 
@@ -84,7 +82,6 @@ public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
                         vectors.length,
                         in,
                         null,
-                        mock(FlatVectorsScorer.class),
                         VectorSimilarityFunction.EUCLIDEAN
                     );
 
@@ -114,13 +111,18 @@ public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    private void assertFallbackScorerIsPrefetchable(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+    private void assertNativeOrJavaScorerIsPrefetchable(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
         final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
         final float[] target = new float[] { 1f, 2f, 3f };
 
         try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
             mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(simdSupported);
-            RandomVectorScorer scorer = KNN1040HalfFloatFlatVectorsValues.selectFallbackScorer(mockValues, target, similarityFunction);
+            RandomVectorScorer scorer = KNN1040HalfFloatFlatVectorsValues.selectNativeOrJavaScorer(
+                mockValues,
+                target,
+                similarityFunction,
+                null
+            );
             assertTrue(scorer instanceof PrefetchableRandomVectorScorer);
         }
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
@@ -6,12 +6,22 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
 import org.opensearch.knn.jni.SimdFp16;
 
 import static org.mockito.Mockito.mock;
@@ -28,6 +38,79 @@ public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
         // COSINE never reaches the native branch at all (see NativeEngines990KnnVectorsScorer#getNativeFunctionType),
         // so this exercises the plain-Java anonymous scorer branch instead.
         assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.COSINE, true);
+    }
+
+    @SneakyThrows
+    public void testScorer_zeroVectors_returnsNull() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            try (IndexOutput out = dir.createOutput("empty.vec", IOContext.DEFAULT)) {
+                // no bytes written; size=0
+            }
+            try (IndexInput in = dir.openInput("empty.vec", IOContext.DEFAULT)) {
+                KNN1040HalfFloatFlatVectorsValues values = new KNN1040HalfFloatFlatVectorsValues(
+                    4,
+                    0,
+                    in,
+                    null,
+                    mock(FlatVectorsScorer.class),
+                    VectorSimilarityFunction.EUCLIDEAN
+                );
+                assertNull(values.scorer(new float[] { 1f, 1f, 1f, 1f }));
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testScorer_nonEmpty_returnsWorkingVectorScorerOverACopiedInstance() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            int dimension = 4;
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f } };
+            byte[] buffer = new byte[dimension * Short.BYTES];
+            try (IndexOutput out = dir.createOutput("vals.vec", IOContext.DEFAULT)) {
+                for (float[] v : vectors) {
+                    KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(v, buffer, dimension);
+                    out.writeBytes(buffer, 0, buffer.length);
+                }
+            }
+
+            try (IndexInput in = dir.openInput("vals.vec", IOContext.DEFAULT)) {
+                try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+                    // Forces the plain-Java fallback branch inside selectFallbackScorer, avoiding any
+                    // dependency on whether the native SIMD lib happens to be loaded in this test run.
+                    mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(false);
+
+                    KNN1040HalfFloatFlatVectorsValues values = new KNN1040HalfFloatFlatVectorsValues(
+                        dimension,
+                        vectors.length,
+                        in,
+                        null,
+                        mock(FlatVectorsScorer.class),
+                        VectorSimilarityFunction.EUCLIDEAN
+                    );
+
+                    float[] target = { 1f, 1f, 1f, 1f };
+                    VectorScorer scorer = values.scorer(target);
+                    assertNotNull(scorer);
+
+                    // bulk() just needs to be reachable/return a usable Bulk; the scoring itself is
+                    // exercised via score()/iterator() below.
+                    assertNotNull(scorer.bulk(DocIdSetIterator.all(vectors.length)));
+
+                    FloatVectorValues.DocIndexIterator iterator = (FloatVectorValues.DocIndexIterator) scorer.iterator();
+                    int ord = 0;
+                    for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+                        float[] decoded = new float[dimension];
+                        for (int d = 0; d < dimension; d++) {
+                            decoded[d] = Float.float16ToFloat(Float.floatToFloat16(vectors[ord][d]));
+                        }
+                        float expected = VectorSimilarityFunction.EUCLIDEAN.compare(target, decoded);
+                        assertEquals("doc " + doc, expected, scorer.score(), 1e-3f);
+                        ord++;
+                    }
+                    assertEquals(vectors.length, ord);
+                }
+            }
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsValuesTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.jni.SimdFp16;
+
+import static org.mockito.Mockito.mock;
+
+public class KNN1040HalfFloatFlatVectorsValuesTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testSelectFallbackScorer_nativeTierAvailable_isWrappedInPrefetchableScorer() {
+        assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.EUCLIDEAN, true);
+    }
+
+    @SneakyThrows
+    public void testSelectFallbackScorer_noNativeKernel_isStillWrappedInPrefetchableScorer() {
+        // COSINE never reaches the native branch at all (see NativeEngines990KnnVectorsScorer#getNativeFunctionType),
+        // so this exercises the plain-Java anonymous scorer branch instead.
+        assertFallbackScorerIsPrefetchable(VectorSimilarityFunction.COSINE, true);
+    }
+
+    @SneakyThrows
+    private void assertFallbackScorerIsPrefetchable(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        final float[] target = new float[] { 1f, 2f, 3f };
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(simdSupported);
+            RandomVectorScorer scorer = KNN1040HalfFloatFlatVectorsValues.selectFallbackScorer(mockValues, target, similarityFunction);
+            assertTrue(scorer instanceof PrefetchableRandomVectorScorer);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -7,15 +7,27 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
 import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
 
 import java.lang.reflect.Field;
@@ -92,6 +104,205 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
             prefetchableField.setAccessible(true);
             assertTrue(prefetchableField.get(candidateScorer) instanceof PrefetchableRandomVectorScorer);
         }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_nonHalfFloatValues_delegatesDirectly() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+        final FloatVectorValues plainValues = mock(FloatVectorValues.class);
+        final RandomVectorScorerSupplier expected = mock(RandomVectorScorerSupplier.class);
+        when(mockDelegate.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, plainValues)).thenReturn(expected);
+
+        RandomVectorScorerSupplier result = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, plainValues);
+        assertSame(expected, result);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_byteTarget_delegatesToDelegate() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+        final KnnVectorValues values = mock(KnnVectorValues.class);
+        final byte[] target = { 1, 2, 3 };
+        final RandomVectorScorer expected = mock(RandomVectorScorer.class);
+        when(mockDelegate.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, values, target)).thenReturn(expected);
+
+        RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, values, target);
+        assertSame(expected, result);
+    }
+
+    @SneakyThrows
+    public void testToString_includesDelegateRepresentation() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        when(mockDelegate.toString()).thenReturn("mockDelegate");
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        assertEquals("KNN1040HalfFloatVectorScorer(delegate=mockDelegate)", scorer.toString());
+    }
+
+    @SneakyThrows
+    public void testScorer_requireDelegate_throwsBeforeSetScoringOrdinalIsCalled() {
+        RandomVectorScorerSupplier supplier = getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, true);
+        UpdateableRandomVectorScorer candidateScorer = supplier.scorer();
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> candidateScorer.score(0));
+        assertTrue(e.getMessage().contains("setScoringOrdinal"));
+    }
+
+    @SneakyThrows
+    public void testScorer_setScoringOrdinalCalledTwice_reusesDelegateThenScoresAndBulkScores() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            int dimension = 4;
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f }, { 2f, 2f, 2f, 2f } };
+            KNN1040HalfFloatFlatVectorsValues values = writeAndOpenValues(dir, "vals.vec", vectors, dimension);
+
+            final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+            final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+            try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+                mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
+
+                RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, values);
+                UpdateableRandomVectorScorer candidateScorer = supplier.scorer();
+
+                candidateScorer.setScoringOrdinal(0);
+                // Second call exercises the "reuse existing delegate/buffer" branch instead of allocating a new one.
+                candidateScorer.setScoringOrdinal(2);
+
+                float expectedSingle = expectedEuclidean(vectors, dimension, 2, 1);
+                assertEquals(expectedSingle, candidateScorer.score(1), 1e-3f);
+
+                float[] scores = new float[2];
+                float maxScore = candidateScorer.bulkScore(new int[] { 0, 1 }, scores, 2);
+                float expectedMax = Math.max(expectedEuclidean(vectors, dimension, 2, 0), expectedEuclidean(vectors, dimension, 2, 1));
+                assertEquals(expectedMax, maxScore, 1e-3f);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testScorerSupplier_copy_returnsNewSupplierBuiltOverCopiedValues() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        final KNN1040HalfFloatFlatVectorsValues copiedValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(copiedValues);
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
+
+            RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, mockValues);
+            RandomVectorScorerSupplier copiedSupplier = supplier.copy();
+
+            assertEquals(NATIVE_TIER_CLASS_NAME, copiedSupplier.getClass().getSimpleName());
+            assertNotSame(supplier, copiedSupplier);
+        }
+    }
+
+    @SneakyThrows
+    public void testHalfFloatRandomVectorScorer_mmapAddress_scoreAndBulkScoreUseNativeAddressPath() {
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            int dimension = 4;
+            float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f } };
+            KNN1040HalfFloatFlatVectorsValues values = writeAndOpenValues(dir, "mmap.vec", vectors, dimension);
+            long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(
+                values.getSlice(),
+                0,
+                values.getSlice().length()
+            );
+            assertNotNull("test host must support mmap address extraction", addressAndSize);
+
+            float[] target = { 1f, 1f, 1f, 1f };
+            KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer halfFloatScorer =
+                new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(
+                    values,
+                    target,
+                    SimdVectorComputeService.SimilarityFunctionType.FP16_L2,
+                    addressAndSize
+                );
+
+            float expected0 = expectedEuclidean(target, vectors, dimension, 0);
+            float expected1 = expectedEuclidean(target, vectors, dimension, 1);
+            assertEquals(expected0, halfFloatScorer.score(0), 1e-3f);
+
+            float[] scores = new float[2];
+            float maxScore = halfFloatScorer.bulkScore(new int[] { 0, 1 }, scores, 2);
+            assertEquals(Math.max(expected0, expected1), maxScore, 1e-3f);
+        }
+    }
+
+    @SneakyThrows
+    public void testHalfFloatRandomVectorScorer_nonMmap_bulkScoreGrowsBufferAndIdentityIdsPastDefaultBatchSize() {
+        try (Directory dir = new ByteBuffersDirectory()) {
+            int dimension = 2;
+            // Default non-mmap buffer is sized for 64 nodes; exceeding that forces both the byte
+            // buffer and the identity-ids array to grow past their initial allocation.
+            int numNodes = 100;
+            float[][] vectors = new float[numNodes][dimension];
+            for (int i = 0; i < numNodes; i++) {
+                vectors[i][0] = i;
+                vectors[i][1] = i + 1;
+            }
+            KNN1040HalfFloatFlatVectorsValues values = writeAndOpenValues(dir, "nonmmap.vec", vectors, dimension);
+
+            float[] target = { 1f, 2f };
+            KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer halfFloatScorer =
+                new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(
+                    values,
+                    target,
+                    SimdVectorComputeService.SimilarityFunctionType.FP16_L2,
+                    null
+                );
+
+            int[] nodes = new int[numNodes];
+            for (int i = 0; i < numNodes; i++) {
+                nodes[i] = i;
+            }
+            float[] scores = new float[numNodes];
+
+            float result = halfFloatScorer.bulkScore(nodes, scores, numNodes);
+            float expectedMax = 0f;
+            for (int i = 0; i < numNodes; i++) {
+                expectedMax = Math.max(expectedMax, expectedEuclidean(target, vectors, dimension, i));
+            }
+            assertEquals(expectedMax, result, 1e-2f);
+        }
+    }
+
+    private KNN1040HalfFloatFlatVectorsValues writeAndOpenValues(Directory dir, String fileName, float[][] vectors, int dimension)
+        throws Exception {
+        byte[] buffer = new byte[dimension * Short.BYTES];
+        try (IndexOutput out = dir.createOutput(fileName, IOContext.DEFAULT)) {
+            for (float[] v : vectors) {
+                KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(v, buffer, dimension);
+                out.writeBytes(buffer, 0, buffer.length);
+            }
+        }
+        IndexInput in = dir.openInput(fileName, IOContext.DEFAULT);
+        return new KNN1040HalfFloatFlatVectorsValues(
+            dimension,
+            vectors.length,
+            in,
+            null,
+            mock(FlatVectorsScorer.class),
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+    }
+
+    private float expectedEuclidean(float[][] vectors, int dimension, int targetOrd, int candidateOrd) {
+        return expectedEuclidean(decodeFp16(vectors[targetOrd], dimension), vectors, dimension, candidateOrd);
+    }
+
+    private float expectedEuclidean(float[] target, float[][] vectors, int dimension, int candidateOrd) {
+        return VectorSimilarityFunction.EUCLIDEAN.compare(target, decodeFp16(vectors[candidateOrd], dimension));
+    }
+
+    private float[] decodeFp16(float[] original, int dimension) {
+        float[] decoded = new float[dimension];
+        for (int d = 0; d < dimension; d++) {
+            decoded[d] = Float.float16ToFloat(Float.floatToFloat16(original[d]));
+        }
+        return decoded;
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -159,24 +159,25 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
             final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
             final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
 
+            RandomVectorScorerSupplier supplier;
             try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
                 mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
-
-                RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, values);
-                UpdateableRandomVectorScorer candidateScorer = supplier.scorer();
-
-                candidateScorer.setScoringOrdinal(0);
-                // Second call exercises the "reuse existing delegate/buffer" branch instead of allocating a new one.
-                candidateScorer.setScoringOrdinal(2);
-
-                float expectedSingle = expectedEuclidean(vectors, dimension, 2, 1);
-                assertEquals(expectedSingle, candidateScorer.score(1), 1e-3f);
-
-                float[] scores = new float[2];
-                float maxScore = candidateScorer.bulkScore(new int[] { 0, 1 }, scores, 2);
-                float expectedMax = Math.max(expectedEuclidean(vectors, dimension, 2, 0), expectedEuclidean(vectors, dimension, 2, 1));
-                assertEquals(expectedMax, maxScore, 1e-3f);
+                supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, values);
             }
+            assertEquals(NATIVE_TIER_CLASS_NAME, supplier.getClass().getSimpleName());
+
+            UpdateableRandomVectorScorer candidateScorer = supplier.scorer();
+
+            candidateScorer.setScoringOrdinal(0);
+            candidateScorer.setScoringOrdinal(2);
+
+            float expectedSingle = expectedEuclidean(vectors, dimension, 2, 1);
+            assertEquals(expectedSingle, candidateScorer.score(1), 1e-3f);
+
+            float[] scores = new float[2];
+            float maxScore = candidateScorer.bulkScore(new int[] { 0, 1 }, scores, 2);
+            float expectedMax = Math.max(expectedEuclidean(vectors, dimension, 2, 0), expectedEuclidean(vectors, dimension, 2, 1));
+            assertEquals(expectedMax, maxScore, 1e-3f);
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.jni.SimdFp16;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
+
+    private static final String NATIVE_TIER_CLASS_NAME = "HalfFloatRandomVectorScorerSupplier";
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_euclideanWithSimdSupported_usesNativeTier() {
+        assertNativeTierUsed(VectorSimilarityFunction.EUCLIDEAN, true);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_maximumInnerProductWithSimdSupported_usesNativeTier() {
+        assertNativeTierUsed(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, true);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_cosine_neverUsesNativeTierRegardlessOfSimd() {
+        // No native FP16 kernel exists for COSINE yet so must fall back even when SIMD is available.
+        assertFallbackTierUsed(VectorSimilarityFunction.COSINE, true);
+        assertFallbackTierUsed(VectorSimilarityFunction.COSINE, false);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_euclideanWithoutSimdSupported_usesFallbackTier() {
+        assertFallbackTierUsed(VectorSimilarityFunction.EUCLIDEAN, false);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_mmapAvailable_threadsAddressIntoSupplier() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        final long[] expectedAddress = new long[] { 123L, 456L };
+        final MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(mockValues, expectedAddress);
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
+
+            RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, mmapValues);
+            assertEquals(NATIVE_TIER_CLASS_NAME, supplier.getClass().getSimpleName());
+
+            Field addressField = supplier.getClass().getDeclaredField("addressAndSize");
+            addressField.setAccessible(true);
+            assertArrayEquals(expectedAddress, (long[]) addressField.get(supplier));
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_scorerWrapsDelegateInPrefetchableScorer() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        when(mockValues.vectorValue(anyInt())).thenReturn(new float[] { 1f, 2f, 3f });
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(true);
+
+            RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, mockValues);
+            UpdateableRandomVectorScorer candidateScorer = supplier.scorer();
+            candidateScorer.setScoringOrdinal(0);
+
+            Field prefetchableField = candidateScorer.getClass().getDeclaredField("prefetchableDelegate");
+            prefetchableField.setAccessible(true);
+            assertTrue(prefetchableField.get(candidateScorer) instanceof PrefetchableRandomVectorScorer);
+        }
+    }
+
+    @SneakyThrows
+    private void assertNativeTierUsed(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        RandomVectorScorerSupplier result = getRandomVectorScorerSupplier(similarityFunction, simdSupported);
+        assertEquals(NATIVE_TIER_CLASS_NAME, result.getClass().getSimpleName());
+    }
+
+    @SneakyThrows
+    private void assertFallbackTierUsed(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        RandomVectorScorerSupplier result = getRandomVectorScorerSupplier(similarityFunction, simdSupported);
+        assertNotEquals(NATIVE_TIER_CLASS_NAME, result.getClass().getSimpleName());
+    }
+
+    @SneakyThrows
+    private RandomVectorScorerSupplier getRandomVectorScorerSupplier(VectorSimilarityFunction similarityFunction, boolean simdSupported) {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        // Only reached by the fallback tier's DefaultFlatVectorScorer, which validates the encoding.
+        when(mockValues.getEncoding()).thenReturn(VectorEncoding.FLOAT32);
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(simdSupported);
+            return scorer.getRandomVectorScorerSupplier(similarityFunction, mockValues);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -85,6 +85,23 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testGetRandomVectorScorerSupplier_mmapAvailableButSimdUnsupported_stillUsesNativeTier() {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);
+
+        final KNN1040HalfFloatFlatVectorsValues mockValues = mock(KNN1040HalfFloatFlatVectorsValues.class);
+        when(mockValues.copy()).thenReturn(mockValues);
+        final MMapFloatVectorValues mmapValues = new MMapFloatVectorValues(mockValues, new long[] { 123L, 456L });
+
+        try (MockedStatic<SimdFp16> mockedSimdFp16 = Mockito.mockStatic(SimdFp16.class)) {
+            mockedSimdFp16.when(SimdFp16::isSIMDSupported).thenReturn(false);
+
+            RandomVectorScorerSupplier supplier = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, mmapValues);
+            assertEquals(NATIVE_TIER_CLASS_NAME, supplier.getClass().getSimpleName());
+        }
+    }
+
+    @SneakyThrows
     public void testGetRandomVectorScorerSupplier_scorerWrapsDelegateInPrefetchableScorer() {
         final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
         final KNN1040HalfFloatVectorScorer scorer = new KNN1040HalfFloatVectorScorer(mockDelegate);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -280,14 +280,7 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
             }
         }
         IndexInput in = dir.openInput(fileName, IOContext.DEFAULT);
-        return new KNN1040HalfFloatFlatVectorsValues(
-            dimension,
-            vectors.length,
-            in,
-            null,
-            mock(FlatVectorsScorer.class),
-            VectorSimilarityFunction.EUCLIDEAN
-        );
+        return new KNN1040HalfFloatFlatVectorsValues(dimension, vectors.length, in, null, VectorSimilarityFunction.EUCLIDEAN);
     }
 
     private float expectedEuclidean(float[][] vectors, int dimension, int targetOrd, int candidateOrd) {

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatVectorScorerTests.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
 
-    private static final String NATIVE_TIER_CLASS_NAME = "HalfFloatRandomVectorScorerSupplier";
+    private static final String NATIVE_TIER_CLASS_NAME = "NativeHalfFloatRandomVectorScorerSupplier";
 
     @SneakyThrows
     public void testGetRandomVectorScorerSupplier_euclideanWithSimdSupported_usesNativeTier() {
@@ -218,7 +218,7 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testHalfFloatRandomVectorScorer_mmapAddress_scoreAndBulkScoreUseNativeAddressPath() {
+    public void testNativeHalfFloatScorer_mmapAddress_scoreAndBulkScoreUseNativeAddressPath() {
         try (Directory dir = new MMapDirectory(createTempDir())) {
             int dimension = 4;
             float[][] vectors = { { 1f, 2f, 3f, 4f }, { 5f, 6f, 7f, 8f } };
@@ -231,8 +231,8 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
             assertNotNull("test host must support mmap address extraction", addressAndSize);
 
             float[] target = { 1f, 1f, 1f, 1f };
-            KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer halfFloatScorer =
-                new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(
+            KNN1040HalfFloatVectorScorer.NativeHalfFloatRandomVectorScorer halfFloatScorer =
+                new KNN1040HalfFloatVectorScorer.NativeHalfFloatRandomVectorScorer(
                     values,
                     target,
                     SimdVectorComputeService.SimilarityFunctionType.FP16_L2,
@@ -250,7 +250,7 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testHalfFloatRandomVectorScorer_nonMmap_bulkScoreGrowsBufferAndIdentityIdsPastDefaultBatchSize() {
+    public void testNativeHalfFloatScorer_nonMmap_bulkScoreGrowsBufferAndIdentityIdsPastDefaultBatchSize() {
         try (Directory dir = new ByteBuffersDirectory()) {
             int dimension = 2;
             // Default non-mmap buffer is sized for 64 nodes; exceeding that forces both the byte
@@ -264,8 +264,8 @@ public class KNN1040HalfFloatVectorScorerTests extends KNNTestCase {
             KNN1040HalfFloatFlatVectorsValues values = writeAndOpenValues(dir, "nonmmap.vec", vectors, dimension);
 
             float[] target = { 1f, 2f };
-            KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer halfFloatScorer =
-                new KNN1040HalfFloatVectorScorer.HalfFloatRandomVectorScorer(
+            KNN1040HalfFloatVectorScorer.NativeHalfFloatRandomVectorScorer halfFloatScorer =
+                new KNN1040HalfFloatVectorScorer.NativeHalfFloatRandomVectorScorer(
                     values,
                     target,
                     SimdVectorComputeService.SimilarityFunctionType.FP16_L2,

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MMapFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MMapFloatVectorValuesTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -25,7 +27,22 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class MMapFloatVectorValuesTests extends LuceneTestCase {
+    @SneakyThrows
+    public void testScorer_delegatesToWrappedFloatVectorValues() {
+        final FloatVectorValues mockDelegate = mock(FloatVectorValues.class);
+        final VectorScorer expected = mock(VectorScorer.class);
+        final float[] target = { 1f, 2f, 3f };
+        when(mockDelegate.scorer(target)).thenReturn(expected);
+
+        final MMapFloatVectorValues values = new MMapFloatVectorValues(mockDelegate, new long[] { 1L, 2L });
+
+        assertSame(expected, values.scorer(target));
+    }
+
     @SneakyThrows
     public void testValidBytesLoad() {
         // Creat temp dir


### PR DESCRIPTION
### Description
Adds the read path for FP16 half-float flat vector fields: `KNN1040HalfFloatFlatVectorsReader`, `KNN1040HalfFloatFlatVectorsValues`, and `KNN1040HalfFloatVectorScorer`, decoding FP16-encoded vector bytes back to `float[]` and selecting the fastest available scorer (mmap-backed native SIMD when available, otherwise a decode-free byte-buffer fallback) for both exhaustive flat search and HNSW graph construction. 

**More than half of the code changes (1200+ lines) are just tests.**

**Note:** `KNN1040HalfFloatFlatVectorsFormat#fieldsWriter` is a temporary `UnsupportedOperationException` stub here, replaced with the real writer once the companion writer PR merges, so this PR can be reviewed and merged independently of it. The two will be wired together in the follow-up FP16 Flat and HNSW formats PR. Tests for the Format will be added in the follow-up PR.

### Related Issues
Resolves #3438 and #3498 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
