### PR TITLE
[DO NOT MERGE] FP32 flat-vector dedup for FAISS (1/2): memory-optimized search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.9](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
+* Add opt-in FP32 flat-vector deduplication for FAISS in memory-optimized search [#3527](https://github.com/opensearch-project/k-NN/pull/3527)
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -26,6 +26,7 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0008-Added-skipping-flat-storage-availability-in-write_in.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0009-Fixing-radial-search-for-IndexHNSWCagra.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0010-Make-selective-FAISS_THROW_IF_NOT-d-8-0-in-IndexBina.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0011-Forward-io_flags-through-float-IndexIDMap-write.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss)

--- a/jni/include/faiss_methods.h
+++ b/jni/include/faiss_methods.h
@@ -36,7 +36,7 @@ public:
 
     virtual faiss::IndexIDMapTemplate<faiss::IndexBinary>* indexBinaryIdMap(faiss::IndexBinary* index);
 
-    virtual void writeIndex(const faiss::Index* idx, faiss::IOWriter* writer);
+    virtual void writeIndex(const faiss::Index* idx, faiss::IOWriter* writer, bool skipFlat);
 
     virtual void writeIndexBinary(const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat);
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -73,9 +73,9 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteInde
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    writeIndex
- * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;)V
+ * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;Z)V
  */
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv *, jclass, jlong, jobject);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv *, jclass, jlong, jobject, jboolean);
 
 
 /*

--- a/jni/patches/faiss/0011-Forward-io_flags-through-float-IndexIDMap-write.patch
+++ b/jni/patches/faiss/0011-Forward-io_flags-through-float-IndexIDMap-write.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gaurav Kumar <gku@amazon.com>
+Date: Wed, 20 Aug 2026 00:00:00 -0700
+Subject: [PATCH] Forward io_flags through the float IndexIDMap write branch
+
+Mirror patch 0008 (which added IO_FLAG_SKIP_STORAGE forwarding for the
+binary IndexBinaryIDMap) for the float write path. The float index is
+serialized as IndexIDMap wrapping IndexHNSWFlat; without forwarding
+io_flags here, IO_FLAG_SKIP_STORAGE never reaches the IndexHNSW writer
+(which already honors it at the "null" storage branch), so a graph-only
+.faiss cannot be produced for FP32 flat-vector deduplication.
+
+Signed-off-by: Gaurav Kumar <gku@amazon.com>
+---
+ faiss/impl/index_write.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/faiss/impl/index_write.cpp b/faiss/impl/index_write.cpp
+index def7dcd2b..f396177e1 100644
+--- a/faiss/impl/index_write.cpp
++++ b/faiss/impl/index_write.cpp
+@@ -765,7 +765,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
+         // no need to store additional info for IndexIDMap2
+         WRITE1(h);
+         write_index_header(idxmap, f);
+-        write_index(idxmap->index, f);
++        write_index(idxmap->index, f, io_flags);
+         WRITEVECTOR(idxmap->id_map);
+     } else if (const IndexHNSW* idxhnsw = dynamic_cast<const IndexHNSW*>(idx)) {
+         uint32_t h = dynamic_cast<const IndexHNSWFlat*>(idx) ? fourcc("IHNf")

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -149,7 +149,7 @@ void IndexService::writeIndex(
 
     try {
         // Write the index to disk
-        faissMethods->writeIndex(idMap.get(), writer);
+        faissMethods->writeIndex(idMap.get(), writer, skipFlat);
         if (auto openSearchIOWriter = dynamic_cast<knn_jni::stream::FaissOpenSearchIOWriter*>(writer)) {
             openSearchIOWriter->flush();
         }
@@ -396,7 +396,7 @@ void ByteIndexService::writeIndex(
 
     try {
         // Write the index to disk
-        faissMethods->writeIndex(idMap.get(), writer);
+        faissMethods->writeIndex(idMap.get(), writer, skipFlat);
         if (auto openSearchIOWriter = dynamic_cast<knn_jni::stream::FaissOpenSearchIOWriter*>(writer)) {
             openSearchIOWriter->flush();
         }

--- a/jni/src/faiss_methods.cpp
+++ b/jni/src/faiss_methods.cpp
@@ -30,8 +30,8 @@ faiss::IndexIDMapTemplate<faiss::IndexBinary>* FaissMethods::indexBinaryIdMap(fa
     return new faiss::IndexBinaryIDMap(index);
 }
 
-void FaissMethods::writeIndex(const faiss::Index* idx, faiss::IOWriter* writer) {
-    faiss::write_index(idx, writer);
+void FaissMethods::writeIndex(const faiss::Index* idx, faiss::IOWriter* writer, bool skipFlat) {
+    faiss::write_index(idx, writer, skipFlat ? faiss::IO_FLAG_SKIP_STORAGE : 0);
 }
 
 void FaissMethods::writeIndexBinary(const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat) {

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -161,12 +161,13 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteInde
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv * env,
                                                                            jclass cls,
                                                                            jlong indexAddress,
-                                                                           jobject output)
+                                                                           jobject output,
+                                                                           jboolean skipFlat)
 {
   try {
       std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
       knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
-      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &indexService);
+      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &indexService, skipFlat);
   } catch (...) {
       jniUtil.CatchCppExceptionAndThrowJava(env);
   }

--- a/jni/tests/faiss_index_service_test.cpp
+++ b/jni/tests/faiss_index_service_test.cpp
@@ -60,7 +60,7 @@ TEST(CreateIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter)))
+    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter), false))
         .Times(1);
 
     // Create the index
@@ -152,7 +152,7 @@ TEST(CreateByteIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter)))
+    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter), false))
         .Times(1);
 
     // Create the index

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -18,6 +18,8 @@
 #include "jni_util.h"
 #include "test_util.h"
 #include "faiss/IndexHNSW.h"
+#include "faiss/IndexIDMap.h"
+#include "faiss/index_io.h"
 #include "faiss/IndexBinaryHNSW.h"
 #include "faiss/IndexIVFPQ.h"
 #include "faiss/IndexIVFFlat.h"
@@ -1926,4 +1928,52 @@ TEST(FaissLoadIndexWithStreamADCTest, PreservesIdMapping) {
 
     // Clean up
     knn_jni::faiss_wrapper::Free(resultPtr, JNI_FALSE);
+}
+
+// Verifies the FP32 flat-vector dedup write side: writing a float IndexIDMap<IndexHNSWFlat> with
+// IO_FLAG_SKIP_STORAGE must produce a graph-only index (null storage). This exercises faiss patch 0011,
+// which forwards io_flags through the float IndexIDMap write branch so the flag reaches the IndexHNSW
+// writer's "null" storage branch. Without the patch, the storage would still be embedded.
+TEST(FaissFloatSkipStorageTest, GraphOnlyIndexWrittenWithSkipStorage) {
+    const int dim = 8;
+    const int numVecs = 60;
+    std::vector<float> vectors(dim * numVecs);
+    for (int i = 0; i < dim * numVecs; ++i) {
+        vectors[i] = test_util::RandomFloat(-1.0f, 1.0f);
+    }
+    std::vector<faiss::idx_t> ids(numVecs);
+    for (int i = 0; i < numVecs; ++i) {
+        ids[i] = i;
+    }
+
+    // Mirror the OpenSearch FP32 write layout: IndexIDMap wrapping IndexHNSWFlat.
+    faiss::IndexHNSWFlat hnsw(dim, 16, faiss::METRIC_L2);
+    faiss::IndexIDMap idMap(&hnsw);
+    idMap.add_with_ids(numVecs, vectors.data(), ids.data());
+
+    const std::string fullPath = test_util::RandomString(16, "tmp/", ".faiss");
+    const std::string skipPath = test_util::RandomString(16, "tmp/", ".faiss");
+
+    // Full write embeds the flat storage; skip write must omit it (graph-only).
+    faiss::write_index(&idMap, fullPath.c_str());
+    faiss::write_index(&idMap, skipPath.c_str(), faiss::IO_FLAG_SKIP_STORAGE);
+
+    // Full build: storage is present.
+    std::unique_ptr<faiss::Index> readFull(faiss::read_index(fullPath.c_str()));
+    auto* idMapFull = dynamic_cast<faiss::IndexIDMap*>(readFull.get());
+    ASSERT_NE(idMapFull, nullptr);
+    auto* hnswFull = dynamic_cast<faiss::IndexHNSW*>(idMapFull->index);
+    ASSERT_NE(hnswFull, nullptr);
+    ASSERT_NE(hnswFull->storage, nullptr);
+
+    // Graph-only build: storage is null (the "null" marker). Relies on faiss patch 0011.
+    std::unique_ptr<faiss::Index> readSkip(faiss::read_index(skipPath.c_str()));
+    auto* idMapSkip = dynamic_cast<faiss::IndexIDMap*>(readSkip.get());
+    ASSERT_NE(idMapSkip, nullptr);
+    auto* hnswSkip = dynamic_cast<faiss::IndexHNSW*>(idMapSkip->index);
+    ASSERT_NE(hnswSkip, nullptr);
+    ASSERT_EQ(hnswSkip->storage, nullptr);
+
+    std::remove(fullPath.c_str());
+    std::remove(skipPath.c_str());
 }

--- a/jni/tests/mocks/faiss_methods_mock.h
+++ b/jni/tests/mocks/faiss_methods_mock.h
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD(faiss::IndexBinary*, indexBinaryFactory, (int d, const char* description), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::Index>*, indexIdMap, (faiss::Index* index), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::IndexBinary>*, indexBinaryIdMap, (faiss::IndexBinary* index), (override));
-    MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, faiss::IOWriter* writer), (override));
+    MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, faiss::IOWriter* writer, bool skipFlat), (override));
     MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat), (override));
 };
 

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -41,6 +41,7 @@ import java.security.InvalidParameterException;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -86,6 +87,7 @@ public class KNNSettings {
      * Settings name
      */
     public static final String INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD = "index.knn.advanced.approximate_threshold";
