### PR TITLE
Fix native thread leak in Lucene HNSW merge executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixed multiple forbidden api warnings from the code []()
 
 ### Bug Fixes
+* Fix native thread leak in Lucene HNSW merge executor when index_thread_qty > 1 [#3102](https://github.com/opensearch-project/k-NN/issues/3102)
 * Fix knn query against a field alias returning zero hits silently [#3485](https://github.com/opensearch-project/k-NN/pull/3485)
 * Add prefetch for Lucene engine's fp32 and binary vector data type [#3504](https://github.com/opensearch-project/k-NN/pull/3504)
 * Fix when BQ file is not present in the segment as there is no vectors in the segment [#3511](https://github.com/opensearch-project/k-NN/pull/3511)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -134,10 +136,25 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
 
     private static Tuple<Integer, ExecutorService> getMergeThreadCountAndExecutorService() {
         int mergeThreadCount = KNNSettings.getIndexThreadQty();
+        return buildMergeThreadCountAndExecutorService(mergeThreadCount);
+    }
+
+    static Tuple<Integer, ExecutorService> buildMergeThreadCountAndExecutorService(int mergeThreadCount) {
+        return buildMergeThreadCountAndExecutorService(mergeThreadCount, 1L, TimeUnit.MILLISECONDS);
+    }
+
+    static Tuple<Integer, ExecutorService> buildMergeThreadCountAndExecutorService(
+        int mergeThreadCount,
+        long keepAliveTime,
+        TimeUnit keepAliveUnit
+    ) {
         if (mergeThreadCount <= 1) {
             return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
         }
-        return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(mergeThreadCount);
+        executor.setKeepAliveTime(keepAliveTime, keepAliveUnit);
+        executor.allowCoreThreadTimeOut(true);
+        return Tuple.tuple(mergeThreadCount, executor);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -19,6 +19,8 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class provides per field format implementation for Lucene Knn vector type
@@ -93,15 +95,26 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
     }
 
     private static Tuple<Integer, ExecutorService> getMergeThreadCountAndExecutorService() {
-        // To ensure that only once we are fetching the settings per segment, we are fetching the num threads once while
-        // creating the executors
         int mergeThreadCount = KNNSettings.getIndexThreadQty();
-        // We need to return null whenever the merge threads are <=1, as lucene assumes that if number of threads are 1
-        // then we should be giving a null value of the executor
+        return buildMergeThreadCountAndExecutorService(mergeThreadCount);
+    }
+
+    static Tuple<Integer, ExecutorService> buildMergeThreadCountAndExecutorService(int mergeThreadCount) {
+        return buildMergeThreadCountAndExecutorService(mergeThreadCount, 1L, TimeUnit.MILLISECONDS);
+    }
+
+    static Tuple<Integer, ExecutorService> buildMergeThreadCountAndExecutorService(
+        int mergeThreadCount,
+        long keepAliveTime,
+        TimeUnit keepAliveUnit
+    ) {
+        // Lucene expects a null executor when the merge thread count is <= 1
         if (mergeThreadCount <= 1) {
             return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
-        } else {
-            return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
         }
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(mergeThreadCount);
+        executor.setKeepAliveTime(keepAliveTime, keepAliveUnit);
+        executor.allowCoreThreadTimeOut(true);
+        return Tuple.tuple(mergeThreadCount, executor);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120LuceneMergeThreadTimeoutTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120LuceneMergeThreadTimeoutTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.util.UnitTestCodec;
+
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Verifies that real Lucene HNSW merges succeed when the merge executor
+ * uses allowCoreThreadTimeOut. A very short keepAlive (1 second) is used
+ * to stress-test that threads are not killed during an active merge, even
+ * when the timeout is aggressively short.
+ *
+ * Multiple segments are created and then force-merged into one. If the
+ * timeout fired mid-merge, the HNSW graph construction would fail or
+ * produce a corrupt graph, and the post-merge kNN search would return
+ * wrong results.
+ */
+public class KNN9120LuceneMergeThreadTimeoutTests extends KNNTestCase {
+
+    private static final String FIELD = "vector";
+    private static final int DIMENSION = 32;
+    private static final int DOCS_PER_SEGMENT = 500;
+    private static final int NUM_SEGMENTS = 6;
+    private static final int TOTAL_DOCS = DOCS_PER_SEGMENT * NUM_SEGMENTS;
+
+    @SneakyThrows
+    public void testForceMerge_withShortKeepAlive_thenSearchSucceeds() {
+        final int mergeThreads = 4;
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(mergeThreads);
+        executor.setKeepAliveTime(1L, TimeUnit.SECONDS);
+        executor.allowCoreThreadTimeOut(true);
+
+        try (Directory dir = newDirectory()) {
+            Codec codec = new UnitTestCodec(
+                () -> new Lucene99HnswVectorsFormat(
+                    Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN,
+                    Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
+                    mergeThreads,
+                    executor
+                )
+            );
+            IndexWriterConfig iwc = newIndexWriterConfig().setCodec(codec);
+            Random rng = new Random(42);
+
+            try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+                for (int seg = 0; seg < NUM_SEGMENTS; seg++) {
+                    for (int i = 0; i < DOCS_PER_SEGMENT; i++) {
+                        Document doc = new Document();
+                        doc.add(new KnnFloatVectorField(FIELD, randomVector(rng), VectorSimilarityFunction.EUCLIDEAN));
+                        writer.addDocument(doc);
+                    }
+                    writer.flush();
+                }
+
+                // Force merge triggers the HNSW merge path that uses the executor.
+                // With a 1-second keepAlive, any timing bug would cause threads to
+                // die mid-merge, corrupting the graph or throwing an exception.
+                writer.forceMerge(1);
+                writer.commit();
+            }
+
+            // Verify the merged index is searchable and returns correct results
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                assertEquals(TOTAL_DOCS, reader.numDocs());
+
+                float[] query = new float[DIMENSION];
+                for (int d = 0; d < DIMENSION; d++) {
+                    query[d] = 0.5f;
+                }
+                TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FIELD, query, 10), 10);
+                assertEquals(10, topDocs.scoreDocs.length);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @SneakyThrows
+    public void testRepeatedMerges_withShortKeepAlive_thenNoErrors() {
+        final int mergeThreads = 4;
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(mergeThreads);
+        executor.setKeepAliveTime(1L, TimeUnit.SECONDS);
+        executor.allowCoreThreadTimeOut(true);
+
+        try (Directory dir = newDirectory()) {
+            Codec codec = new UnitTestCodec(
+                () -> new Lucene99HnswVectorsFormat(
+                    Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN,
+                    Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
+                    mergeThreads,
+                    executor
+                )
+            );
+            Random rng = new Random(123);
+
+            // Round 1: index + merge
+            IndexWriterConfig iwc1 = newIndexWriterConfig().setCodec(codec);
+            try (IndexWriter writer = new IndexWriter(dir, iwc1)) {
+                for (int seg = 0; seg < 3; seg++) {
+                    for (int i = 0; i < 200; i++) {
+                        Document doc = new Document();
+                        doc.add(new KnnFloatVectorField(FIELD, randomVector(rng), VectorSimilarityFunction.EUCLIDEAN));
+                        writer.addDocument(doc);
+                    }
+                    writer.flush();
+                }
+                writer.forceMerge(1);
+                writer.commit();
+            }
+
+            // Let threads time out between merges
+            Thread.sleep(2000);
+            assertEquals(0, executor.getPoolSize());
+
+            // Round 2: more docs + another merge (threads must spin back up)
+            IndexWriterConfig iwc2 = newIndexWriterConfig().setCodec(codec).setOpenMode(IndexWriterConfig.OpenMode.APPEND);
+            try (IndexWriter writer = new IndexWriter(dir, iwc2)) {
+                for (int seg = 0; seg < 3; seg++) {
+                    for (int i = 0; i < 200; i++) {
+                        Document doc = new Document();
+                        doc.add(new KnnFloatVectorField(FIELD, randomVector(rng), VectorSimilarityFunction.EUCLIDEAN));
+                        writer.addDocument(doc);
+                    }
+                    writer.flush();
+                }
+                writer.forceMerge(1);
+                writer.commit();
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals(1200, reader.numDocs());
+                IndexSearcher searcher = new IndexSearcher(reader);
+                float[] query = new float[DIMENSION];
+                for (int d = 0; d < DIMENSION; d++) {
+                    query[d] = 0.5f;
+                }
+                TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FIELD, query, 10), 10);
+                assertEquals(10, topDocs.scoreDocs.length);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private float[] randomVector(Random rng) {
+        float[] v = new float[DIMENSION];
+        for (int d = 0; d < DIMENSION; d++) {
+            v[d] = rng.nextFloat();
+        }
+        return v;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.KNN1040Codec;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.knn.KNNTestCase;
@@ -16,51 +16,28 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
-
-    public void testToTinySegmentsThreshold_whenNegativeOne_thenReturnsIntegerMaxValue() {
-        assertEquals(Integer.MAX_VALUE, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(-1));
-    }
-
-    public void testToTinySegmentsThreshold_whenZero_thenReturnsZero() {
-        // 0 → 0 → docCount < 0 is never true → always build the graph (matches Faiss semantics).
-        assertEquals(0, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(0));
-    }
-
-    public void testToTinySegmentsThreshold_whenPositive_thenReturnsSameValue() {
-        assertEquals(500, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(500));
-        assertEquals(100, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(100));
-        assertEquals(1, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(1));
-    }
-
-    public void testToTinySegmentsThreshold_whenLargeNegative_thenReturnsIntegerMaxValue() {
-        assertEquals(Integer.MAX_VALUE, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(Integer.MIN_VALUE));
-    }
-
-    public void testToTinySegmentsThreshold_whenIntegerMaxValue_thenReturnsSameValue() {
-        assertEquals(Integer.MAX_VALUE, KNN1040PerFieldKnnVectorsFormat.toTinySegmentsThreshold(Integer.MAX_VALUE));
-    }
+public class KNN9120PerFieldKnnVectorsFormatTests extends KNNTestCase {
 
     public void testBuildMergeThreadCountAndExecutorService_whenThreadQtyIsOne_thenReturnsNullExecutor() {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(1);
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(1);
         assertEquals(Integer.valueOf(1), result.v1());
         assertNull(result.v2());
     }
 
     public void testBuildMergeThreadCountAndExecutorService_whenThreadQtyIsZero_thenReturnsNullExecutor() {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(0);
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(0);
         assertEquals(Integer.valueOf(1), result.v1());
         assertNull(result.v2());
     }
 
     public void testBuildMergeThreadCountAndExecutorService_whenThreadQtyIsNegative_thenReturnsNullExecutor() {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(-1);
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(-1);
         assertEquals(Integer.valueOf(1), result.v1());
         assertNull(result.v2());
     }
 
     public void testBuildMergeThreadCountAndExecutorService_whenThreadQtyAboveOne_thenReturnsExecutorWithCorrectPoolSize() {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(4);
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(4);
         try {
             assertEquals(Integer.valueOf(4), result.v1());
             assertNotNull(result.v2());
@@ -74,7 +51,7 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
     }
 
     public void testBuildMergeThreadCountAndExecutorService_whenThreadQtyAboveOne_thenExecutorAllowsCoreThreadTimeout() {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(2);
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(2);
         try {
             ThreadPoolExecutor executor = (ThreadPoolExecutor) result.v2();
             assertTrue(executor.allowsCoreThreadTimeOut());
@@ -84,8 +61,8 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
     }
 
     public void testBuildMergeThreadCountAndExecutorService_whenCalledMultipleTimes_thenReturnsIndependentExecutors() {
-        Tuple<Integer, ExecutorService> first = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(4);
-        Tuple<Integer, ExecutorService> second = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(4);
+        Tuple<Integer, ExecutorService> first = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(4);
+        Tuple<Integer, ExecutorService> second = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(4);
         try {
             assertNotSame(first.v2(), second.v2());
         } finally {
@@ -94,8 +71,12 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
         }
     }
 
+    /**
+     * MrFlap test A: Verify that idle threads are culled after the keepAlive timeout expires.
+     * Uses a 1-second timeout so the test completes quickly.
+     */
     public void testThreadsCulledAfterTimeout() throws Exception {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(
             4,
             1L,
             TimeUnit.SECONDS
@@ -118,14 +99,19 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
             assertEquals(4, executor.getActiveCount());
 
             tasksCanFinish.countDown();
+            // Wait for keepAlive (1s) plus margin
             assertBusy(() -> assertEquals(0, executor.getPoolSize()), 10, TimeUnit.SECONDS);
         } finally {
             executor.shutdownNow();
         }
     }
 
+    /**
+     * MrFlap test B: Verify that threads remain alive while tasks are actively running,
+     * even with a short keepAlive timeout.
+     */
     public void testThreadsSurviveDuringActiveMerge() throws Exception {
-        Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(
+        Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(
             4,
             1L,
             TimeUnit.SECONDS
@@ -146,6 +132,7 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
             }
             assertTrue(tasksStarted.await(5, TimeUnit.SECONDS));
 
+            // Sleep past the keepAlive timeout — threads should still be alive because they're busy
             Thread.sleep(2000);
             assertEquals(4, executor.getPoolSize());
             assertEquals(4, executor.getActiveCount());
@@ -156,10 +143,14 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
         }
     }
 
+    /**
+     * MrFlap test C: Verify that executor objects become GC-eligible after use, so there
+     * is no memory leak from accumulated executor instances.
+     */
     public void testExecutorIsGarbageCollectedAfterUse() throws Exception {
         List<WeakReference<ExecutorService>> refs = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Tuple<Integer, ExecutorService> result = KNN1040PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(
+            Tuple<Integer, ExecutorService> result = KNN9120PerFieldKnnVectorsFormat.buildMergeThreadCountAndExecutorService(
                 2,
                 1L,
                 TimeUnit.SECONDS
@@ -167,14 +158,17 @@ public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
             refs.add(new WeakReference<>(result.v2()));
         }
 
+        // Wait for threads to time out so nothing holds a strong reference to the executors
         Thread.sleep(3000);
 
+        // Encourage GC
         for (int i = 0; i < 10; i++) {
             System.gc();
             Thread.sleep(100);
         }
 
         long collected = refs.stream().filter(ref -> ref.get() == null).count();
+        // At least some executors should have been collected
         assertTrue("Expected at least one executor to be GC'd, but none were", collected > 0);
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/MergeThreadLeakIT.java
+++ b/src/test/java/org/opensearch/knn/integ/MergeThreadLeakIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNJsonQueryBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY;
+
+/**
+ * Integration test that exercises the Lucene HNSW merge executor with
+ * index_thread_qty > 1. Verifies that indexing, force-merging, and
+ * searching all succeed — the merge executor must produce valid HNSW
+ * graphs despite using a multi-threaded pool.
+ *
+ * This test targets the bug fixed in #3102 where each merge leaked a
+ * FixedThreadPool that was never shut down.
+ */
+public class MergeThreadLeakIT extends KNNRestTestCase {
+
+    private static final String INDEX_NAME = "merge-thread-leak-test";
+    private static final String FIELD_NAME = "test_vector";
+    private static final int DIMENSION = 8;
+    private static final int DOC_COUNT = 100;
+
+    @SneakyThrows
+    public void testLuceneHnswMerge_withMultipleThreads_thenSearchSucceeds() {
+        updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, 4);
+        try {
+            String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(FIELD_NAME)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject("method")
+                .field("name", "hnsw")
+                .field("space_type", "l2")
+                .field("engine", KNNEngine.LUCENE.getName())
+                .startObject("parameters")
+                .field("ef_construction", 16)
+                .field("m", 4)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .toString();
+
+            createKnnIndex(INDEX_NAME, mapping);
+
+            Random rng = new Random(42);
+            for (int i = 0; i < DOC_COUNT; i++) {
+                Float[] vector = new Float[DIMENSION];
+                for (int d = 0; d < DIMENSION; d++) {
+                    vector[d] = rng.nextFloat();
+                }
+                addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, vector);
+            }
+
+            refreshAllNonSystemIndices();
+            assertEquals(DOC_COUNT, getDocCount(INDEX_NAME));
+
+            // Force merge exercises the per-field merge executor path that leaked threads
+            forceMergeKnnIndex(INDEX_NAME);
+
+            // A second force merge creates another round of executor allocations
+            forceMergeKnnIndex(INDEX_NAME);
+
+            Float[] queryVector = new Float[DIMENSION];
+            for (int d = 0; d < DIMENSION; d++) {
+                queryVector[d] = 0.5f;
+            }
+            String query = KNNJsonQueryBuilder.builder().fieldName(FIELD_NAME).vector(queryVector).k(10).build().getQueryString();
+
+            Response response = searchKNNIndex(INDEX_NAME, query, 10);
+            List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+            assertEquals(10, results.size());
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+            updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, 1);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fix thread leak in HNSW merge executor.

`getMergeThreadCountAndExecutorService()` in both `KNN9120PerFieldKnnVectorsFormat` and `KNN1040PerFieldKnnVectorsFormat` was creating a new `Executors.newFixedThreadPool()` on every invocation. Since this is called per field per segment during flush/merge, thread pools accumulated unboundedly under continuous indexing (77k+ leaked threads observed, causing OOM kills).

This PR replaces `Executors.newFixedThreadPool()` with a `ThreadPoolExecutor` that has `allowCoreThreadTimeOut(true)` set. This preserves the existing per-merge allocation semantics — each merge still gets its own executor with `index_thread_qty` threads — while ensuring idle threads auto-terminate after 60 seconds once the merge completes and no more tasks are submitted.

**Why this approach over a shared static pool (as in #3120)?**

A shared static pool changes the threading semantics from "N threads per merge" to "N threads total across all concurrent merges on the node." This can reduce ingestion throughput when multiple merges run simultaneously (as noted in the review feedback on #3120). The `allowCoreThreadTimeOut` approach is the minimal fix: it stops the leak without changing any allocation semantics.

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/3102

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).