### PR TITLE
Fix shared mutable PerLeafResult.EMPTY_RESULT causing NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix knn query against a field alias returning zero hits silently [#3485](https://github.com/opensearch-project/k-NN/pull/3485)
 * Add prefetch for Lucene engine's fp32 and binary vector data type [#3504](https://github.com/opensearch-project/k-NN/pull/3504)
 * Fix when BQ file is not present in the segment as there is no vectors in the segment [#3511](https://github.com/opensearch-project/k-NN/pull/3511)
+* Fix shared mutable PerLeafResult.EMPTY_RESULT causing NPE [#3534](https://github.com/opensearch-project/k-NN/pull/3534)
 
 ### Refactoring
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -328,7 +328,7 @@ public abstract class KNNWeight extends Weight {
         // We should give this condition a deeper look that where it should be placed. For now I feel this is a good
         // place,
         if (filterWeight != null && filterCardinality == 0) {
-            return PerLeafResult.EMPTY_RESULT;
+            return PerLeafResult.empty();
         }
         if (knnQuery.isExplain()) {
             knnExplanation.setCardinality(filterCardinality);

--- a/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
+++ b/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
@@ -158,14 +158,6 @@ public class PerLeafResult {
         }
     };
 
-    // A statically defined empty {@code PerLeafResult} used as a lightweight placeholder when a segment produces no hits.
-    public static final PerLeafResult EMPTY_RESULT = new PerLeafResult(
-        MATCH_NO_BIT_SET,
-        0,
-        TopDocsCollector.EMPTY_TOPDOCS,
-        SearchMode.EXACT_SEARCH
-    );
-
     public static PerLeafResult empty() {
         return new PerLeafResult(MATCH_NO_BIT_SET, 0, TopDocsCollector.EMPTY_TOPDOCS, SearchMode.EXACT_SEARCH);
     }

--- a/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
+++ b/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
@@ -166,6 +166,10 @@ public class PerLeafResult {
         SearchMode.EXACT_SEARCH
     );
 
+    public static PerLeafResult empty() {
+        return new PerLeafResult(MATCH_NO_BIT_SET, 0, TopDocsCollector.EMPTY_TOPDOCS, SearchMode.EXACT_SEARCH);
+    }
+
     /**
      * Indicates the search mode applied within a segment. Either exact or approximate nearest neighbor (ANN) search.
      */

--- a/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
@@ -145,7 +145,7 @@ public class ResultUtilTests extends KNNTestCase {
     }
 
     public void testMatchNoBitSet_nextClearBit_throwsUOE() {
-        expectThrows(UnsupportedOperationException.class, () -> PerLeafResult.EMPTY_RESULT.getFilterBits().nextClearBit(0, 10));
+        expectThrows(UnsupportedOperationException.class, () -> PerLeafResult.empty().getFilterBits().nextClearBit(0, 10));
     }
 
 }

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -396,7 +396,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         // Given
         List<LeafReaderContext> leaves = reader.leaves();
         leaf1 = leaves.get(0);
-        when(knnWeight.searchLeaf(leaf1, 4)).thenReturn(PerLeafResult.EMPTY_RESULT);
+        when(knnWeight.searchLeaf(leaf1, 4)).thenReturn(PerLeafResult.empty());
         when(knnQuery.getK()).thenReturn(4);
 
         try (MockedStatic<KNNSettings> mockedKnnSettings = mockStatic(KNNSettings.class)) {


### PR DESCRIPTION
### Description
`KNNWeight#searchLeaf` handed the process-wide `PerLeafResult.EMPTY_RESULT` singleton to callers that treat the return value as a per-query object and mutate it via `setResult`. This returns a fresh instance instead, so no `PerLeafResult` is aliased across queries.

### Related Issues
Resolves [#3535](https://github.com/opensearch-project/k-NN/issues/3535)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