+    public static final String INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP = "index.knn.advanced.flat_vector_dedup";
     public static final String KNN_ALGO_PARAM_EF_SEARCH = "index.knn.algo_param.ef_search";
     public static final String KNN_ALGO_PARAM_INDEX_THREAD_QTY = "knn.algo_param.index_thread_qty";
     public static final String KNN_MEMORY_CIRCUIT_BREAKER_ENABLED = "knn.memory.circuit_breaker.enabled";
@@ -138,6 +140,7 @@ public class KNNSettings {
     public static final boolean KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
     public static final Integer INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE = 0;
+    public static final boolean INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE = false;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN = -1;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX = Integer.MAX_VALUE - 2;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_M = 16;
@@ -207,6 +210,50 @@ public class KNNSettings {
         INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
         INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
         INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX,
+        IndexScope,
+        Dynamic
+    );
+
+    /**
+     * When enabled on a FAISS FP32 index, the flat vectors are not embedded in the .faiss file (a graph-only index is
+     * written). Vectors are served from Lucene's .vec file at search time, avoiding the duplicate on-disk storage.
+     * Index-scoped, dynamic, and OFF by default. FP32 native (FAISS) HNSW only; other data types are ignored.
+     */
+    public static final Setting<Boolean> INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING = Setting.boolSetting(
+        INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP,
+        INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE,
+        // Flat-vector dedup writes a graph-only .faiss whose vectors are served from Lucene's .vec only by
+        // memory-optimized search. It is therefore only safe to enable together with memory_optimized_search.
+        // (MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING is referenced lazily at validation time, so the forward
+        // reference to a field declared later in this class is safe.)
+        new Setting.Validator<Boolean>() {
+            @Override
+            public void validate(final Boolean value) {
+                // Cross-setting validation is performed in the two-argument overload.
+            }
+
+            @Override
+            public void validate(final Boolean value, final Map<Setting<?>, Object> settings) {
+                if (Boolean.TRUE.equals(value) == false) {
+                    return;
+                }
+                final Object memoryOptimizedSearchEnabled = settings.get(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
+                if (Boolean.TRUE.equals(memoryOptimizedSearchEnabled) == false) {
+                    throw new IllegalArgumentException(
+                        "["
+                            + INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP
+                            + "] can only be enabled when ["
+                            + MEMORY_OPTIMIZED_KNN_SEARCH_MODE
+                            + "] is enabled on the index."
+                    );
+                }
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                return List.<Setting<?>>of(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING).iterator();
+            }
+        },
         IndexScope,
         Dynamic
     );
@@ -741,6 +788,7 @@ public class KNNSettings {
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
             INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING,
+            INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING,
             KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING,
             KNN_CIRCUIT_BREAKER_TRIGGERED_SETTING,
@@ -1138,6 +1186,40 @@ public class KNNSettings {
         final IndexSettings indexSettings = mapperService.getIndexSettings();
         final Integer approximateThresholdValue = indexSettings.getValue(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
         return approximateThresholdValue != null ? approximateThresholdValue : INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
+    }
+
+    /**
+     * Retrieves the {@code index.knn.advanced.flat_vector_dedup} value from the given
+     * {@link org.opensearch.index.mapper.MapperService}'s index settings, or returns the default value (false) when
+     * {@code mapperService} is null or the setting is not explicitly configured.
+     *
+     * @param mapperService the mapper service (nullable)
+     * @return whether flat-vector deduplication (graph-only .faiss) is enabled for the index
+     */
+    public static boolean isFlatVectorDedupEnabled(@Nullable MapperService mapperService) {
+        if (mapperService == null) {
+            return INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE;
+        }
+        final IndexSettings indexSettings = mapperService.getIndexSettings();
+        final Boolean flatVectorDedupEnabled = indexSettings.getValue(INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING);
+        return flatVectorDedupEnabled != null ? flatVectorDedupEnabled : INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE;
+    }
+
+    /**
+     * Retrieves the {@code index.knn.memory_optimized_search} value from the given
+     * {@link org.opensearch.index.mapper.MapperService}'s index settings, or returns the default value (false) when
+     * {@code mapperService} is null or the setting is not explicitly configured. Named distinctly from the
+     * {@code String}-indexName overload to avoid an ambiguous overload when called with a {@code null} literal.
+     *
+     * @param mapperService the mapper service (nullable)
+     * @return whether memory-optimized search is enabled for the index
+     */
+    public static boolean isMemoryOptimizedKnnSearchModeEnabledForMapper(@Nullable MapperService mapperService) {
+        if (mapperService == null) {
+            return DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
+        }
+        final Boolean memoryOptimizedSearchEnabled = mapperService.getIndexSettings().getValue(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
+        return memoryOptimizedSearchEnabled != null ? memoryOptimizedSearchEnabled : DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
     }
 
     private static String percentageAsString(Integer percentage) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -126,7 +126,9 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
                 approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
-                quantizedValues
+                quantizedValues,
+                // SQ has its own graph-only path; FP32 flat-vector dedup does not apply here.
+                false
             );
         } finally {
             IOUtils.close(flatVectorsReader);
@@ -167,7 +169,9 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
                 approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
-                quantizedValues
+                quantizedValues,
+                // SQ has its own graph-only path; FP32 flat-vector dedup does not apply here.
+                false
             );
         } finally {
             IOUtils.close(flatVectorsReader);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -41,6 +41,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
     private final int approximateThreshold;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final boolean flatVectorDedup;
 
     public NativeEngines990KnnVectorsFormat() {
         this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE);
@@ -54,9 +55,18 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
         int approximateThreshold,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
+        this(approximateThreshold, nativeIndexBuildStrategyFactory, KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE);
+    }
+
+    public NativeEngines990KnnVectorsFormat(
+        int approximateThreshold,
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        boolean flatVectorDedup
+    ) {
         super(FORMAT_NAME);
         this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.flatVectorDedup = flatVectorDedup;
     }
 
     /**
@@ -70,7 +80,8 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
             state,
             flatVectorsFormat.fieldsWriter(state),
             approximateThreshold,
-            nativeIndexBuildStrategyFactory
+            nativeIndexBuildStrategyFactory,
+            flatVectorDedup
         );
     }
 
@@ -109,6 +120,8 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
             + flatVectorsFormat
             + ", approximateThreshold="
             + approximateThreshold
+            + ", flatVectorDedup="
+            + flatVectorDedup
             + ")";
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -47,6 +47,7 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
     private boolean finished;
     private final Integer approximateThreshold;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final boolean flatVectorDedup;
 
     public NativeEngines990KnnVectorsWriter(
         SegmentWriteState segmentWriteState,
@@ -54,10 +55,21 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
         Integer approximateThreshold,
         NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
+        this(segmentWriteState, flatVectorsWriter, approximateThreshold, nativeIndexBuildStrategyFactory, false);
+    }
+
+    public NativeEngines990KnnVectorsWriter(
+        SegmentWriteState segmentWriteState,
+        FlatVectorsWriter flatVectorsWriter,
+        Integer approximateThreshold,
+        NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        boolean flatVectorDedup
+    ) {
         this.segmentWriteState = segmentWriteState;
         this.flatVectorsWriter = flatVectorsWriter;
         this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.flatVectorDedup = flatVectorDedup;
     }
 
     /**
@@ -95,7 +107,8 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
                 approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
-                null
+                null,
+                flatVectorDedup
             );
         }
     }
@@ -107,7 +120,16 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
 
         if (mergeRunnable != null) mergeRunnable.run();
 
-        doMergeOneField(fieldInfo, mergeState, this::train, approximateThreshold, segmentWriteState, nativeIndexBuildStrategyFactory, null);
+        doMergeOneField(
+            fieldInfo,
+            mergeState,
+            this::train,
+            approximateThreshold,
+            segmentWriteState,
+            nativeIndexBuildStrategyFactory,
+            null,
+            flatVectorDedup
+        );
         return null;
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
@@ -40,7 +40,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
         final Integer approximateThreshold,
         final SegmentWriteState segmentWriteState,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean flatVectorDedup
     ) throws IOException {
         // Check total live docs first to avoid unnecessary supplier creation for empty fields
         final int totalLiveDocs;
@@ -89,7 +90,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
             segmentWriteState,
             quantizationState,
             nativeIndexBuildStrategyFactory,
-            quantizedByteVectorValues
+            quantizedByteVectorValues,
+            flatVectorDedup
         );
 
         final StopWatch stopWatch = new StopWatch().start();
@@ -106,7 +108,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
         final Integer approximateThreshold,
         final SegmentWriteState segmentWriteState,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean flatVectorDedup
     ) throws IOException {
         final VectorDataType vectorDataType = extractVectorDataType(fieldInfo);
         final Supplier<KNNVectorValues<?>> knnVectorValuesSupplier = getKNNVectorValuesSupplierForMerge(
@@ -143,7 +146,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
             segmentWriteState,
             quantizationState,
             nativeIndexBuildStrategyFactory,
-            quantizedByteVectorValues
+            quantizedByteVectorValues,
+            flatVectorDedup
         );
 
         final StopWatch stopWatch = new StopWatch().start();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -122,7 +122,13 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
 
             // Write vector
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                JNIService.writeIndex(indexInfo.getIndexOutputWithBuffer(), indexMemoryAddress, engine, indexParameters, false);
+                JNIService.writeIndex(
+                    indexInfo.getIndexOutputWithBuffer(),
+                    indexMemoryAddress,
+                    engine,
+                    indexParameters,
+                    indexInfo.isSkipVectorStorage()
+                );
                 return null;
             });
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -63,6 +63,9 @@ public class NativeIndexWriter {
     private final QuantizationState quantizationState;
     @Nullable
     private final QuantizedByteVectorValues quantizedByteVectorValues;
+    // When true (FAISS FP32 HNSW with index.knn.advanced.flat_vector_dedup enabled), a graph-only .faiss is written
+    // and vectors are served from Lucene's .vec file. Threaded from the codec format; false for all other cases.
+    private final boolean skipVectorStorage;
 
     /**
      * Gets the correct writer type from fieldInfo
@@ -71,7 +74,7 @@ public class NativeIndexWriter {
      * @return correct NativeIndexWriter to make index specified in fieldInfo
      */
     public static NativeIndexWriter getWriter(final FieldInfo fieldInfo, SegmentWriteState state) {
-        return createWriter(fieldInfo, state, null, new NativeIndexBuildStrategyFactory(), null);
+        return createWriter(fieldInfo, state, null, new NativeIndexBuildStrategyFactory(), null, false);
     }
 
     /**
@@ -95,7 +98,7 @@ public class NativeIndexWriter {
         final QuantizationState quantizationState,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
-        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, null);
+        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, null, false);
     }
 
     /**
@@ -115,7 +118,31 @@ public class NativeIndexWriter {
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
         @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
     ) {
-        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, quantizedByteVectorValues);
+        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, quantizedByteVectorValues, false);
+    }
+
+    /**
+     * Same as {@link #getWriter(FieldInfo, SegmentWriteState, QuantizationState, NativeIndexBuildStrategyFactory,
+     * QuantizedByteVectorValues)} with control over flat-vector dedup (graph-only .faiss).
+     *
+     * @param skipVectorStorage when true, the flat vector storage is skipped in the .faiss (FAISS FP32 HNSW only).
+     */
+    public static NativeIndexWriter getWriter(
+        final FieldInfo fieldInfo,
+        final SegmentWriteState state,
+        final QuantizationState quantizationState,
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean skipVectorStorage
+    ) {
+        return createWriter(
+            fieldInfo,
+            state,
+            quantizationState,
+            nativeIndexBuildStrategyFactory,
+            quantizedByteVectorValues,
+            skipVectorStorage
+        );
     }
 
     /**
@@ -219,6 +246,15 @@ public class NativeIndexWriter {
             parameters = getParameters(fieldInfo, vectorDataType, knnEngine);
         }
 
+        // Flat-vector dedup (graph-only .faiss) applies only to non-model FAISS FP32 fields, which build a plain HNSW
+        // via MemOptimizedNativeIndexBuildStrategy. Quantized (SQ) fields have their own graph-only path; models may be
+        // IVF (whose writer does not honor IO_FLAG_SKIP_STORAGE), so they are excluded.
+        final boolean skipVectorStorageForField = skipVectorStorage
+            && knnEngine == KNNEngine.FAISS
+            && vectorDataType == VectorDataType.FLOAT
+            && quantizationState == null
+            && fieldInfo.attributes().containsKey(MODEL_ID) == false;
+
         return BuildIndexParams.builder()
             .field(fieldInfo.getName())
             .indexParameters(parameters)
@@ -231,6 +267,7 @@ public class NativeIndexWriter {
             .segmentWriteState(state)
             .isFlush(isFlush)
             .quantizedByteVectorValues(quantizedByteVectorValues)
+            .skipVectorStorage(skipVectorStorageForField)
             .build();
     }
 
@@ -359,8 +396,16 @@ public class NativeIndexWriter {
         final SegmentWriteState state,
         @Nullable final QuantizationState quantizationState,
         NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean skipVectorStorage
     ) {
-        return new NativeIndexWriter(state, fieldInfo, nativeIndexBuildStrategyFactory, quantizationState, quantizedByteVectorValues);
+        return new NativeIndexWriter(
+            state,
+            fieldInfo,
+            nativeIndexBuildStrategyFactory,
+            quantizationState,
+            quantizedByteVectorValues,
+            skipVectorStorage
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
@@ -44,4 +44,10 @@ public class BuildIndexParams {
      */
     @Nullable
     QuantizedByteVectorValues quantizedByteVectorValues;
+    /**
+     * When true, the flat vector storage is not embedded in the .faiss file (a graph-only index is written via
+     * IO_FLAG_SKIP_STORAGE) and vectors are served from Lucene's .vec file at search time. Set only for FAISS FP32
+     * HNSW fields when {@code index.knn.advanced.flat_vector_dedup} is enabled; false otherwise.
+     */
+    boolean skipVectorStorage;
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -65,6 +65,11 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
     @Override
     public KnnVectorsFormat resolve() {
         final int approximateThreshold = KNNSettings.getApproximateThresholdValue(mapperService);
-        return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory);
+        // Only write a graph-only (deduped) .faiss when memory-optimized search is enabled: MOS is the only search
+        // path that serves vectors from Lucene's .vec, so graph-only segments are only safe to produce under MOS.
+        // KNNSettings validation enforces the same invariant at config time; this is the write-path safety net.
+        final boolean flatVectorDedup = KNNSettings.isFlatVectorDedupEnabled(mapperService)
+            && KNNSettings.isMemoryOptimizedKnnSearchModeEnabledForMapper(mapperService);
+        return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory, flatVectorDedup);
     }
 }

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -121,8 +121,11 @@ class FaissService {
      *
      * @param indexAddress address of native memory where index is stored
      * @param output       Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
+     * @param skipFlat     Control flag that skips flushing the flat vector storage into the .faiss file. When true, a
+     *                     graph-only index is written (the "null" storage marker) and vectors are served from Lucene's
+     *                     .vec file at search time.
      */
-    public static native void writeIndex(long indexAddress, IndexOutputWithBuffer output);
+    public static native void writeIndex(long indexAddress, IndexOutputWithBuffer output, boolean skipFlat);
 
     /**
      * Writes a faiss index.

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -113,7 +113,7 @@ public class JNIService {
             } else if (IndexUtil.isByteIndex(parameters)) {
                 FaissService.writeByteIndex(indexAddress, output);
             } else {
-                FaissService.writeIndex(indexAddress, output);
+                FaissService.writeIndex(indexAddress, output, skipFlat);
             }
             return;
         }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFP32FlatIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFP32FlatIndex.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import java.util.Locale;
+
+import lombok.Getter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * A virtual {@link FaissIndex} that serves full-precision FP32 vectors from Lucene's {@link FlatVectorsReader} instead
+ * of from the .faiss file. When flat-vector deduplication is enabled ({@code index.knn.advanced.flat_vector_dedup}), a
+ * FAISS FP32 HNSW graph is written without its embedded flat storage (IO_FLAG_SKIP_STORAGE), and the full-precision
+ * vectors live only in Lucene's .vec file. This class installs itself as the flat storage under {@link FaissHNSWIndex},
+ * delegating vector access to the Lucene reader.
+ *
+ * <p>Mirrors {@link FaissScalarQuantizedFlatIndex}, but extends {@link FaissIndex} directly (float storage is set via
+ * {@link AbstractFaissHNSWIndex#setFlatVectors}, which accepts any {@link FaissIndex}) and serves non-quantized floats.
+ */
+public class FaissFP32FlatIndex extends FaissIndex {
+    static final String FAISS_FP32_FLAT_INDEX = "FaissFP32FlatIndex";
+
+    @Getter
+    private final FlatVectorsReader flatVectorsReader;
+    @Getter
+    private final String fieldName;
+
+    public FaissFP32FlatIndex(final FlatVectorsReader flatVectorsReader, final String fieldName) {
+        super(FAISS_FP32_FLAT_INDEX);
+        this.flatVectorsReader = flatVectorsReader;
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    protected void doLoad(IndexInput input) throws IOException {
+        // No-op: full-precision vectors are managed by Lucene's FlatVectorsReader, not loaded from the .faiss file.
+    }
+
+    @Override
+    public VectorEncoding getVectorEncoding() {
+        return VectorEncoding.FLOAT32;
+    }
+
+    @Override
+    public FloatVectorValues getFloatValues(IndexInput indexInput) throws IOException {
+        return flatVectorsReader.getFloatVectorValues(fieldName);
+    }
+
+    @Override
+    public ByteVectorValues getByteValues(IndexInput indexInput) throws IOException {
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "%s does not support byte vector values.", FAISS_FP32_FLAT_INDEX)
+        );
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -12,6 +12,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
@@ -38,6 +39,12 @@ public class FaissFlatIndexFactory {
         if (FieldInfoExtractor.isSQField(fieldInfo)
             && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue()) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
+        }
+        // FP32 flat-vector dedup: a full-precision (non-quantized) float field whose embedded flat storage was skipped
+        // in the .faiss (index.knn.advanced.flat_vector_dedup). Serve the vectors from Lucene's .vec file.
+        if (FieldInfoExtractor.isSQField(fieldInfo) == false
+            && FieldInfoExtractor.extractVectorDataType(fieldInfo) == VectorDataType.FLOAT) {
+            return new FaissFP32FlatIndex(flatVectorsReader, fieldInfo.getName());
         }
         return null;
     }
@@ -94,6 +101,27 @@ public class FaissFlatIndexFactory {
                     "Unsupported metric type: " + metricType + ", only support " + Arrays.asList(FaissMetricType.values())
                 );
             }
