### PR TITLE
Fix exact search scoring with L2 instead of the configured space type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add prefetch for Lucene engine's fp32 and binary vector data type [#3504](https://github.com/opensearch-project/k-NN/pull/3504)
 * Fix when BQ file is not present in the segment as there is no vectors in the segment [#3511](https://github.com/opensearch-project/k-NN/pull/3511)
 * Drop HasIndexSlice from ScalarQuantizedFloatVectorValues and expose float/quantized delegates via getters [#3486](https://github.com/opensearch-project/k-NN/pull/3486)
+* Fix exact search and rescore scoring innerproduct and cosinesimil fields with L2 on model based and 2.17 to 2.19 indices [#3537](https://github.com/opensearch-project/k-NN/pull/3537)
 
 ### Refactoring
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)

--- a/src/main/java/org/opensearch/knn/index/query/scorers/VectorScorers.java
+++ b/src/main/java/org/opensearch/knn/index/query/scorers/VectorScorers.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
@@ -36,9 +37,11 @@ import static org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter
  * scoring strategy:
  * <ul>
  *   <li>{@link BinaryDocValues} → delegates to {@link KNNBinaryDocValuesScorer}</li>
- *   <li>{@link FloatVectorValues} → uses the provided {@link VectorScorerMode} (score or rescore)</li>
+ *   <li>{@link FloatVectorValues} → uses the provided {@link VectorScorerMode} (score or rescore),
+ *       unless the configured space type disagrees with the similarity function recorded on the field</li>
  *   <li>{@link ByteVectorValues} with float target → ADC (Asymmetric Distance Computation) scoring</li>
- *   <li>{@link ByteVectorValues} with byte target → uses the provided {@link VectorScorerMode}</li>
+ *   <li>{@link ByteVectorValues} with byte target → uses the provided {@link VectorScorerMode}, with the
+ *       same space type override as the float case</li>
  * </ul>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -160,7 +163,11 @@ public final class VectorScorers {
 
         final KnnVectorValues knnVectorValues = docIdsIteratorValues.getKnnVectorValues();
         if (knnVectorValues instanceof FloatVectorValues floatVectorValues) {
-            return vectorScorerMode.createScorer(floatVectorValues, target);
+            final VectorSimilarityFunction configuredFunction = resolveSimilarityFunction(spaceType);
+            if (configuredFunction == null || configuredFunction == fieldInfo.getVectorSimilarityFunction()) {
+                return vectorScorerMode.createScorer(floatVectorValues, target);
+            }
+            return createSimilarityOverrideScorer(floatVectorValues, target, configuredFunction);
         }
         if (knnVectorValues instanceof ByteVectorValues byteVectorValues && FieldInfoExtractor.isAdc(fieldInfo)) {
             return createADCScorer(fieldInfo, byteVectorValues, target, spaceType);
@@ -184,9 +191,14 @@ public final class VectorScorers {
 
         final KnnVectorValues knnVectorValues = docIdsIteratorValues.getKnnVectorValues();
         if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
-            return spaceType == SpaceType.HAMMING
-                ? createHammingDistanceScorer(fieldInfo, byteVectorValues, target, spaceType)
-                : vectorScorerMode.createScorer(byteVectorValues, target);
+            if (spaceType == SpaceType.HAMMING) {
+                return createHammingDistanceScorer(fieldInfo, byteVectorValues, target, spaceType);
+            }
+            final VectorSimilarityFunction configuredFunction = resolveSimilarityFunction(spaceType);
+            if (configuredFunction == null || configuredFunction == fieldInfo.getVectorSimilarityFunction()) {
+                return vectorScorerMode.createScorer(byteVectorValues, target);
+            }
+            return createSimilarityOverrideScorer(byteVectorValues, target, configuredFunction);
         }
         throw new IllegalArgumentException("Byte target requires ByteVectorValues but got " + knnVectorValues.getClass().getSimpleName());
     }
@@ -200,6 +212,96 @@ public final class VectorScorers {
             return scorer;
         }
         return new NestedBestChildVectorScorer(acceptedChildrenIterator, parentBitSet, scorer);
+    }
+
+    /**
+     * Resolves the Lucene {@link VectorSimilarityFunction} for the given space type.
+     *
+     * @param spaceType the configured space type
+     * @return the matching similarity function, or {@code null} if the space type has no Lucene equivalent
+     */
+    // TODO: L1 and LINF have no Lucene similarity function, so they return null here and keep scoring with
+    // the function recorded on the field. Correcting them needs a dedicated scorer, the way HAMMING has one.
+    @Nullable
+    private static VectorSimilarityFunction resolveSimilarityFunction(final SpaceType spaceType) {
+        // L1, LINF and UNDEFINED report no similarity function, HAMMING throws when asked for one.
+        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = spaceType.getKnnVectorSimilarityFunction();
+        if (knnVectorSimilarityFunction == null || knnVectorSimilarityFunction == KNNVectorSimilarityFunction.HAMMING) {
+            return null;
+        }
+        return knnVectorSimilarityFunction.getVectorSimilarityFunction();
+    }
+
+    /**
+     * Creates a {@link VectorScorer} that scores with the given similarity function instead of the one
+     * recorded on the field.
+     * <p>
+     * The two differ when a field does not carry its space type into the recorded function.
+     * {@code ModelFieldMapper} passes {@link SpaceType#DEFAULT} whatever the model was trained with, and
+     * {@code FaissFieldStrategy} does the same for indices created in 2.17 through 2.19. Correcting the
+     * recorded value is not an option for existing indices, since Lucene requires a field's vector
+     * similarity to be identical across the segments of one index. Recording it correctly for newly
+     * created indices, behind an index version gate, is left alone here.
+     * <p>
+     * This ignores {@link VectorScorerMode}, since neither a scorer nor a rescorer can be bound to a
+     * different similarity function.
+     * <p>
+     * The Lucene99 scorer is what the per field formats reachable here delegate to anyway, so going through
+     * {@code FlatVectorsScorerProvider#getFlatVectorsScorer} would select the same implementation.
+     *
+     * @param vectorValues the vector values for the segment
+     * @param target the float query vector
+     * @param similarityFunction the function to score with
+     * @return a scorer over the given values
+     * @throws IOException if an I/O error occurs
+     */
+    private static VectorScorer createSimilarityOverrideScorer(
+        final FloatVectorValues vectorValues,
+        final float[] target,
+        final VectorSimilarityFunction similarityFunction
+    ) throws IOException {
+        return toVectorScorer(
+            FlatVectorsScorerProvider.getLucene99FlatVectorsScorer().getRandomVectorScorer(similarityFunction, vectorValues, target),
+            vectorValues
+        );
+    }
+
+    /**
+     * Byte counterpart of {@link #createSimilarityOverrideScorer(FloatVectorValues, float[], VectorSimilarityFunction)}.
+     */
+    private static VectorScorer createSimilarityOverrideScorer(
+        final ByteVectorValues vectorValues,
+        final byte[] target,
+        final VectorSimilarityFunction similarityFunction
+    ) throws IOException {
+        return toVectorScorer(
+            FlatVectorsScorerProvider.getLucene99FlatVectorsScorer().getRandomVectorScorer(similarityFunction, vectorValues, target),
+            vectorValues
+        );
+    }
+
+    /**
+     * Adapts a {@link RandomVectorScorer} to the {@link VectorScorer} contract over the given values.
+     */
+    private static VectorScorer toVectorScorer(final RandomVectorScorer randomVectorScorer, final KnnVectorValues vectorValues) {
+        return new VectorScorer() {
+            final KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
+
+            @Override
+            public float score() throws IOException {
+                return randomVectorScorer.score(iterator.index());
+            }
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return iterator;
+            }
+
+            @Override
+            public Bulk bulk(final DocIdSetIterator matchingDocs) {
+                return Bulk.fromRandomScorerSparse(randomVectorScorer, iterator, matchingDocs);
+            }
+        };
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -1689,6 +1689,257 @@ public class FaissIT extends KNNCompressionRestTestCase {
     }
 
     @SneakyThrows
+    public void testFilteredExactSearch_withModelBasedInnerProduct_thenScoresUseInnerProduct() {
+        assertModelBasedFilteredExactSearchScores("innerproduct", SpaceType.INNER_PRODUCT, VectorDataType.FLOAT);
+    }
+
+    @SneakyThrows
+    public void testFilteredExactSearch_withModelBasedCosine_thenScoresUseCosine() {
+        assertModelBasedFilteredExactSearchScores("cosinesimil", SpaceType.COSINESIMIL, VectorDataType.FLOAT);
+    }
+
+    @SneakyThrows
+    public void testFilteredExactSearch_withModelBasedByteInnerProduct_thenScoresUseInnerProduct() {
+        assertModelBasedFilteredExactSearchScores("innerproduct", SpaceType.INNER_PRODUCT, VectorDataType.BYTE);
+    }
+
+    @SneakyThrows
+    public void testFilteredExactSearch_withModelBasedL2_thenScoresUseL2() {
+        assertModelBasedFilteredExactSearchScores("l2", SpaceType.L2, VectorDataType.FLOAT);
+    }
+
+    @SneakyThrows
+    public void testFilteredRadialSearch_withModelBasedInnerProduct_thenUsesInnerProductThreshold() {
+        String modelId = "test-model-radial-ip";
+        String trainingIndexName = "train-index-radial-ip";
+        String trainingFieldName = "train-field";
+        String indexName = "test-index-radial-ip";
+        String fieldName = "test-field-name";
+        String filterField = "color";
+        int dimension = 2;
+
+        // Same vectors, query and min_score expectation as the Faiss_IP case in RadialSearchIT, which
+        // only covers method based fields. Inner product scores are 2.0, 1.8, 1.3 and 1.0.
+        // A radius is set, so exact search is reached through KNNWeight#isMaxDistCompGreaterThanEstimatedDistComp
+        // rather than the filter count check.
+        float[][] vectors = { { 1.0f, 0.0f }, { 0.8f, 0.1f }, { 0.3f, 0.3f }, { 0.0f, 1.0f } };
+        float[] queryVector = { 1.0f, 0.0f };
+        float minScore = 1.4f;
+
+        createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
+        bulkIngestRandomVectors(trainingIndexName, trainingFieldName, 1100, dimension);
+
+        XContentBuilder method = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .endObject()
+            .endObject();
+        trainModel(modelId, trainingIndexName, trainingFieldName, dimension, xContentBuilderToMap(method), "faiss ivf innerproduct");
+        assertTrainingSucceeds(modelId, 30, 1000);
+
+        String indexMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field(MODEL_ID, modelId)
+            .endObject()
+            .startObject(filterField)
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), indexMapping);
+
+        final List<KNNResult> results;
+        try {
+            for (int i = 0; i < vectors.length; i++) {
+                addKnnDocWithAttributes(indexName, Integer.toString(i), fieldName, vectors[i], ImmutableMap.of(filterField, "red"));
+            }
+
+            XContentBuilder query = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(fieldName)
+                .field("vector", queryVector)
+                .field("min_score", minScore)
+                .startObject("filter")
+                .startObject("term")
+                .field(filterField, "red")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+
+            Response radialResponse = searchKNNIndex(indexName, query, 10);
+            results = parseSearchResponse(EntityUtils.toString(radialResponse.getEntity()), fieldName);
+        } finally {
+            // The model cannot be deleted while an index still refers to it, so clean up before asserting.
+            deleteKNNIndex(indexName);
+            deleteKNNIndex(trainingIndexName);
+            deleteModel(modelId);
+        }
+
+        // The threshold is derived from the model's space type while the documents are scored by the exact
+        // searcher. Scoring with L2 caps every score at 1.0, so a threshold of 1.4 would match nothing.
+        assertEquals(2, results.size());
+        for (KNNResult result : results) {
+            float expected = SpaceType.INNER_PRODUCT.getKnnVectorSimilarityFunction().compare(queryVector, result.getVector());
+            assertTrue("returned doc " + result.getDocId() + " is below the min_score threshold", expected >= minScore);
+            assertEquals(expected, result.getScore(), 0.0001f);
+        }
+    }
+
+    /**
+     * Builds a model based faiss IVF index for the given space type and data type, then checks that a
+     * filtered query which falls back to exact search scores with that space type. A model based field
+     * records the default similarity function rather than the trained model's space type, so the exact
+     * search path has to score with the space type it resolves rather than the recorded function.
+     */
+    private void assertModelBasedFilteredExactSearchScores(String spaceTypeName, SpaceType spaceType, VectorDataType dataType)
+        throws Exception {
+        String suffix = spaceTypeName + "-" + dataType.getValue();
+        String modelId = "test-model-" + suffix;
+        String trainingIndexName = "train-index-" + suffix;
+        String trainingFieldName = "train-field";
+        String indexName = "test-index-" + suffix;
+        String fieldName = "test-field-name";
+        int dimension = 8;
+        int numDocs = 20;
+        int firstMatchingRating = 16;
+        // The filter matches 4 of the 20 docs, which satisfies KNNWeight#isFilterIdCountLessThanK and
+        // sends the query down the exact search path.
+        int k = 20;
+
+        String trainingMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(trainingFieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(VECTOR_DATA_TYPE_FIELD, dataType.getValue())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceTypeName)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(trainingIndexName, trainingMapping);
+        if (dataType == VectorDataType.BYTE) {
+            bulkIngestRandomByteVectors(trainingIndexName, trainingFieldName, 1100, dimension);
+        } else {
+            bulkIngestRandomVectors(trainingIndexName, trainingFieldName, 1100, dimension);
+        }
+
+        XContentBuilder trainRequest = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
+            .field(TRAIN_FIELD_PARAMETER, trainingFieldName)
+            .field(DIMENSION, dimension)
+            .field(MODEL_DESCRIPTION, "faiss ivf " + suffix)
+            .field(VECTOR_DATA_TYPE_FIELD, dataType.getValue())
+            .field(
+                KNN_METHOD,
+                Map.of(
+                    NAME,
+                    METHOD_IVF,
+                    KNN_ENGINE,
+                    FAISS_NAME,
+                    METHOD_PARAMETER_SPACE_TYPE,
+                    spaceTypeName,
+                    PARAMETERS,
+                    Map.of(METHOD_PARAMETER_NLIST, 1)
+                )
+            )
+            .endObject();
+        trainModel(modelId, trainRequest);
+        assertTrainingSucceeds(modelId, 30, 1000);
+
+        String indexMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field(MODEL_ID, modelId)
+            .endObject()
+            .startObject("rating")
+            .field("type", "integer")
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), indexMapping);
+
+        float[] queryVector = new float[dimension];
+        for (int j = 0; j < dimension; j++) {
+            queryVector[j] = dataType == VectorDataType.BYTE ? (j % 5) - 2 : ((j * 3) % 7) - 3.0f;
+        }
+
+        final List<KNNResult> results;
+        try {
+            for (int i = 0; i < numDocs; i++) {
+                float[] indexVector = new float[dimension];
+                for (int j = 0; j < dimension; j++) {
+                    int raw = (i * 7 + j * 3) % 11 - 5;
+                    indexVector[j] = dataType == VectorDataType.BYTE ? raw : raw / 10.0f;
+                }
+                addKnnDocWithAttributes(
+                    indexName,
+                    Integer.toString(i),
+                    fieldName,
+                    indexVector,
+                    ImmutableMap.of("rating", String.valueOf(i))
+                );
+            }
+
+            Response filteredResponse = searchKNNIndex(
+                indexName,
+                new KNNQueryBuilder(
+                    fieldName,
+                    queryVector,
+                    k,
+                    QueryBuilders.rangeQuery("rating").gte(firstMatchingRating).lte(numDocs - 1)
+                ),
+                k
+            );
+            results = parseSearchResponse(EntityUtils.toString(filteredResponse.getEntity()), fieldName);
+        } finally {
+            // The model cannot be deleted while an index still refers to it, so clean up before asserting.
+            deleteKNNIndex(indexName);
+            deleteKNNIndex(trainingIndexName);
+            deleteModel(modelId);
+        }
+
+        assertEquals(numDocs - firstMatchingRating, results.size());
+        for (KNNResult result : results) {
+            float expected = spaceType.getKnnVectorSimilarityFunction().compare(queryVector, result.getVector());
+            if (spaceType != SpaceType.L2) {
+                // The defect scored with the recorded default, L2. Guards against a fixture where the two
+                // metrics agree and the assertion below could not fail.
+                float asL2 = SpaceType.L2.getKnnVectorSimilarityFunction().compare(queryVector, result.getVector());
+                assertNotEquals("expected score for doc " + result.getDocId() + " coincides with its L2 score", expected, asL2, 0.0001f);
+            }
+            assertEquals(
+                "score for doc " + result.getDocId() + " does not use space type " + spaceTypeName,
+                expected,
+                result.getScore(),
+                0.0001f
+            );
+        }
+    }
+
+    @SneakyThrows
     public void testQueryWithFilter_withDifferentCombination_thenSuccess() {
         setupKNNIndexForFilterQuery();
         final float[] searchVector = { 6.0f, 6.0f, 4.1f };

--- a/src/test/java/org/opensearch/knn/index/query/scorers/VectorScorersTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/scorers/VectorScorersTests.java
@@ -80,11 +80,165 @@ public class VectorScorersTests extends KNNTestCase {
         KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
         when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
         when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
 
         VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.L2, fieldInfo);
 
         assertNotNull(scorer);
         assertScores(buildExpectedScores(query, docs, SpaceType.L2), scorer);
+    }
+
+    @SneakyThrows
+    public void testFloatTarget_withFloatVectorValues_fieldSimilarityDisagrees_scoresWithConfiguredSpaceType() {
+        float[] query = { 1.0f, 2.0f };
+        List<float[]> docs = List.of(new float[] { 1.0f, 2.0f }, new float[] { 3.0f, 4.0f });
+        // A model based field records the default similarity function regardless of the model's space type.
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            docs,
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<Integer, Float> innerProductScores = buildExpectedScores(query, docs, SpaceType.INNER_PRODUCT);
+        Map<Integer, Float> recordedScores = buildExpectedScores(query, docs, SpaceType.L2);
+        // Guards against the fixture drifting to vectors where both functions agree.
+        assertNotEquals(recordedScores, innerProductScores);
+
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.INNER_PRODUCT, fieldInfo);
+
+        assertNotNull(scorer);
+        assertScores(innerProductScores, scorer);
+    }
+
+    @SneakyThrows
+    public void testFloatTarget_withFloatVectorValues_fieldSimilarityDisagrees_rescoreMode() {
+        float[] query = { 1.0f, 2.0f };
+        List<float[]> docs = List.of(new float[] { 1.0f, 2.0f }, new float[] { 3.0f, 4.0f });
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            docs,
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<Integer, Float> innerProductScores = buildExpectedScores(query, docs, SpaceType.INNER_PRODUCT);
+        assertNotEquals(buildExpectedScores(query, docs, SpaceType.L2), innerProductScores);
+
+        // The rescore pass reaches this path through RescoreKNNVectorQuery, which asks for RESCORE mode.
+        VectorScorer scorer = VectorScorers.createScorer(
+            iteratorValues,
+            query,
+            VectorScorerMode.RESCORE,
+            SpaceType.INNER_PRODUCT,
+            fieldInfo
+        );
+
+        assertNotNull(scorer);
+        assertScores(innerProductScores, scorer);
+    }
+
+    @SneakyThrows
+    public void testFloatTarget_withFloatVectorValues_fieldSimilarityDisagrees_cosineSpaceType() {
+        float[] query = { 1.0f, 2.0f };
+        List<float[]> docs = List.of(new float[] { 2.0f, 1.0f }, new float[] { 3.0f, 4.0f });
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            docs,
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<Integer, Float> cosineScores = buildExpectedScores(query, docs, SpaceType.COSINESIMIL);
+        assertNotEquals(buildExpectedScores(query, docs, SpaceType.L2), cosineScores);
+
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.COSINESIMIL, fieldInfo);
+
+        assertNotNull(scorer);
+        assertScores(cosineScores, scorer);
+    }
+
+    @SneakyThrows
+    public void testFloatTarget_withFloatVectorValues_fieldSimilarityAgrees_delegatesToScoreMode() {
+        float[] query = { 1.0f, 2.0f };
+        List<float[]> docs = List.of(new float[] { 1.0f, 2.0f }, new float[] { 3.0f, 4.0f });
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            docs,
+            VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT);
+
+        VectorScorerMode vectorScorerMode = mock(VectorScorerMode.class);
+        VectorScorer delegated = mock(VectorScorer.class);
+        when(vectorScorerMode.createScorer(any(FloatVectorValues.class), any(float[].class))).thenReturn(delegated);
+
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, vectorScorerMode, SpaceType.INNER_PRODUCT, fieldInfo);
+
+        assertSame(delegated, scorer);
+    }
+
+    @SneakyThrows
+    public void testFloatTarget_withFloatVectorValues_hammingSpaceType_delegatesToScoreMode() {
+        float[] query = { 1.0f, 2.0f };
+        List<float[]> docs = List.of(new float[] { 1.0f, 2.0f });
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            docs,
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
+
+        VectorScorerMode vectorScorerMode = mock(VectorScorerMode.class);
+        VectorScorer delegated = mock(VectorScorer.class);
+        when(vectorScorerMode.createScorer(any(FloatVectorValues.class), any(float[].class))).thenReturn(delegated);
+
+        // Defensive: HAMMING requires binary data and so routes to the byte overload. It has no Lucene
+        // equivalent either, so there is nothing to compare against and the mode still applies.
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, vectorScorerMode, SpaceType.HAMMING, fieldInfo);
+
+        assertSame(delegated, scorer);
+    }
+
+    @SneakyThrows
+    public void testFloatTarget_withFloatVectorValues_spaceTypeWithoutLuceneEquivalent_delegatesToScoreMode() {
+        float[] query = { 1.0f, 2.0f };
+        List<float[]> docs = List.of(new float[] { 1.0f, 2.0f });
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            docs,
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
+
+        VectorScorerMode vectorScorerMode = mock(VectorScorerMode.class);
+        VectorScorer delegated = mock(VectorScorer.class);
+        when(vectorScorerMode.createScorer(any(FloatVectorValues.class), any(float[].class))).thenReturn(delegated);
+
+        // L1 and LINF have no Lucene similarity function, so the recorded one is used and these fields keep
+        // scoring with L2. That gap is not addressed here and needs a dedicated scorer, as HAMMING has.
+        for (SpaceType spaceType : List.of(SpaceType.L1, SpaceType.LINF)) {
+            VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, vectorScorerMode, spaceType, fieldInfo);
+            assertSame(delegated, scorer);
+        }
     }
 
     @SneakyThrows