+            return;
+        }
+
+        // Float HNSW path (local JNI build with IO_FLAG_SKIP_STORAGE for FP32 flat-vector dedup). A plain float HNSW
+        // (IHNf) whose flat storage was skipped loads a FaissEmptyIndex placeholder; replace it with a Lucene-backed
+        // FP32 flat index. NOTE: this method also handles binary/CAGRA; the "Binary" in its name is historical.
+        if (nested instanceof FaissHNSWIndex hnswIndex && FaissEmptyIndex.isEmptyIndex(hnswIndex.getFlatVectors())) {
+            final FaissIndex flatIndex = createFlatIndex(fieldInfo, flatVectorsReader);
+            if (flatIndex == null) {
+                throw new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "%s found for field [%s] but %s returned null - cannot wire flat storage for float HNSW index.",
+                        FaissEmptyIndex.class.getName(),
+                        fieldInfo.getName(),
+                        FaissFlatIndexFactory.class.getName()
+                    )
+                );
+            }
+            hnswIndex.setFlatVectors(flatIndex);
+            // No space type override needed - float HNSW reads the correct metric type from readCommonHeader() in doLoad().
             return;
         }
 

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -14,6 +14,8 @@ import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.env.Environment;
@@ -34,8 +36,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.opensearch.test.NodeRoles.dataNode;
@@ -313,5 +317,29 @@ public class KNNSettingsTests extends KNNTestCase {
         int availableProcessors = Runtime.getRuntime().availableProcessors();
         int expected = (availableProcessors >= 32) ? 4 : 1;
         assertEquals(expected, threadQtyWithEmpty);
+    }
+
+    public void testFlatVectorDedupRequiresMemoryOptimizedSearch() {
+        final Set<Setting<?>> registeredSettings = new HashSet<>(IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
+        registeredSettings.add(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING);
+        registeredSettings.add(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
+        final IndexScopedSettings indexScopedSettings = new IndexScopedSettings(Settings.EMPTY, registeredSettings);
+
+        // flat_vector_dedup enabled without memory_optimized_search is rejected.
+        final Settings dedupWithoutMos = Settings.builder()
+            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
+            .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, false)
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> indexScopedSettings.validate(dedupWithoutMos, true));
+
+        // flat_vector_dedup enabled together with memory_optimized_search is allowed.
+        final Settings dedupWithMos = Settings.builder()
+            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
+            .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
+            .build();
+        indexScopedSettings.validate(dedupWithMos, true);
+
+        // flat_vector_dedup disabled is always allowed, regardless of memory_optimized_search.
+        indexScopedSettings.validate(Settings.EMPTY, true);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -184,7 +184,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -285,7 +285,8 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                         segmentWriteState,
                         quantizationState,
                         nativeIndexBuildStrategyFactory,
-                        null
+                        null,
+                        false
                     )
                 ).thenReturn(nativeIndexWriter);
             });
@@ -383,7 +384,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -458,7 +459,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -533,7 +534,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -617,7 +618,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -716,7 +717,8 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                         segmentWriteState,
                         quantizationState,
                         nativeIndexBuildStrategyFactory,
-                        null
+                        null,
+                        false
                     )
                 ).thenReturn(nativeIndexWriter);
             });
@@ -826,7 +828,8 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                         segmentWriteState,
                         quantizationState,
                         nativeIndexBuildStrategyFactory,
-                        null
+                        null,
+                        false
                     )
                 ).thenReturn(nativeIndexWriter);
             });

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -166,7 +166,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
 
             when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
@@ -237,7 +237,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
 
             when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
@@ -299,7 +299,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
 
             when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
@@ -371,7 +371,14 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
             }
 
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(
+                    fieldInfo,
+                    segmentWriteState,
+                    quantizationState,
+                    nativeIndexBuildStrategyFactory,
+                    null,
+                    false
+                )
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
@@ -22,6 +22,7 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
@@ -65,6 +66,23 @@ public class MOSFaissFloatIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     public void testWhenNoIndexBuilt() {
         doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
         doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
+    }
+
+    // Enables FP32 flat-vector dedup (graph-only .faiss). With memory-optimized search, the vectors must be served from
+    // Lucene's .vec file and produce results identical to a normal (non-deduped) build.
+    private static final Consumer<Settings.Builder> FLAT_VECTOR_DEDUP_ENABLED = settingsBuilder -> settingsBuilder.put(
+        KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP,
+        true
+    );
+
+    public void testNonNestedFloatIndexWithFlatVectorDedup() {
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, FLAT_VECTOR_DEDUP_ENABLED);
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.INNER_PRODUCT, FLAT_VECTOR_DEDUP_ENABLED);
+    }
+
+    // Nested indexing exercises the sparse ordinal->docId path (FaissIdMapIndex) on top of the FP32 flat index.
+    public void testNestedFloatIndexWithFlatVectorDedup() {
+        doTestNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, SpaceType.L2, FLAT_VECTOR_DEDUP_ENABLED);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
@@ -193,7 +193,7 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testMaybeSetFlatIndex_whenCagraWithEmptyFlatVectorsAndNonSQField_thenThrows() {
+    public void testMaybeSetFlatIndex_whenCagraWithEmptyFlatVectorsAndFP32Field_thenSetsFP32FlatIndex() {
         FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
 
         FaissHNSWCagraIndex cagraIndex = new FaissHNSWCagraIndex(FaissHNSWCagraIndex.IHNC);
@@ -202,13 +202,64 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
         FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
         when(idMapIndex.getNestedIndex()).thenReturn(cagraIndex);
 
+        // Default field is full-precision FP32 (non-SQ). With flat-vector dedup, a graph-only float CAGRA index is now
+        // served from Lucene's .vec via FaissFP32FlatIndex instead of throwing (previously unsupported).
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
 
-        try {
-            FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("CAGRA"));
-        }
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertNotNull(cagraIndex.getFlatVectors());
+        assertFalse(FaissEmptyIndex.isEmptyIndex(cagraIndex.getFlatVectors()));
+        assertTrue(cagraIndex.getFlatVectors() instanceof FaissFP32FlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenFP32Field_thenReturnsFaissFP32FlatIndex() {
+        // A default (non-SQ, full-precision) float field maps to the FP32 flat index.
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissIndex result = FaissFlatIndexFactory.createFlatIndex(fieldInfo, mockReader);
+
+        assertTrue(result instanceof FaissFP32FlatIndex);
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenFloatHnswWithEmptyFlatVectors_thenSetsFP32FlatIndex() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        // Plain float HNSW (IHNf) whose flat storage was skipped (IO_FLAG_SKIP_STORAGE) loads a FaissEmptyIndex.
+        FaissHNSWIndex hnswIndex = new FaissHNSWIndex(FaissHNSWIndex.IHNF);
+        hnswIndex.setFlatVectors(FaissEmptyIndex.INSTANCE);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(hnswIndex);
+
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertNotNull(hnswIndex.getFlatVectors());
+        assertFalse(FaissEmptyIndex.isEmptyIndex(hnswIndex.getFlatVectors()));
+        assertTrue(hnswIndex.getFlatVectors() instanceof FaissFP32FlatIndex);
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenFloatHnswWithExistingFlatVectors_thenNoOp() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        // A normal (non-deduped) float HNSW already has real flat storage; it must not be overwritten.
+        FaissHNSWIndex hnswIndex = new FaissHNSWIndex(FaissHNSWIndex.IHNF);
+        FaissIndex existingFlat = mock(FaissIndex.class);
+        hnswIndex.setFlatVectors(existingFlat);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(hnswIndex);
+
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertSame(existingFlat, hnswIndex.getFlatVectors());
     }
 }


### PR DESCRIPTION
 > [!IMPORTANT]
> **Part 1 of 2. Draft - do not merge to `main`.** This is opened against `main` temporarily; it will be retargeted to a `flat-vector-dedup` feature branch, and the feature merges to `main` only when both parts are in. Part 2 (default/non-MOS path) is #3538.

Relates to #3526 (sub-task of #2823).

## Problem
For a FAISS FP32 `knn_vector` field, the raw vectors are stored twice per segment: once in Lucene's `.vec` and again embedded in the `.faiss` HNSW graph file. This doubles the on-disk footprint of the vector payload; the `.vec` copy is already the source of truth for exact search and rescoring.

## What this PR does (memory-optimized search)
Behind a new index setting `index.knn.advanced.flat_vector_dedup` (default **off**, FP32 native FAISS HNSW only):
- **Write:** serialize a **graph-only** `.faiss` via `IO_FLAG_SKIP_STORAGE` (skips embedded vectors). Includes a one-line faiss patch (`0011`) forwarding `io_flags` through the float `IndexIDMap` write.
- **Read (MOS):** `FaissFP32FlatIndex` serves vectors directly from `.vec`, so the graph-only `.faiss` is searchable under memory-optimized search.

The default (non-MOS) path is completed in #3538 (which reconstructs the flat storage from `.vec` at load); this PR enables the MOS path.

## Benchmark (1M × 768-d, FAISS HNSW, inner-product)
- **Index size on disk: -48.7%** (5.87 GB → 3.01 GB).
- Query latency and recall unchanged (identical vectors; once loaded the in-memory structure is identical). Verified on MOS and non-MOS.

## Testing
- MOS parity IT (`MOSFaissFloatIndexIT`): identical docIds/scores vs a non-deduped build, dense + nested, L2 + inner product.
- C++ `jni_test`: graph-only write produces null embedded storage.
- Full unit suite + JNI rebuild green.