@@ -163,11 +317,37 @@ public class VectorScorersTests extends KNNTestCase {
         KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
         when(iteratorValues.getDocIdSetIterator()).thenReturn(byteVectorValues.iterator());
         when(iteratorValues.getKnnVectorValues()).thenReturn(byteVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
 
         VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.L2, fieldInfo);
 
         assertNotNull(scorer);
         assertScores(buildExpectedScores(query, docs, SpaceType.L2), scorer);
+    }
+
+    @SneakyThrows
+    public void testByteTarget_withByteVectorValues_fieldSimilarityDisagrees_scoresWithConfiguredSpaceType() {
+        byte[] query = { 4, 2 };
+        List<byte[]> docs = List.of(new byte[] { 4, 2 }, new byte[] { 1, 7 });
+        // A model based byte field records the default similarity function, same as the float case.
+        TestVectorValues.PreDefinedByteVectorValues byteVectorValues = new TestVectorValues.PreDefinedByteVectorValues(
+            docs,
+            VectorSimilarityFunction.EUCLIDEAN
+        );
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(byteVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(byteVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
+
+        Map<Integer, Float> innerProductScores = buildExpectedScores(query, docs, SpaceType.INNER_PRODUCT);
+        // Guards against the fixture drifting to vectors where both functions agree.
+        assertNotEquals(buildExpectedScores(query, docs, SpaceType.L2), innerProductScores);
+
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.INNER_PRODUCT, fieldInfo);
+
+        assertNotNull(scorer);
+        assertScores(innerProductScores, scorer);
     }
 
     @SneakyThrows
@@ -227,6 +407,7 @@ public class VectorScorersTests extends KNNTestCase {
         KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
         when(iteratorValues.getDocIdSetIterator()).thenReturn(floatVectorValues.iterator());
         when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
 
         VectorScorerMode vectorScorerMode = mock(VectorScorerMode.class);
         VectorScorer baseScorer = mock(VectorScorer.class);
@@ -259,6 +440,7 @@ public class VectorScorersTests extends KNNTestCase {
         KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
         when(iteratorValues.getDocIdSetIterator()).thenReturn(byteVectorValues.iterator());
         when(iteratorValues.getKnnVectorValues()).thenReturn(byteVectorValues);
+        when(fieldInfo.getVectorSimilarityFunction()).thenReturn(VectorSimilarityFunction.EUCLIDEAN);
 
         VectorScorerMode vectorScorerMode = mock(VectorScorerMode.class);
         VectorScorer baseScorer = mock(VectorScorer.class);


### PR DESCRIPTION
### Description

Exact search resolves the space type from model metadata or from the field attribute, then dropped it when constructing the scorer, so it scored with the similarity function recorded on the field instead.

This is additive in the sense that matters for review: no field that records its space type correctly changes behaviour. When the recorded function already matches the configured space type, the existing scorer is used unchanged. `l2` fields and method based faiss fields on 3.0 and later indices return exactly the scores they return today, and there is a test for each.

Two kinds of field do not carry their space type into the recorded function:

- `ModelFieldMapper` passes `SpaceType.DEFAULT` whatever the model was trained with, so every model based field records L2.
- `FaissFieldStrategy` passes `SpaceType.DEFAULT` for indices created before 3.0, and vector attributes are only written from 2.17, so faiss and nmslib fields on 2.17 through 2.19 indices record L2 as well.

For those fields a filtered query that falls back to exact search scored with L2 while the same query without a filter scored with the configured space type. The explain output reports the mismatch directly:

```
"description": "... was Exact ... with vectorDataType = FLOAT, spaceType = innerproduct"
"value": 0.24021216      <- the L2 score
```

Reproduced on main with the script from #3449:

```
dot product: 0.47397148609161377      squared L2: 3.1629865169525146
expected inner-product score: 1.4739714860916138
expected L2 score:            0.24021216401441603
filtered score:   0.24021216   -> matches L2: True,  matches IP: False
unfiltered score: 1.4739715    -> matches IP: True,  matches L2: False
```

Radial search is affected further than scoring. Its threshold is derived from the configured space type and was compared against L2 scores, so it returned the wrong set of documents: the added radial test returns 2 documents with the fix and 0 without it. Rescoring reaches the same path through `RescoreKNNVectorQuery`, so disk based rescored searches change scores too. Float and byte vectors were both affected.

The fix resolves this at query time rather than correcting what the mapper writes, because Lucene requires a field's vector similarity to be identical across the segments of an index (`FieldInfo#verifySameVectorOptions`), so changing the recorded value would break merges on indices that already exist. Resolving it at query time also fixes existing indices without a reindex.

Testing: unit coverage for the agree, disagree, byte, rescore and no-Lucene-equivalent cases, and five integration tests covering innerproduct, cosinesimil, byte innerproduct, radial, and an l2 control. Removing the fix fails four of the five integration tests and four unit tests, and leaves the l2 control passing.

### Related Issues
Resolves #3449

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
