### PR TITLE
[DO NOT MERGE] FP32 flat-vector dedup for FAISS (2/2): non-MOS SEQUENTIAL reconstruction (stacked on #3527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.9](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
+* Add opt-in FP32 flat-vector deduplication for FAISS in memory-optimized search [#3527](https://github.com/opensearch-project/k-NN/pull/3527)
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -26,6 +26,7 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0008-Added-skipping-flat-storage-availability-in-write_in.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0009-Fixing-radial-search-for-IndexHNSWCagra.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0010-Make-selective-FAISS_THROW_IF_NOT-d-8-0-in-IndexBina.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0011-Forward-io_flags-through-float-IndexIDMap-write.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss)

--- a/jni/include/faiss_methods.h
+++ b/jni/include/faiss_methods.h
@@ -36,7 +36,7 @@ public:
 
     virtual faiss::IndexIDMapTemplate<faiss::IndexBinary>* indexBinaryIdMap(faiss::IndexBinary* index);
 
-    virtual void writeIndex(const faiss::Index* idx, faiss::IOWriter* writer);
+    virtual void writeIndex(const faiss::Index* idx, faiss::IOWriter* writer, bool skipFlat);
 
     virtual void writeIndexBinary(const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat);
 

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -62,6 +62,12 @@ namespace knn_jni {
         // Returns a pointer of the loaded index
         jlong LoadIndexWithStream(faiss::IOReader* ioReader);
 
+        // Reconstructs the native flat storage for a graph-only .faiss produced by FP32 flat-vector deduplication
+        // (IO_FLAG_SKIP_STORAGE). If `index` is a float IndexIDMap wrapping an IndexHNSW whose storage is null, this
+        // streams the full-precision vectors from the mediator (backed by Lucene's .vec file) into a new IndexFlat and
+        // assigns it as the HNSW storage. No-op for any other index shape (normal indices already have storage).
+        void ReconstructFlatStorageFromStreamIfNeeded(faiss::Index* index, knn_jni::stream::NativeEngineIndexInputMediator* mediator);
+
         // Loads an index with a reader implemented IOReader. The index
         // is expected to be a binary index. For ADC, it will be converted into a
         // float index.

--- a/jni/include/native_engines_stream_support.h
+++ b/jni/include/native_engines_stream_support.h
@@ -87,6 +87,56 @@ class NativeEngineIndexInputMediator {
     return bytes;
   }
 
+  // Streams up to `maxVectors` full-precision FP32 vectors (each `dim` floats, row-major) from the Java
+  // IndexInputWithBuffer's attached vector cursor into `destination`, returning the number of vectors copied
+  // (0 at end of the iterator). Used to reconstruct native flat storage for a graph-only .faiss produced by
+  // FP32 flat-vector deduplication (IO_FLAG_SKIP_STORAGE), where the vectors live only in Lucene's .vec file.
+  //
+  // Mirrors copyBytes: the Java side stages the batch into a reused float[] (IndexInputWithBuffer.vectorBuffer),
+  // and this method memcpy's it out under a JNI critical section. The float[] is lazily (re)allocated on the Java
+  // side, so it is fetched per call and its local ref released.
+  int32_t copyVectors(int32_t maxVectors, int32_t dim, float * RESTRICT destination) {
+    auto jclazz = getIndexInputWithBufferClass(jni_interface, env);
+
+    jvalue args;
+    args.i = maxVectors;
+    const int32_t copiedVectors =
+        jni_interface->CallNonvirtualIntMethodA(env, indexInput, jclazz, getCopyVectorsMethod(jni_interface, env), &args);
+    jni_interface->HasExceptionInStack(env, "Reading full-precision vectors via IndexInput has failed.");
+
+    if (copiedVectors <= 0) {
+      return copiedVectors;
+    }
+
+    // The vectorBuffer float[] is (re)allocated lazily on the Java side, so fetch it fresh each call.
+    jfloatArray vectorBufferArray =
+        (jfloatArray) jni_interface->GetObjectField(env, indexInput, getVectorBufferFieldId(jni_interface, env));
+
+    // Defensive bounds check: the Java staging buffer is sized from the Lucene vector dimension, while `dim` here is
+    // the graph's dimension. They always match (same field), but if they ever diverged the memcpy below would
+    // over-read. Fail cleanly instead of corrupting memory.
+    const int64_t requiredFloats = ((int64_t) copiedVectors) * ((int64_t) dim);
+    if (jni_interface->GetJavaFloatArrayLength(env, vectorBufferArray) < requiredFloats) {
+      jni_interface->DeleteLocalRef(env, vectorBufferArray);
+      throw std::runtime_error("Vector staging buffer is smaller than copiedVectors * dim; dimension mismatch between .vec and the graph.");
+    }
+
+    // === Critical Section Start ===
+    jfloat * RESTRICT primitiveArray =
+        (jfloat *) jni_interface->GetPrimitiveArrayCritical(env, vectorBufferArray, nullptr);
+
+    std::memcpy(destination, primitiveArray, ((size_t) copiedVectors) * ((size_t) dim) * sizeof(float));
+
+    // JNI_ABORT: we only read the Java array, so skip copying back.
+    jni_interface->ReleasePrimitiveArrayCritical(env, vectorBufferArray, primitiveArray, JNI_ABORT);
+    // === Critical Section End ===
+
+    // Release the local ref to avoid overflowing the local reference table across many batches.
+    jni_interface->DeleteLocalRef(env, vectorBufferArray);
+
+    return copiedVectors;
+  }
+
  private:
   static jclass getIndexInputWithBufferClass(JNIUtilInterface *jni_interface, JNIEnv *env) {
     static jclass INDEX_INPUT_WITH_BUFFER_CLASS =
@@ -110,6 +160,18 @@ class NativeEngineIndexInputMediator {
     static jfieldID BUFFER_FIELD_ID =
         jni_interface->GetFieldID(env, getIndexInputWithBufferClass(jni_interface, env), "buffer", "[B");
     return BUFFER_FIELD_ID;
+  }
+
+  static jmethodID getCopyVectorsMethod(JNIUtilInterface *jni_interface, JNIEnv *env) {
+    static jmethodID COPY_VECTORS_METHOD_ID =
+        jni_interface->GetMethodID(env, getIndexInputWithBufferClass(jni_interface, env), "copyVectors", "(I)I");
+    return COPY_VECTORS_METHOD_ID;
+  }
+
+  static jfieldID getVectorBufferFieldId(JNIUtilInterface *jni_interface, JNIEnv *env) {
+    static jfieldID VECTOR_BUFFER_FIELD_ID =
+        jni_interface->GetFieldID(env, getIndexInputWithBufferClass(jni_interface, env), "vectorBuffer", "[F");
+    return VECTOR_BUFFER_FIELD_ID;
   }
 
   JNIUtilInterface *jni_interface;

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -73,9 +73,9 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteInde
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    writeIndex
- * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;)V
+ * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;Z)V
  */
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv *, jclass, jlong, jobject);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv *, jclass, jlong, jobject, jboolean);
 
 
 /*

--- a/jni/patches/faiss/0011-Forward-io_flags-through-float-IndexIDMap-write.patch
+++ b/jni/patches/faiss/0011-Forward-io_flags-through-float-IndexIDMap-write.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gaurav Kumar <gku@amazon.com>
+Date: Wed, 20 Aug 2026 00:00:00 -0700
+Subject: [PATCH] Forward io_flags through the float IndexIDMap write branch
+
+Mirror patch 0008 (which added IO_FLAG_SKIP_STORAGE forwarding for the
+binary IndexBinaryIDMap) for the float write path. The float index is
+serialized as IndexIDMap wrapping IndexHNSWFlat; without forwarding
+io_flags here, IO_FLAG_SKIP_STORAGE never reaches the IndexHNSW writer
+(which already honors it at the "null" storage branch), so a graph-only
+.faiss cannot be produced for FP32 flat-vector deduplication.
+
+Signed-off-by: Gaurav Kumar <gku@amazon.com>
+---
+ faiss/impl/index_write.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/faiss/impl/index_write.cpp b/faiss/impl/index_write.cpp
+index def7dcd2b..f396177e1 100644
+--- a/faiss/impl/index_write.cpp
++++ b/faiss/impl/index_write.cpp
+@@ -765,7 +765,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
+         // no need to store additional info for IndexIDMap2
+         WRITE1(h);
+         write_index_header(idxmap, f);
+-        write_index(idxmap->index, f);
++        write_index(idxmap->index, f, io_flags);
+         WRITEVECTOR(idxmap->id_map);
+     } else if (const IndexHNSW* idxhnsw = dynamic_cast<const IndexHNSW*>(idx)) {
+         uint32_t h = dynamic_cast<const IndexHNSWFlat*>(idx) ? fourcc("IHNf")

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -149,7 +149,7 @@ void IndexService::writeIndex(
 
     try {
         // Write the index to disk
-        faissMethods->writeIndex(idMap.get(), writer);
+        faissMethods->writeIndex(idMap.get(), writer, skipFlat);
         if (auto openSearchIOWriter = dynamic_cast<knn_jni::stream::FaissOpenSearchIOWriter*>(writer)) {
             openSearchIOWriter->flush();
         }
@@ -396,7 +396,7 @@ void ByteIndexService::writeIndex(
 
     try {
         // Write the index to disk
-        faissMethods->writeIndex(idMap.get(), writer);
+        faissMethods->writeIndex(idMap.get(), writer, skipFlat);
         if (auto openSearchIOWriter = dynamic_cast<knn_jni::stream::FaissOpenSearchIOWriter*>(writer)) {
             openSearchIOWriter->flush();
         }

--- a/jni/src/faiss_methods.cpp
+++ b/jni/src/faiss_methods.cpp
@@ -30,8 +30,8 @@ faiss::IndexIDMapTemplate<faiss::IndexBinary>* FaissMethods::indexBinaryIdMap(fa
     return new faiss::IndexBinaryIDMap(index);
 }
 
-void FaissMethods::writeIndex(const faiss::Index* idx, faiss::IOWriter* writer) {
-    faiss::write_index(idx, writer);
+void FaissMethods::writeIndex(const faiss::Index* idx, faiss::IOWriter* writer, bool skipFlat) {
+    faiss::write_index(idx, writer, skipFlat ? faiss::IO_FLAG_SKIP_STORAGE : 0);
 }
 
 void FaissMethods::writeIndexBinary(const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat) {

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -20,6 +20,7 @@
 #include "faiss/index_factory.h"
 #include "faiss/index_io.h"
 #include "faiss/IndexHNSW.h"
+#include "faiss/IndexFlat.h"
 #include "faiss/IndexIVFFlat.h"
 #include "faiss/Index.h"
 #include "faiss/impl/IDSelector.h"
@@ -592,6 +593,68 @@ jlong knn_jni::faiss_wrapper::LoadIndexWithStream(faiss::IOReader* ioReader) {
 
     return (jlong) indexReader;
 }
+
+void knn_jni::faiss_wrapper::ReconstructFlatStorageFromStreamIfNeeded(
+    faiss::Index* index,
+    knn_jni::stream::NativeEngineIndexInputMediator* mediator
+) {
+    if (index == nullptr || mediator == nullptr) {
+        return;
+    }
+
+    // FP32 flat-vector dedup writes a float IndexIDMap wrapping an IndexHNSW whose flat storage was skipped
+    // (IO_FLAG_SKIP_STORAGE), so read_index yields storage == nullptr. Detect exactly that shape; anything else
+    // (normal indices with embedded storage, binary/ADC handled elsewhere) is left untouched.
+    auto* idMap = dynamic_cast<faiss::IndexIDMap*>(index);
+    if (idMap == nullptr) {
+        return;
+    }
+    auto* hnsw = dynamic_cast<faiss::IndexHNSW*>(idMap->index);
+    if (hnsw == nullptr || hnsw->storage != nullptr) {
+        return;
+    }
+
+    const int dimension = hnsw->d;
+    if (dimension <= 0) {
+        throw std::runtime_error("Cannot reconstruct flat storage: invalid dimension in graph-only HNSW header.");
+    }
+
+    // Build flat storage matching the graph's metric type and dimension (both restored from the HNSW header on read).
+    // IndexFlat is trained by construction, so no training is needed.
+    std::unique_ptr<faiss::IndexFlat> flatStorage(new faiss::IndexFlat(dimension, hnsw->metric_type));
+
+    // Stream the full-precision vectors from Lucene's .vec (via the Java mediator) in add order and append them.
+    // Batch ~2 MB worth of vectors per JNI crossing to amortize the callback across many vectors, avoiding a
+    // per-vector crossing (which would be prohibitive for large segments).
+    constexpr int64_t TARGET_BATCH_BYTES = 2 * 1024 * 1024;
+    const int32_t maxVectorsPerBatch = std::max<int32_t>(
+        1,
+        static_cast<int32_t>(TARGET_BATCH_BYTES / (static_cast<int64_t>(dimension) * sizeof(float)))
+    );
+    std::vector<float> batch(static_cast<size_t>(maxVectorsPerBatch) * dimension);
+
+    int64_t totalAdded = 0;
+    int32_t copied;
+    while ((copied = mediator->copyVectors(maxVectorsPerBatch, dimension, batch.data())) > 0) {
+        flatStorage->add(copied, batch.data());
+        totalAdded += copied;
+    }
+
+    // The streamed vector count must match the graph's vector count; otherwise the HNSW graph would reference vectors
+    // that are missing or misaligned (silent recall corruption). Fail loudly instead of returning a broken index.
+    if (totalAdded != hnsw->ntotal) {
+        throw std::runtime_error(
+            "Reconstructed flat storage vector count (" + std::to_string(totalAdded) +
+            ") does not match graph-only HNSW ntotal (" + std::to_string(hnsw->ntotal) +
+            "); the .vec file and .faiss graph are out of sync.");
+    }
+
+    // Assign as the HNSW storage. own_fields = true so the flat storage is freed when the enclosing IndexIDMap
+    // (own_fields = true from read_index) is deleted on the normal (non-binary) free path.
+    hnsw->storage = flatStorage.release();
+    hnsw->own_fields = true;
+}
+
 jlong knn_jni::faiss_wrapper::LoadIndexWithStreamADCParams(faiss::IOReader* ioReader, knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject methodParamsJ) {
     auto methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
 

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -161,12 +161,13 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteInde
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv * env,
                                                                            jclass cls,
                                                                            jlong indexAddress,
-                                                                           jobject output)
+                                                                           jobject output,
+                                                                           jboolean skipFlat)
 {
   try {
       std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
       knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
-      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &indexService);
+      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &indexService, skipFlat);
   } catch (...) {
       jniUtil.CatchCppExceptionAndThrowJava(env);
   }

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -324,8 +324,13 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndexWithSt
         knn_jni::stream::FaissOpenSearchIOReader faissOpenSearchIOReader {&mediator};
 
         // Pass IOReader to Faiss for loading vector index.
-        return knn_jni::faiss_wrapper::LoadIndexWithStream(
-                 &faissOpenSearchIOReader);
+        jlong indexAddress = knn_jni::faiss_wrapper::LoadIndexWithStream(&faissOpenSearchIOReader);
+
+        // If this is a graph-only .faiss (FP32 flat-vector dedup), reconstruct the native flat storage by streaming
+        // the full-precision vectors from Lucene's .vec file through the same mediator. No-op for normal indices.
+        knn_jni::faiss_wrapper::ReconstructFlatStorageFromStreamIfNeeded((faiss::Index*) indexAddress, &mediator);
+
+        return indexAddress;
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_index_service_test.cpp
+++ b/jni/tests/faiss_index_service_test.cpp
@@ -60,7 +60,7 @@ TEST(CreateIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter)))
+    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter), false))
         .Times(1);
 
     // Create the index
@@ -152,7 +152,7 @@ TEST(CreateByteIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter)))
+    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter), false))
         .Times(1);
 
     // Create the index

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -18,6 +18,8 @@
 #include "jni_util.h"
 #include "test_util.h"
 #include "faiss/IndexHNSW.h"
+#include "faiss/IndexIDMap.h"
+#include "faiss/index_io.h"
 #include "faiss/IndexBinaryHNSW.h"
 #include "faiss/IndexIVFPQ.h"
 #include "faiss/IndexIVFFlat.h"
@@ -1926,4 +1928,52 @@ TEST(FaissLoadIndexWithStreamADCTest, PreservesIdMapping) {
 
     // Clean up
     knn_jni::faiss_wrapper::Free(resultPtr, JNI_FALSE);
+}
+
+// Verifies the FP32 flat-vector dedup write side: writing a float IndexIDMap<IndexHNSWFlat> with
+// IO_FLAG_SKIP_STORAGE must produce a graph-only index (null storage). This exercises faiss patch 0011,
+// which forwards io_flags through the float IndexIDMap write branch so the flag reaches the IndexHNSW
+// writer's "null" storage branch. Without the patch, the storage would still be embedded.
+TEST(FaissFloatSkipStorageTest, GraphOnlyIndexWrittenWithSkipStorage) {
+    const int dim = 8;
+    const int numVecs = 60;
+    std::vector<float> vectors(dim * numVecs);
+    for (int i = 0; i < dim * numVecs; ++i) {
+        vectors[i] = test_util::RandomFloat(-1.0f, 1.0f);
+    }
+    std::vector<faiss::idx_t> ids(numVecs);
+    for (int i = 0; i < numVecs; ++i) {
+        ids[i] = i;
+    }
+
+    // Mirror the OpenSearch FP32 write layout: IndexIDMap wrapping IndexHNSWFlat.
+    faiss::IndexHNSWFlat hnsw(dim, 16, faiss::METRIC_L2);
+    faiss::IndexIDMap idMap(&hnsw);
+    idMap.add_with_ids(numVecs, vectors.data(), ids.data());
+
+    const std::string fullPath = test_util::RandomString(16, "tmp/", ".faiss");
+    const std::string skipPath = test_util::RandomString(16, "tmp/", ".faiss");
+
+    // Full write embeds the flat storage; skip write must omit it (graph-only).
+    faiss::write_index(&idMap, fullPath.c_str());
+    faiss::write_index(&idMap, skipPath.c_str(), faiss::IO_FLAG_SKIP_STORAGE);
+
+    // Full build: storage is present.
+    std::unique_ptr<faiss::Index> readFull(faiss::read_index(fullPath.c_str()));
+    auto* idMapFull = dynamic_cast<faiss::IndexIDMap*>(readFull.get());
+    ASSERT_NE(idMapFull, nullptr);
+    auto* hnswFull = dynamic_cast<faiss::IndexHNSW*>(idMapFull->index);
+    ASSERT_NE(hnswFull, nullptr);
+    ASSERT_NE(hnswFull->storage, nullptr);
+
+    // Graph-only build: storage is null (the "null" marker). Relies on faiss patch 0011.
+    std::unique_ptr<faiss::Index> readSkip(faiss::read_index(skipPath.c_str()));
+    auto* idMapSkip = dynamic_cast<faiss::IndexIDMap*>(readSkip.get());
+    ASSERT_NE(idMapSkip, nullptr);
+    auto* hnswSkip = dynamic_cast<faiss::IndexHNSW*>(idMapSkip->index);
+    ASSERT_NE(hnswSkip, nullptr);
+    ASSERT_EQ(hnswSkip->storage, nullptr);
+
+    std::remove(fullPath.c_str());
+    std::remove(skipPath.c_str());
 }

--- a/jni/tests/mocks/faiss_methods_mock.h
+++ b/jni/tests/mocks/faiss_methods_mock.h
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD(faiss::IndexBinary*, indexBinaryFactory, (int d, const char* description), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::Index>*, indexIdMap, (faiss::Index* index), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::IndexBinary>*, indexBinaryIdMap, (faiss::IndexBinary* index), (override));
-    MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, faiss::IOWriter* writer), (override));
+    MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, faiss::IOWriter* writer, bool skipFlat), (override));
     MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat), (override));
 };
 

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.store.Directory;
+import org.opensearch.common.CheckedSupplier;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.MapperService;
@@ -22,6 +23,8 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.codec.util.NativeMemoryCacheKeyHelper;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
@@ -104,7 +107,7 @@ public class KNNIndexShard {
 
                 // Load off-heap index
                 final List<EngineFileContext> engineFileContexts = getAllEngineFileContexts(loadedFieldNames, leafReaderContext);
-                warmUpOffHeapIndex(engineFileContexts, directory);
+                warmUpOffHeapIndex(engineFileContexts, directory, leafReaderContext);
                 log.info(
                     "[KNN] Loaded off-heap indices for fields {}",
                     engineFileContexts.stream().map(ctx -> ctx.fieldName).collect(Collectors.toSet())
@@ -117,7 +120,12 @@ public class KNNIndexShard {
         }
     }
 
-    private void warmUpOffHeapIndex(final List<EngineFileContext> engineFileContexts, final Directory directory) {
+    private void warmUpOffHeapIndex(
+        final List<EngineFileContext> engineFileContexts,
+        final Directory directory,
+        final LeafReaderContext leafReaderContext
+    ) throws IOException {
+        final SegmentReader segmentReader = Lucene.segmentReader(leafReaderContext.reader());
         for (final EngineFileContext engineFileContext : engineFileContexts) {
             try {
                 // Get cache key for an off-heap index
@@ -125,6 +133,13 @@ public class KNNIndexShard {
                     engineFileContext.vectorFileName,
                     engineFileContext.segmentInfo
                 );
+
+                final KNNEngine knnEngine = KNNEngine.getEngineNameFromPath(engineFileContext.getVectorFileName());
+                // Provide a lazy supplier of full-precision vectors so native can reconstruct flat storage when warming
+                // up a graph-only (FP32 flat-vector deduped) FAISS float index. Invoked only if native needs it; null
+                // otherwise, so normal indices pay nothing.
+                final CheckedSupplier<KNNVectorValues<?>, IOException> knnVectorValuesSupplier =
+                    maybeGetVectorValuesSupplierForReconstruction(segmentReader, engineFileContext, knnEngine);
 
                 // Load an off-heap index
                 nativeMemoryCacheManager.get(
@@ -134,14 +149,15 @@ public class KNNIndexShard {
                         NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
                         getParametersAtLoading(
                             engineFileContext.getSpaceType(),
-                            KNNEngine.getEngineNameFromPath(engineFileContext.getVectorFileName()),
+                            knnEngine,
                             getIndexName(),
                             engineFileContext.getVectorDataType(),
                             engineFileContext.getSegmentLevelQuantizationInfo()
 
                         ),
                         getIndexName(),
-                        engineFileContext.getModelId()
+                        engineFileContext.getModelId(),
+                        knnVectorValuesSupplier
                     ),
                     true
                 );
@@ -149,6 +165,28 @@ public class KNNIndexShard {
                 throw new RuntimeException(ex);
             }
         }
+    }
+
+    /**
+     * Returns a lazy supplier of full-precision {@link KNNVectorValues} for the field when the index could be a
+     * graph-only (FP32 flat-vector deduped) FAISS float index, so native can reconstruct flat storage from Lucene's
+     * .vec file during warmup. Returns null for non-FAISS, non-float, or quantized fields, where reconstruction does
+     * not apply. The supplier defers segment-reader access until native actually needs it (only for graph-only indices).
+     */
+    private CheckedSupplier<KNNVectorValues<?>, IOException> maybeGetVectorValuesSupplierForReconstruction(
+        final SegmentReader segmentReader,
+        final EngineFileContext engineFileContext,
+        final KNNEngine knnEngine
+    ) {
+        if (knnEngine != KNNEngine.FAISS
+            || engineFileContext.getVectorDataType() != VectorDataType.FLOAT
+            || engineFileContext.getSegmentLevelQuantizationInfo() != null) {
+            return null;
+        }
+        return () -> {
+            final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(segmentReader, engineFileContext.getFieldName());
+            return fieldInfo == null ? null : KNNVectorValuesFactory.getVectorValues(fieldInfo, segmentReader);
+        };
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -41,7 +41,6 @@ import java.security.InvalidParameterException;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -222,38 +221,6 @@ public class KNNSettings {
     public static final Setting<Boolean> INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING = Setting.boolSetting(
         INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP,
         INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE,
-        // Flat-vector dedup writes a graph-only .faiss whose vectors are served from Lucene's .vec only by
-        // memory-optimized search. It is therefore only safe to enable together with memory_optimized_search.
-        // (MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING is referenced lazily at validation time, so the forward
-        // reference to a field declared later in this class is safe.)
-        new Setting.Validator<Boolean>() {
-            @Override
-            public void validate(final Boolean value) {
-                // Cross-setting validation is performed in the two-argument overload.
-            }
-
-            @Override
-            public void validate(final Boolean value, final Map<Setting<?>, Object> settings) {
-                if (Boolean.TRUE.equals(value) == false) {
-                    return;
-                }
-                final Object memoryOptimizedSearchEnabled = settings.get(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
-                if (Boolean.TRUE.equals(memoryOptimizedSearchEnabled) == false) {
-                    throw new IllegalArgumentException(
-                        "["
-                            + INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP
-                            + "] can only be enabled when ["
-                            + MEMORY_OPTIMIZED_KNN_SEARCH_MODE
-                            + "] is enabled on the index."
-                    );
-                }
-            }
-
-            @Override
-            public Iterator<Setting<?>> settings() {
-                return List.<Setting<?>>of(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING).iterator();
-            }
-        },
         IndexScope,
         Dynamic
     );
@@ -1203,23 +1170,6 @@ public class KNNSettings {
         final IndexSettings indexSettings = mapperService.getIndexSettings();
         final Boolean flatVectorDedupEnabled = indexSettings.getValue(INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING);
         return flatVectorDedupEnabled != null ? flatVectorDedupEnabled : INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE;
-    }
-
-    /**
-     * Retrieves the {@code index.knn.memory_optimized_search} value from the given
-     * {@link org.opensearch.index.mapper.MapperService}'s index settings, or returns the default value (false) when
-     * {@code mapperService} is null or the setting is not explicitly configured. Named distinctly from the
-     * {@code String}-indexName overload to avoid an ambiguous overload when called with a {@code null} literal.
-     *
-     * @param mapperService the mapper service (nullable)
-     * @return whether memory-optimized search is enabled for the index
-     */
-    public static boolean isMemoryOptimizedKnnSearchModeEnabledForMapper(@Nullable MapperService mapperService) {
-        if (mapperService == null) {
-            return DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
-        }
-        final Boolean memoryOptimizedSearchEnabled = mapperService.getIndexSettings().getValue(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
-        return memoryOptimizedSearchEnabled != null ? memoryOptimizedSearchEnabled : DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
     }
 
     private static String percentageAsString(Integer percentage) {

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -41,6 +41,7 @@ import java.security.InvalidParameterException;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -86,6 +87,7 @@ public class KNNSettings {
      * Settings name
      */
     public static final String INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD = "index.knn.advanced.approximate_threshold";
+    public static final String INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP = "index.knn.advanced.flat_vector_dedup";
     public static final String KNN_ALGO_PARAM_EF_SEARCH = "index.knn.algo_param.ef_search";
     public static final String KNN_ALGO_PARAM_INDEX_THREAD_QTY = "knn.algo_param.index_thread_qty";
     public static final String KNN_MEMORY_CIRCUIT_BREAKER_ENABLED = "knn.memory.circuit_breaker.enabled";
@@ -138,6 +140,7 @@ public class KNNSettings {
     public static final boolean KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
     public static final Integer INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE = 0;
+    public static final boolean INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE = false;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN = -1;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX = Integer.MAX_VALUE - 2;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_M = 16;
@@ -207,6 +210,50 @@ public class KNNSettings {
         INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
         INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
         INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX,
+        IndexScope,
+        Dynamic
+    );
+
+    /**
+     * When enabled on a FAISS FP32 index, the flat vectors are not embedded in the .faiss file (a graph-only index is
+     * written). Vectors are served from Lucene's .vec file at search time, avoiding the duplicate on-disk storage.
+     * Index-scoped, dynamic, and OFF by default. FP32 native (FAISS) HNSW only; other data types are ignored.
+     */
+    public static final Setting<Boolean> INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING = Setting.boolSetting(
+        INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP,
+        INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE,
+        // Flat-vector dedup writes a graph-only .faiss whose vectors are served from Lucene's .vec only by
+        // memory-optimized search. It is therefore only safe to enable together with memory_optimized_search.
+        // (MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING is referenced lazily at validation time, so the forward
+        // reference to a field declared later in this class is safe.)
+        new Setting.Validator<Boolean>() {
+            @Override
+            public void validate(final Boolean value) {
+                // Cross-setting validation is performed in the two-argument overload.
+            }
+
+            @Override
+            public void validate(final Boolean value, final Map<Setting<?>, Object> settings) {
+                if (Boolean.TRUE.equals(value) == false) {
+                    return;
+                }
+                final Object memoryOptimizedSearchEnabled = settings.get(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
+                if (Boolean.TRUE.equals(memoryOptimizedSearchEnabled) == false) {
+                    throw new IllegalArgumentException(
+                        "["
+                            + INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP
+                            + "] can only be enabled when ["
+                            + MEMORY_OPTIMIZED_KNN_SEARCH_MODE
+                            + "] is enabled on the index."
+                    );
+                }
+            }
+
+            @Override
+            public Iterator<Setting<?>> settings() {
+                return List.<Setting<?>>of(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING).iterator();
+            }
+        },
         IndexScope,
         Dynamic
     );
@@ -741,6 +788,7 @@ public class KNNSettings {
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
             INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING,
+            INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING,
             KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING,
             KNN_CIRCUIT_BREAKER_TRIGGERED_SETTING,
@@ -1138,6 +1186,40 @@ public class KNNSettings {
         final IndexSettings indexSettings = mapperService.getIndexSettings();
         final Integer approximateThresholdValue = indexSettings.getValue(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
         return approximateThresholdValue != null ? approximateThresholdValue : INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
+    }
+
+    /**
+     * Retrieves the {@code index.knn.advanced.flat_vector_dedup} value from the given
+     * {@link org.opensearch.index.mapper.MapperService}'s index settings, or returns the default value (false) when
+     * {@code mapperService} is null or the setting is not explicitly configured.
+     *
+     * @param mapperService the mapper service (nullable)
+     * @return whether flat-vector deduplication (graph-only .faiss) is enabled for the index
+     */
+    public static boolean isFlatVectorDedupEnabled(@Nullable MapperService mapperService) {
+        if (mapperService == null) {
+            return INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE;
+        }
+        final IndexSettings indexSettings = mapperService.getIndexSettings();
+        final Boolean flatVectorDedupEnabled = indexSettings.getValue(INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING);
+        return flatVectorDedupEnabled != null ? flatVectorDedupEnabled : INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE;
+    }
+
+    /**
+     * Retrieves the {@code index.knn.memory_optimized_search} value from the given
+     * {@link org.opensearch.index.mapper.MapperService}'s index settings, or returns the default value (false) when
+     * {@code mapperService} is null or the setting is not explicitly configured. Named distinctly from the
+     * {@code String}-indexName overload to avoid an ambiguous overload when called with a {@code null} literal.
+     *
+     * @param mapperService the mapper service (nullable)
+     * @return whether memory-optimized search is enabled for the index
+     */
+    public static boolean isMemoryOptimizedKnnSearchModeEnabledForMapper(@Nullable MapperService mapperService) {
+        if (mapperService == null) {
+            return DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
+        }
+        final Boolean memoryOptimizedSearchEnabled = mapperService.getIndexSettings().getValue(MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
+        return memoryOptimizedSearchEnabled != null ? memoryOptimizedSearchEnabled : DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
     }
 
     private static String percentageAsString(Integer percentage) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -126,7 +126,9 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
                 approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
-                quantizedValues
+                quantizedValues,
+                // SQ has its own graph-only path; FP32 flat-vector dedup does not apply here.
+                false
             );
         } finally {
             IOUtils.close(flatVectorsReader);
@@ -167,7 +169,9 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
                 approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
-                quantizedValues
+                quantizedValues,
+                // SQ has its own graph-only path; FP32 flat-vector dedup does not apply here.
+                false
             );
         } finally {
             IOUtils.close(flatVectorsReader);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -41,6 +41,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
     private final int approximateThreshold;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final boolean flatVectorDedup;
 
     public NativeEngines990KnnVectorsFormat() {
         this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE);
@@ -54,9 +55,18 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
         int approximateThreshold,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
+        this(approximateThreshold, nativeIndexBuildStrategyFactory, KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_DEFAULT_VALUE);
+    }
+
+    public NativeEngines990KnnVectorsFormat(
+        int approximateThreshold,
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        boolean flatVectorDedup
+    ) {
         super(FORMAT_NAME);
         this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.flatVectorDedup = flatVectorDedup;
     }
 
     /**
@@ -70,7 +80,8 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
             state,
             flatVectorsFormat.fieldsWriter(state),
             approximateThreshold,
-            nativeIndexBuildStrategyFactory
+            nativeIndexBuildStrategyFactory,
+            flatVectorDedup
         );
     }
 
@@ -109,6 +120,8 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
             + flatVectorsFormat
             + ", approximateThreshold="
             + approximateThreshold
+            + ", flatVectorDedup="
+            + flatVectorDedup
             + ")";
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -47,6 +47,7 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
     private boolean finished;
     private final Integer approximateThreshold;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final boolean flatVectorDedup;
 
     public NativeEngines990KnnVectorsWriter(
         SegmentWriteState segmentWriteState,
@@ -54,10 +55,21 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
         Integer approximateThreshold,
         NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
+        this(segmentWriteState, flatVectorsWriter, approximateThreshold, nativeIndexBuildStrategyFactory, false);
+    }
+
+    public NativeEngines990KnnVectorsWriter(
+        SegmentWriteState segmentWriteState,
+        FlatVectorsWriter flatVectorsWriter,
+        Integer approximateThreshold,
+        NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        boolean flatVectorDedup
+    ) {
         this.segmentWriteState = segmentWriteState;
         this.flatVectorsWriter = flatVectorsWriter;
         this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.flatVectorDedup = flatVectorDedup;
     }
 
     /**
@@ -95,7 +107,8 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
                 approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
-                null
+                null,
+                flatVectorDedup
             );
         }
     }
@@ -107,7 +120,16 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
 
         if (mergeRunnable != null) mergeRunnable.run();
 
-        doMergeOneField(fieldInfo, mergeState, this::train, approximateThreshold, segmentWriteState, nativeIndexBuildStrategyFactory, null);
+        doMergeOneField(
+            fieldInfo,
+            mergeState,
+            this::train,
+            approximateThreshold,
+            segmentWriteState,
+            nativeIndexBuildStrategyFactory,
+            null,
+            flatVectorDedup
+        );
         return null;
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
@@ -40,7 +40,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
         final Integer approximateThreshold,
         final SegmentWriteState segmentWriteState,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean flatVectorDedup
     ) throws IOException {
         // Check total live docs first to avoid unnecessary supplier creation for empty fields
         final int totalLiveDocs;
@@ -89,7 +90,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
             segmentWriteState,
             quantizationState,
             nativeIndexBuildStrategyFactory,
-            quantizedByteVectorValues
+            quantizedByteVectorValues,
+            flatVectorDedup
         );
 
         final StopWatch stopWatch = new StopWatch().start();
@@ -106,7 +108,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
         final Integer approximateThreshold,
         final SegmentWriteState segmentWriteState,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean flatVectorDedup
     ) throws IOException {
         final VectorDataType vectorDataType = extractVectorDataType(fieldInfo);
         final Supplier<KNNVectorValues<?>> knnVectorValuesSupplier = getKNNVectorValuesSupplierForMerge(
@@ -143,7 +146,8 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
             segmentWriteState,
             quantizationState,
             nativeIndexBuildStrategyFactory,
-            quantizedByteVectorValues
+            quantizedByteVectorValues,
+            flatVectorDedup
         );
 
         final StopWatch stopWatch = new StopWatch().start();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -122,7 +122,13 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
 
             // Write vector
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                JNIService.writeIndex(indexInfo.getIndexOutputWithBuffer(), indexMemoryAddress, engine, indexParameters, false);
+                JNIService.writeIndex(
+                    indexInfo.getIndexOutputWithBuffer(),
+                    indexMemoryAddress,
+                    engine,
+                    indexParameters,
+                    indexInfo.isSkipVectorStorage()
+                );
                 return null;
             });
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -63,6 +63,9 @@ public class NativeIndexWriter {
     private final QuantizationState quantizationState;
     @Nullable
     private final QuantizedByteVectorValues quantizedByteVectorValues;
+    // When true (FAISS FP32 HNSW with index.knn.advanced.flat_vector_dedup enabled), a graph-only .faiss is written
+    // and vectors are served from Lucene's .vec file. Threaded from the codec format; false for all other cases.
+    private final boolean skipVectorStorage;
 
     /**
      * Gets the correct writer type from fieldInfo
@@ -71,7 +74,7 @@ public class NativeIndexWriter {
      * @return correct NativeIndexWriter to make index specified in fieldInfo
      */
     public static NativeIndexWriter getWriter(final FieldInfo fieldInfo, SegmentWriteState state) {
-        return createWriter(fieldInfo, state, null, new NativeIndexBuildStrategyFactory(), null);
+        return createWriter(fieldInfo, state, null, new NativeIndexBuildStrategyFactory(), null, false);
     }
 
     /**
@@ -95,7 +98,7 @@ public class NativeIndexWriter {
         final QuantizationState quantizationState,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
-        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, null);
+        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, null, false);
     }
 
     /**
@@ -115,7 +118,31 @@ public class NativeIndexWriter {
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
         @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
     ) {
-        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, quantizedByteVectorValues);
+        return createWriter(fieldInfo, state, quantizationState, nativeIndexBuildStrategyFactory, quantizedByteVectorValues, false);
+    }
+
+    /**
+     * Same as {@link #getWriter(FieldInfo, SegmentWriteState, QuantizationState, NativeIndexBuildStrategyFactory,
+     * QuantizedByteVectorValues)} with control over flat-vector dedup (graph-only .faiss).
+     *
+     * @param skipVectorStorage when true, the flat vector storage is skipped in the .faiss (FAISS FP32 HNSW only).
+     */
+    public static NativeIndexWriter getWriter(
+        final FieldInfo fieldInfo,
+        final SegmentWriteState state,
+        final QuantizationState quantizationState,
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean skipVectorStorage
+    ) {
+        return createWriter(
+            fieldInfo,
+            state,
+            quantizationState,
+            nativeIndexBuildStrategyFactory,
+            quantizedByteVectorValues,
+            skipVectorStorage
+        );
     }
 
     /**
@@ -219,6 +246,15 @@ public class NativeIndexWriter {
             parameters = getParameters(fieldInfo, vectorDataType, knnEngine);
         }
 
+        // Flat-vector dedup (graph-only .faiss) applies only to non-model FAISS FP32 fields, which build a plain HNSW
+        // via MemOptimizedNativeIndexBuildStrategy. Quantized (SQ) fields have their own graph-only path; models may be
+        // IVF (whose writer does not honor IO_FLAG_SKIP_STORAGE), so they are excluded.
+        final boolean skipVectorStorageForField = skipVectorStorage
+            && knnEngine == KNNEngine.FAISS
+            && vectorDataType == VectorDataType.FLOAT
+            && quantizationState == null
+            && fieldInfo.attributes().containsKey(MODEL_ID) == false;
+
         return BuildIndexParams.builder()
             .field(fieldInfo.getName())
             .indexParameters(parameters)
@@ -231,6 +267,7 @@ public class NativeIndexWriter {
             .segmentWriteState(state)
             .isFlush(isFlush)
             .quantizedByteVectorValues(quantizedByteVectorValues)
+            .skipVectorStorage(skipVectorStorageForField)
             .build();
     }
 
@@ -359,8 +396,16 @@ public class NativeIndexWriter {
         final SegmentWriteState state,
         @Nullable final QuantizationState quantizationState,
         NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues
+        @Nullable final QuantizedByteVectorValues quantizedByteVectorValues,
+        final boolean skipVectorStorage
     ) {
-        return new NativeIndexWriter(state, fieldInfo, nativeIndexBuildStrategyFactory, quantizationState, quantizedByteVectorValues);
+        return new NativeIndexWriter(
+            state,
+            fieldInfo,
+            nativeIndexBuildStrategyFactory,
+            quantizationState,
+            quantizedByteVectorValues,
+            skipVectorStorage
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
@@ -44,4 +44,10 @@ public class BuildIndexParams {
      */
     @Nullable
     QuantizedByteVectorValues quantizedByteVectorValues;
+    /**
+     * When true, the flat vector storage is not embedded in the .faiss file (a graph-only index is written via
+     * IO_FLAG_SKIP_STORAGE) and vectors are served from Lucene's .vec file at search time. Set only for FAISS FP32
+     * HNSW fields when {@code index.knn.advanced.flat_vector_dedup} is enabled; false otherwise.
+     */
+    boolean skipVectorStorage;
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -65,11 +65,10 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
     @Override
     public KnnVectorsFormat resolve() {
         final int approximateThreshold = KNNSettings.getApproximateThresholdValue(mapperService);
-        // Only write a graph-only (deduped) .faiss when memory-optimized search is enabled: MOS is the only search
-        // path that serves vectors from Lucene's .vec, so graph-only segments are only safe to produce under MOS.
-        // KNNSettings validation enforces the same invariant at config time; this is the write-path safety net.
-        final boolean flatVectorDedup = KNNSettings.isFlatVectorDedupEnabled(mapperService)
-            && KNNSettings.isMemoryOptimizedKnnSearchModeEnabledForMapper(mapperService);
+        // Write a graph-only (deduped) .faiss whenever flat_vector_dedup is enabled. Memory-optimized search serves
+        // vectors directly from Lucene's .vec; the default (non-MOS) path reconstructs the flat storage from .vec at
+        // load, so graph-only segments are safe on both paths.
+        final boolean flatVectorDedup = KNNSettings.isFlatVectorDedupEnabled(mapperService);
         return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory, flatVectorDedup);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -65,6 +65,11 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
     @Override
     public KnnVectorsFormat resolve() {
         final int approximateThreshold = KNNSettings.getApproximateThresholdValue(mapperService);
-        return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory);
+        // Only write a graph-only (deduped) .faiss when memory-optimized search is enabled: MOS is the only search
+        // path that serves vectors from Lucene's .vec, so graph-only segments are only safe to produce under MOS.
+        // KNNSettings validation enforces the same invariant at config time; this is the write-path safety net.
+        final boolean flatVectorDedup = KNNSettings.isFlatVectorDedupEnabled(mapperService)
+            && KNNSettings.isMemoryOptimizedKnnSearchModeEnabledForMapper(mapperService);
+        return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory, flatVectorDedup);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -13,15 +13,19 @@ package org.opensearch.knn.index.memory;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.util.NativeMemoryCacheKeyHelper;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.common.CheckedSupplier;
 import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
 import java.io.IOException;
 import java.util.Map;
@@ -105,6 +109,14 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         IndexInputWithBuffer indexInputWithBuffer;
 
         /**
+         * Lazily supplies the field's full-precision vectors, used only to reconstruct native flat storage when
+         * loading a graph-only .faiss produced by FP32 flat-vector deduplication. Invoked only if native needs it
+         * (graph-only index); null when reconstruction cannot apply.
+         */
+        @Getter
+        CheckedSupplier<KNNVectorValues<?>, IOException> knnVectorValuesSupplier;
+
+        /**
          * Constructor
          *
          * @param directory Lucene directory to create required IndexInput/IndexOutput to access files.
@@ -141,23 +153,86 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             String openSearchIndexName,
             String modelId
         ) {
+            this(directory, vectorIndexCacheKey, indexLoadStrategy, parameters, openSearchIndexName, modelId, null);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param directory Lucene directory to create required IndexInput/IndexOutput to access files.
+         * @param vectorIndexCacheKey Cache key for {@link NativeMemoryCacheManager}. It must contain a vector file name.
+         * @param indexLoadStrategy strategy to load index into memory
+         * @param parameters load time parameters
+         * @param openSearchIndexName opensearch index associated with index
+         * @param modelId model to be loaded. If none available, pass null
+         * @param knnVectorValuesSupplier lazily supplies full-precision vectors to reconstruct native flat storage for
+         *                        a graph-only (FP32 flat-vector deduped) .faiss. Pass null when not applicable.
+         */
+        public IndexEntryContext(
+            Directory directory,
+            String vectorIndexCacheKey,
+            NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy,
+            Map<String, Object> parameters,
+            String openSearchIndexName,
+            String modelId,
+            CheckedSupplier<KNNVectorValues<?>, IOException> knnVectorValuesSupplier
+        ) {
             super(vectorIndexCacheKey);
             this.directory = directory;
             this.indexLoadStrategy = indexLoadStrategy;
             this.openSearchIndexName = openSearchIndexName;
             this.parameters = parameters;
             this.modelId = modelId;
+            this.knnVectorValuesSupplier = knnVectorValuesSupplier;
         }
+
+        // Bytes to add to the on-disk .faiss size to account for vectors reconstructed into native RAM at load
+        // (flat-vector dedup). -1 until computed once, then cached (calculateSizeInKB is called repeatedly by the cache
+        // manager for capacity checks).
+        private long reconstructedVectorBytes = -1L;
 
         @Override
         public Integer calculateSizeInKB() {
             final String indexFileName = NativeMemoryCacheKeyHelper.extractVectorIndexFileName(key);
             try {
                 final long fileLength = directory.fileLength(indexFileName);
-                return (int) (fileLength / 1024L);
+                return (int) ((fileLength + reconstructedVectorBytes(indexFileName)) / 1024L);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+        }
+
+        /**
+         * For a graph-only (flat-vector-deduped) .faiss, the loaded index reconstructs the field's vectors from the
+         * segment's Lucene .vec into native RAM, but the .faiss file on disk holds only the graph. Without adjustment
+         * the native-memory cache would size this entry by the (small) graph-only file and under-count the loaded
+         * footprint, so the circuit breaker would not reserve/evict correctly. Add the segment's .vec size when
+         * flat_vector_dedup is enabled for the index. Conservative: counts the whole segment .vec (all float vector
+         * fields); exact for the common single-vector-field case. Best-effort and cached; on any error it falls back to
+         * file-size-only accounting.
+         */
+        private long reconstructedVectorBytes(final String indexFileName) {
+            if (reconstructedVectorBytes >= 0) {
+                return reconstructedVectorBytes;
+            }
+            long bytes = 0L;
+            try {
+                if (openSearchIndexName != null
+                    && KNNSettings.getIndexSettings(openSearchIndexName)
+                        .getAsBoolean(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, false)) {
+                    final String segmentName = IndexFileNames.parseSegmentName(indexFileName);
+                    for (final String file : directory.listAll()) {
+                        if (file.endsWith(".vec") && segmentName.equals(IndexFileNames.parseSegmentName(file))) {
+                            bytes += directory.fileLength(file);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // Best-effort: fall back to file-size-only accounting rather than fail sizing.
+                bytes = 0L;
+            }
+            reconstructedVectorBytes = bytes;
+            return bytes;
         }
 
         @Override
@@ -181,7 +256,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
 
             // Try to open an index input then pass it down to native engine for loading an index.
             try {
-                indexSizeKb = Math.toIntExact(directory.fileLength(vectorFileName) / 1024);
+                indexSizeKb = Math.toIntExact((directory.fileLength(vectorFileName) + reconstructedVectorBytes(vectorFileName)) / 1024);
                 readStream = directory.openInput(vectorFileName, IOContext.READONCE);
                 readStream.seek(0);
                 indexInputWithBuffer = new IndexInputWithBuffer(readStream);

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
@@ -90,6 +90,10 @@ public interface NativeMemoryLoadStrategy<T extends NativeMemoryAllocation, U ex
                 throw new IllegalStateException("Index [" + indexEntryContext.getOpenSearchIndexName() + "] is not preloaded");
             }
             try (indexEntryContext) {
+                // Attach the (lazy) full-precision vector supplier so native can reconstruct flat storage if this is a
+                // graph-only (FP32 flat-vector deduped) .faiss. Null for normal loads; the supplier is invoked only if
+                // native actually needs to reconstruct.
+                indexEntryContext.indexInputWithBuffer.setKnnVectorValuesSupplier(indexEntryContext.getKnnVectorValuesSupplier());
                 final long indexAddress = JNIService.loadIndex(
                     indexEntryContext.indexInputWithBuffer,
                     indexEntryContext.getParameters(),

--- a/src/main/java/org/opensearch/knn/index/query/DefaultKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/DefaultKNNWeight.java
@@ -14,6 +14,10 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Version;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.common.CheckedSupplier;
+import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
@@ -190,6 +194,16 @@ public class DefaultKNNWeight extends KNNWeight {
         final String modelId,
         LeafReaderContext context
     ) throws ExecutionException, IOException {
+        // For a potentially graph-only (FP32 flat-vector deduped) FAISS float index, provide a lazy supplier of the
+        // full-precision vectors so native can reconstruct flat storage from the .vec file at load. The supplier is
+        // invoked only if the loaded .faiss has no embedded storage; null otherwise, so normal loads pay nothing.
+        final CheckedSupplier<KNNVectorValues<?>, IOException> knnVectorValuesSupplier = maybeGetVectorValuesSupplierForReconstruction(
+            reader,
+            knnQuery.getField(),
+            knnEngine,
+            vectorDataType,
+            quantizedVector
+        );
         return nativeMemoryCacheManager.get(
             new NativeMemoryEntryContext.IndexEntryContext(
                 reader.directory(),
@@ -204,9 +218,32 @@ public class DefaultKNNWeight extends KNNWeight {
                     segmentLevelQuantizationInfo
                 ),
                 knnQuery.getIndexName(),
-                modelId
+                modelId,
+                knnVectorValuesSupplier
             ),
             true
         );
+    }
+
+    /**
+     * Returns a lazy supplier of full-precision {@link KNNVectorValues} for the field when the loaded index could be a
+     * graph-only (FP32 flat-vector deduped) FAISS float index, so native can reconstruct flat storage from Lucene's
+     * .vec file. Returns null for non-FAISS, non-float, or quantized fields, where reconstruction does not apply. The
+     * supplier defers all segment-reader access until native actually needs it (only for graph-only indices).
+     */
+    private CheckedSupplier<KNNVectorValues<?>, IOException> maybeGetVectorValuesSupplierForReconstruction(
+        final SegmentReader reader,
+        final String field,
+        final KNNEngine knnEngine,
+        final VectorDataType vectorDataType,
+        final byte[] quantizedVector
+    ) {
+        if (knnEngine != KNNEngine.FAISS || vectorDataType != VectorDataType.FLOAT || quantizedVector != null) {
+            return null;
+        }
+        return () -> {
+            final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, field);
+            return fieldInfo == null ? null : KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        };
     }
 }

--- a/src/main/java/org/opensearch/knn/index/store/IndexInputWithBuffer.java
+++ b/src/main/java/org/opensearch/knn/index/store/IndexInputWithBuffer.java
@@ -6,7 +6,18 @@
 package org.opensearch.knn.index.store;
 
 import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.DataAccessHint;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.CheckedSupplier;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 
 import java.io.IOException;
 
@@ -16,11 +27,42 @@ import java.io.IOException;
  * called by native engine via JNI API.
  * Therefore, this class servers as a read layer in native engines to read the bytes it wants.
  */
+@Log4j2
 public class IndexInputWithBuffer {
     private IndexInput indexInput;
     private long contentLength;
     // 64K buffer.
     private byte[] buffer = new byte[64 * 1024];
+
+    /**
+     * Lazily supplies the field's full-precision vectors, used only to reconstruct native flat storage when loading a
+     * graph-only .faiss produced by FP32 flat-vector deduplication (IO_FLAG_SKIP_STORAGE). Set right before
+     * {@code loadIndex}; the supplier is invoked (once) only if native calls {@link #copyVectors(int)}, which happens
+     * only for a graph-only index. For normal (non-deduped) loads it is never invoked, so there is no cost or reader
+     * access. Null when reconstruction cannot apply (non-FAISS/non-FP32/quantized).
+     */
+    @Setter
+    private CheckedSupplier<KNNVectorValues<?>, IOException> knnVectorValuesSupplier;
+    // Materialized (lazily, on first copyVectors call) from knnVectorValuesSupplier.
+    private KNNVectorValues<?> knnVectorValues;
+    // Reused staging buffer for batched vector streaming to native (sized maxVectors * dimension, lazily).
+    private float[] vectorBuffer;
+    // Once the vector iterator is exhausted, do not advance it again: calling nextDoc() past NO_MORE_DOCS on a sparse
+    // (IndexedDISI-backed) iterator throws an AssertionError. This lets native call copyVectors one final time safely.
+    private boolean vectorsExhausted;
+
+    // Sequential-read state for reconstructing flat storage from .vec. Reconstruction consumes vectors in FAISS-ordinal
+    // order, which is exactly the contiguous layout of the Lucene flat file, so it is a pure forward scan of .vec.
+    // However the flat reader opens .vec with DataAccessHint.RANDOM (HNSW does random access), which disables OS
+    // readahead; without it, streaming the whole file faults the mmap 4KB page by page (hundreds of thousands of
+    // synchronous reads on a cold cache). For the one-shot reconstruction scan we flip the flat-vector IndexInput to
+    // DataAccessHint.SEQUENTIAL (kernel then reads ahead aggressively), and restore RANDOM once done so later
+    // random-access reads (exact search, rescore) are not penalized. This is advisory only (madvise): the bytes
+    // returned are unchanged, so the reconstructed IndexFlat is byte-identical and recall/scores do not change.
+    // vectorDataSlice is null when the flat reader does not expose its slice, in which case reconstruction proceeds
+    // with the original (RANDOM) read path - correct, just not accelerated.
+    private boolean sequentialReadsInitAttempted;
+    private IndexInput vectorDataSlice;
 
     public IndexInputWithBuffer(@NonNull IndexInput indexInput) {
         this.indexInput = indexInput;
@@ -43,6 +85,112 @@ public class IndexInputWithBuffer {
 
     private long remainingBytes() {
         return contentLength - indexInput.getFilePointer();
+    }
+
+    /**
+     * Invoked from native engines via JNI to stream full-precision FP32 vectors when reconstructing the native flat
+     * storage for a graph-only .faiss (FP32 flat-vector dedup). Advances {@link #knnVectorValues} and stages up to
+     * {@code maxVectors} consecutive vectors (row-major, {@code dimension} floats each) into the reused
+     * {@link #vectorBuffer}, which native reads under a JNI critical section. Vectors are yielded in doc-id iteration
+     * order, which matches the FAISS ordinal order they were added in at write time.
+     *
+     * @param maxVectors maximum number of vectors to stage in this batch.
+     * @return the number of vectors staged (0 once the iterator is exhausted).
+     * @throws IOException on read failure.
+     */
+    private int copyVectors(int maxVectors) throws IOException {
+        if (vectorsExhausted) {
+            return 0;
+        }
+        // Materialize the vector values lazily on first use, so normal (non-graph-only) loads never pay for it.
+        if (knnVectorValues == null) {
+            if (knnVectorValuesSupplier == null) {
+                vectorsExhausted = true;
+                return 0;
+            }
+            knnVectorValues = knnVectorValuesSupplier.get();
+        }
+        // Only full-precision float vectors are reconstructed this way; native never calls this otherwise.
+        if ((knnVectorValues instanceof KNNFloatVectorValues) == false) {
+            vectorsExhausted = true;
+            return 0;
+        }
+        final KNNFloatVectorValues floatVectorValues = (KNNFloatVectorValues) knnVectorValues;
+        // One-time: switch the underlying .vec slice to sequential read advice for this forward scan.
+        if (sequentialReadsInitAttempted == false) {
+            sequentialReadsInitAttempted = true;
+            maybeEnableSequentialReads(floatVectorValues);
+        }
+        int copied = 0;
+        while (copied < maxVectors) {
+            if (knnVectorValues.nextDoc() == DocIdSetIterator.NO_MORE_DOCS) {
+                vectorsExhausted = true;
+                // Scan finished: restore random read advice so subsequent random-access reads are not penalized.
+                restoreDefaultReadAdvice();
+                break;
+            }
+            // getVector() returns a shared reference; copy it into the staging buffer.
+            final float[] vector = floatVectorValues.getVector();
+            final int dimension = vector.length;
+            final int requiredCapacity = maxVectors * dimension;
+            if (vectorBuffer == null || vectorBuffer.length < requiredCapacity) {
+                vectorBuffer = new float[requiredCapacity];
+            }
+            System.arraycopy(vector, 0, vectorBuffer, copied * dimension, dimension);
+            copied++;
+        }
+        return copied;
+    }
+
+    /**
+     * Best-effort switch of the Lucene flat-vector {@link IndexInput} (the {@code .vec} slice) backing the field's
+     * float vectors to {@link DataAccessHint#SEQUENTIAL}, so the kernel reads ahead aggressively during the forward
+     * reconstruction scan instead of faulting page by page. Only the standard flat
+     * format, whose values implement {@link HasIndexSlice}, is accelerated; any other shape leaves
+     * {@link #vectorDataSlice} null and reconstruction proceeds on the original read path. Never throws: this is an
+     * optimization, not a correctness requirement.
+     */
+    private void maybeEnableSequentialReads(final KNNFloatVectorValues floatVectorValues) {
+        try {
+            final KNNVectorValuesIterator iterator = floatVectorValues.getVectorValuesIterator();
+            if ((iterator instanceof KNNVectorValuesIterator.DocIdsIteratorValues) == false) {
+                log.debug("Flat-vector dedup: iterator is not DocIdsIteratorValues; skipping sequential read advice");
+                return;
+            }
+            final KnnVectorValues luceneVectorValues = ((KNNVectorValuesIterator.DocIdsIteratorValues) iterator).getKnnVectorValues();
+            if ((luceneVectorValues instanceof HasIndexSlice) == false) {
+                log.debug("Flat-vector dedup: values do not expose an index slice; skipping sequential read advice");
+                return;
+            }
+            final IndexInput slice = ((HasIndexSlice) luceneVectorValues).getSlice();
+            if (slice == null) {
+                return;
+            }
+            slice.updateIOContext(IOContext.DEFAULT.withHints(DataAccessHint.SEQUENTIAL));
+            vectorDataSlice = slice;
+            log.debug("Flat-vector dedup: enabled SEQUENTIAL read advice on .vec slice (length={})", slice.length());
+        } catch (final Throwable t) {
+            // Any failure here just disables the optimization; reconstruction proceeds with the default read path.
+            vectorDataSlice = null;
+            log.debug("Flat-vector dedup: could not enable sequential read advice; using default read path", t);
+        }
+    }
+
+    /**
+     * Restores {@link DataAccessHint#RANDOM} on the flat-vector slice after the reconstruction scan, so later
+     * random-access reads of the same file are not penalized by the sequential hint. Best-effort and idempotent.
+     */
+    private void restoreDefaultReadAdvice() {
+        if (vectorDataSlice == null) {
+            return;
+        }
+        try {
+            vectorDataSlice.updateIOContext(IOContext.DEFAULT.withHints(DataAccessHint.RANDOM));
+        } catch (final Throwable ignored) {
+            // Best-effort restore; nothing actionable if it fails.
+        } finally {
+            vectorDataSlice = null;
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -121,8 +121,11 @@ class FaissService {
      *
      * @param indexAddress address of native memory where index is stored
      * @param output       Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
+     * @param skipFlat     Control flag that skips flushing the flat vector storage into the .faiss file. When true, a
+     *                     graph-only index is written (the "null" storage marker) and vectors are served from Lucene's
+     *                     .vec file at search time.
      */
-    public static native void writeIndex(long indexAddress, IndexOutputWithBuffer output);
+    public static native void writeIndex(long indexAddress, IndexOutputWithBuffer output, boolean skipFlat);
 
     /**
      * Writes a faiss index.

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -113,7 +113,7 @@ public class JNIService {
             } else if (IndexUtil.isByteIndex(parameters)) {
                 FaissService.writeByteIndex(indexAddress, output);
             } else {
-                FaissService.writeIndex(indexAddress, output);
+                FaissService.writeIndex(indexAddress, output, skipFlat);
             }
             return;
         }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFP32FlatIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFP32FlatIndex.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import java.util.Locale;
+
+import lombok.Getter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * A virtual {@link FaissIndex} that serves full-precision FP32 vectors from Lucene's {@link FlatVectorsReader} instead
+ * of from the .faiss file. When flat-vector deduplication is enabled ({@code index.knn.advanced.flat_vector_dedup}), a
+ * FAISS FP32 HNSW graph is written without its embedded flat storage (IO_FLAG_SKIP_STORAGE), and the full-precision
+ * vectors live only in Lucene's .vec file. This class installs itself as the flat storage under {@link FaissHNSWIndex},
+ * delegating vector access to the Lucene reader.
+ *
+ * <p>Mirrors {@link FaissScalarQuantizedFlatIndex}, but extends {@link FaissIndex} directly (float storage is set via
+ * {@link AbstractFaissHNSWIndex#setFlatVectors}, which accepts any {@link FaissIndex}) and serves non-quantized floats.
+ */
+public class FaissFP32FlatIndex extends FaissIndex {
+    static final String FAISS_FP32_FLAT_INDEX = "FaissFP32FlatIndex";
+
+    @Getter
+    private final FlatVectorsReader flatVectorsReader;
+    @Getter
+    private final String fieldName;
+
+    public FaissFP32FlatIndex(final FlatVectorsReader flatVectorsReader, final String fieldName) {
+        super(FAISS_FP32_FLAT_INDEX);
+        this.flatVectorsReader = flatVectorsReader;
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    protected void doLoad(IndexInput input) throws IOException {
+        // No-op: full-precision vectors are managed by Lucene's FlatVectorsReader, not loaded from the .faiss file.
+    }
+
+    @Override
+    public VectorEncoding getVectorEncoding() {
+        return VectorEncoding.FLOAT32;
+    }
+
+    @Override
+    public FloatVectorValues getFloatValues(IndexInput indexInput) throws IOException {
+        return flatVectorsReader.getFloatVectorValues(fieldName);
+    }
+
+    @Override
+    public ByteVectorValues getByteValues(IndexInput indexInput) throws IOException {
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "%s does not support byte vector values.", FAISS_FP32_FLAT_INDEX)
+        );
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -12,6 +12,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
@@ -38,6 +39,12 @@ public class FaissFlatIndexFactory {
         if (FieldInfoExtractor.isSQField(fieldInfo)
             && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue()) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
+        }
+        // FP32 flat-vector dedup: a full-precision (non-quantized) float field whose embedded flat storage was skipped
+        // in the .faiss (index.knn.advanced.flat_vector_dedup). Serve the vectors from Lucene's .vec file.
+        if (FieldInfoExtractor.isSQField(fieldInfo) == false
+            && FieldInfoExtractor.extractVectorDataType(fieldInfo) == VectorDataType.FLOAT) {
+            return new FaissFP32FlatIndex(flatVectorsReader, fieldInfo.getName());
         }
         return null;
     }
@@ -94,6 +101,27 @@ public class FaissFlatIndexFactory {
                     "Unsupported metric type: " + metricType + ", only support " + Arrays.asList(FaissMetricType.values())
                 );
             }
+            return;
+        }
+
+        // Float HNSW path (local JNI build with IO_FLAG_SKIP_STORAGE for FP32 flat-vector dedup). A plain float HNSW
+        // (IHNf) whose flat storage was skipped loads a FaissEmptyIndex placeholder; replace it with a Lucene-backed
+        // FP32 flat index. NOTE: this method also handles binary/CAGRA; the "Binary" in its name is historical.
+        if (nested instanceof FaissHNSWIndex hnswIndex && FaissEmptyIndex.isEmptyIndex(hnswIndex.getFlatVectors())) {
+            final FaissIndex flatIndex = createFlatIndex(fieldInfo, flatVectorsReader);
+            if (flatIndex == null) {
+                throw new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "%s found for field [%s] but %s returned null - cannot wire flat storage for float HNSW index.",
+                        FaissEmptyIndex.class.getName(),
+                        fieldInfo.getName(),
+                        FaissFlatIndexFactory.class.getName()
+                    )
+                );
+            }
+            hnswIndex.setFlatVectors(flatIndex);
+            // No space type override needed - float HNSW reads the correct metric type from readCommonHeader() in doLoad().
             return;
         }
 

--- a/src/test/java/org/opensearch/knn/index/FaissHNSWFlatE2EIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissHNSWFlatE2EIT.java
@@ -14,6 +14,7 @@ package org.opensearch.knn.index;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
+import org.opensearch.common.settings.Settings;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -190,5 +191,102 @@ public class FaissHNSWFlatE2EIT extends KNNRestTestCase {
         }
 
         fail("Graphs are not getting evicted");
+    }
+
+    // Exercises FP32 flat-vector dedup on the DEFAULT (non-MOS) search path: a graph-only .faiss (no embedded flat
+    // storage) is written, then bulk-loaded into native memory where the flat storage is reconstructed by streaming
+    // full-precision vectors from Lucene's .vec file. Scores must remain exact (identical to a full build), which
+    // verifies the reconstructed storage and its ordinal ordering against the graph.
+    @SneakyThrows
+    public void testEndToEnd_whenFlatVectorDedup_thenSucceed() {
+        String indexName = "test-index-flat-vector-dedup";
+        String fieldName = "test-field-1";
+        SpaceType spaceType = SpaceType.L2;
+        Integer dimension = testData.indexData.vectors[0].length;
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, 16)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, 128)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        String mapping = builder.toString();
+
+        // Enable flat-vector dedup (graph-only .faiss). Memory-optimized search is left disabled, so search bulk-loads
+        // the index into native memory and reconstructs the flat storage from .vec - the non-MOS path under test.
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
+            .build();
+        createKnnIndex(indexName, settings, mapping);
+
+        for (int i = 0; i < testData.indexData.docs.length; i++) {
+            addKnnDoc(
+                indexName,
+                Integer.toString(testData.indexData.docs[i]),
+                fieldName,
+                Floats.asList(testData.indexData.vectors[i]).toArray()
+            );
+        }
+        refreshAllNonSystemIndices();
+        assertEquals(testData.indexData.docs.length, getDocCount(indexName));
+
+        if (deleteRandomDocs) {
+            final Set<Integer> docIdsToBeDeleted = new HashSet<>();
+            while (docIdsToBeDeleted.size() < 10) {
+                docIdsToBeDeleted.add(randomInt(testData.indexData.docs.length - 1));
+            }
+            for (Integer id : docIdsToBeDeleted) {
+                deleteKnnDoc(indexName, Integer.toString(testData.indexData.docs[id]));
+            }
+            refreshAllNonSystemIndices();
+            // Force-merge to consolidate and purge deletes, producing a merged graph-only .faiss whose native
+            // reconstruction from .vec is exercised on search. Mirrors the non-deduped end-to-end test.
+            forceMergeKnnIndex(indexName, 3);
+            assertEquals(testData.indexData.docs.length - 10, getDocCount(indexName));
+        }
+
+        // Even without a force-merge, flushed segments are written graph-only (dedup) and are bulk-loaded into native
+        // memory on search, exercising the reconstruction path.
+        for (int i = 0; i < testData.queries.length; i++) {
+            final KNNQueryBuilder queryBuilder = KNNQueryBuilder.builder()
+                .fieldName(fieldName)
+                .vector(testData.queries[i])
+                .k(k)
+                .methodParameters(methodParameters)
+                .build();
+            Response response = searchKNNIndex(indexName, queryBuilder, k);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
+
+            // Exact-score check first: catches any ordinal misalignment in the reconstructed storage. Each returned
+            // result's search score must equal the exact L2 score of its own (source) vector.
+            List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
+            for (int j = 0; j < knnResults.size(); j++) {
+                float[] primitiveArray = knnResults.get(j).getVector();
+                assertEquals(
+                    KNNEngine.FAISS.score(KNNScoringUtil.l2Squared(testData.queries[i], primitiveArray), spaceType),
+                    actualScores.get(j),
+                    0.0001
+                );
+            }
+            assertEquals(k, knnResults.size());
+        }
+
+        deleteKNNIndex(indexName);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -14,8 +14,6 @@ import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.network.NetworkModule;
-import org.opensearch.common.settings.IndexScopedSettings;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.env.Environment;
@@ -36,10 +34,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.opensearch.test.NodeRoles.dataNode;
@@ -317,29 +313,5 @@ public class KNNSettingsTests extends KNNTestCase {
         int availableProcessors = Runtime.getRuntime().availableProcessors();
         int expected = (availableProcessors >= 32) ? 4 : 1;
         assertEquals(expected, threadQtyWithEmpty);
-    }
-
-    public void testFlatVectorDedupRequiresMemoryOptimizedSearch() {
-        final Set<Setting<?>> registeredSettings = new HashSet<>(IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
-        registeredSettings.add(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING);
-        registeredSettings.add(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
-        final IndexScopedSettings indexScopedSettings = new IndexScopedSettings(Settings.EMPTY, registeredSettings);
-
-        // flat_vector_dedup enabled without memory_optimized_search is rejected.
-        final Settings dedupWithoutMos = Settings.builder()
-            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
-            .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, false)
-            .build();
-        expectThrows(IllegalArgumentException.class, () -> indexScopedSettings.validate(dedupWithoutMos, true));
-
-        // flat_vector_dedup enabled together with memory_optimized_search is allowed.
-        final Settings dedupWithMos = Settings.builder()
-            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
-            .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
-            .build();
-        indexScopedSettings.validate(dedupWithMos, true);
-
-        // flat_vector_dedup disabled is always allowed, regardless of memory_optimized_search.
-        indexScopedSettings.validate(Settings.EMPTY, true);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -14,6 +14,8 @@ import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.env.Environment;
@@ -34,8 +36,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.opensearch.test.NodeRoles.dataNode;
@@ -313,5 +317,29 @@ public class KNNSettingsTests extends KNNTestCase {
         int availableProcessors = Runtime.getRuntime().availableProcessors();
         int expected = (availableProcessors >= 32) ? 4 : 1;
         assertEquals(expected, threadQtyWithEmpty);
+    }
+
+    public void testFlatVectorDedupRequiresMemoryOptimizedSearch() {
+        final Set<Setting<?>> registeredSettings = new HashSet<>(IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
+        registeredSettings.add(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP_SETTING);
+        registeredSettings.add(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE_SETTING);
+        final IndexScopedSettings indexScopedSettings = new IndexScopedSettings(Settings.EMPTY, registeredSettings);
+
+        // flat_vector_dedup enabled without memory_optimized_search is rejected.
+        final Settings dedupWithoutMos = Settings.builder()
+            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
+            .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, false)
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> indexScopedSettings.validate(dedupWithoutMos, true));
+
+        // flat_vector_dedup enabled together with memory_optimized_search is allowed.
+        final Settings dedupWithMos = Settings.builder()
+            .put(KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP, true)
+            .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
+            .build();
+        indexScopedSettings.validate(dedupWithMos, true);
+
+        // flat_vector_dedup disabled is always allowed, regardless of memory_optimized_search.
+        indexScopedSettings.validate(Settings.EMPTY, true);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -184,7 +184,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -285,7 +285,8 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                         segmentWriteState,
                         quantizationState,
                         nativeIndexBuildStrategyFactory,
-                        null
+                        null,
+                        false
                     )
                 ).thenReturn(nativeIndexWriter);
             });
@@ -383,7 +384,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -458,7 +459,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -533,7 +534,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -617,7 +618,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
-                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                    () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
                 ).thenReturn(nativeIndexWriter);
             });
 
@@ -716,7 +717,8 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                         segmentWriteState,
                         quantizationState,
                         nativeIndexBuildStrategyFactory,
-                        null
+                        null,
+                        false
                     )
                 ).thenReturn(nativeIndexWriter);
             });
@@ -826,7 +828,8 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                         segmentWriteState,
                         quantizationState,
                         nativeIndexBuildStrategyFactory,
-                        null
+                        null,
+                        false
                     )
                 ).thenReturn(nativeIndexWriter);
             });

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -166,7 +166,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
 
             when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
@@ -237,7 +237,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
 
             when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
@@ -299,7 +299,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
 
             when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory, null, false)
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
@@ -371,7 +371,14 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
             }
 
             nativeIndexWriterMockedStatic.when(
-                () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState, nativeIndexBuildStrategyFactory, null)
+                () -> NativeIndexWriter.getWriter(
+                    fieldInfo,
+                    segmentWriteState,
+                    quantizationState,
+                    nativeIndexBuildStrategyFactory,
+                    null,
+                    false
+                )
             ).thenReturn(nativeIndexWriter);
             doAnswer(answer -> {
                 Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
@@ -22,6 +22,7 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
@@ -65,6 +66,23 @@ public class MOSFaissFloatIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     public void testWhenNoIndexBuilt() {
         doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
         doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
+    }
+
+    // Enables FP32 flat-vector dedup (graph-only .faiss). With memory-optimized search, the vectors must be served from
+    // Lucene's .vec file and produce results identical to a normal (non-deduped) build.
+    private static final Consumer<Settings.Builder> FLAT_VECTOR_DEDUP_ENABLED = settingsBuilder -> settingsBuilder.put(
+        KNNSettings.INDEX_KNN_ADVANCED_FLAT_VECTOR_DEDUP,
+        true
+    );
+
+    public void testNonNestedFloatIndexWithFlatVectorDedup() {
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, FLAT_VECTOR_DEDUP_ENABLED);
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.INNER_PRODUCT, FLAT_VECTOR_DEDUP_ENABLED);
+    }
+
+    // Nested indexing exercises the sparse ordinal->docId path (FaissIdMapIndex) on top of the FP32 flat index.
+    public void testNestedFloatIndexWithFlatVectorDedup() {
+        doTestNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, SpaceType.L2, FLAT_VECTOR_DEDUP_ENABLED);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
@@ -193,7 +193,7 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testMaybeSetFlatIndex_whenCagraWithEmptyFlatVectorsAndNonSQField_thenThrows() {
+    public void testMaybeSetFlatIndex_whenCagraWithEmptyFlatVectorsAndFP32Field_thenSetsFP32FlatIndex() {
         FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
 
         FaissHNSWCagraIndex cagraIndex = new FaissHNSWCagraIndex(FaissHNSWCagraIndex.IHNC);
@@ -202,13 +202,64 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
         FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
         when(idMapIndex.getNestedIndex()).thenReturn(cagraIndex);
 
+        // Default field is full-precision FP32 (non-SQ). With flat-vector dedup, a graph-only float CAGRA index is now
+        // served from Lucene's .vec via FaissFP32FlatIndex instead of throwing (previously unsupported).
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
 
-        try {
-            FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
-            fail("Expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("CAGRA"));
-        }
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertNotNull(cagraIndex.getFlatVectors());
+        assertFalse(FaissEmptyIndex.isEmptyIndex(cagraIndex.getFlatVectors()));
+        assertTrue(cagraIndex.getFlatVectors() instanceof FaissFP32FlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenFP32Field_thenReturnsFaissFP32FlatIndex() {
+        // A default (non-SQ, full-precision) float field maps to the FP32 flat index.
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissIndex result = FaissFlatIndexFactory.createFlatIndex(fieldInfo, mockReader);
+
+        assertTrue(result instanceof FaissFP32FlatIndex);
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenFloatHnswWithEmptyFlatVectors_thenSetsFP32FlatIndex() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        // Plain float HNSW (IHNf) whose flat storage was skipped (IO_FLAG_SKIP_STORAGE) loads a FaissEmptyIndex.
+        FaissHNSWIndex hnswIndex = new FaissHNSWIndex(FaissHNSWIndex.IHNF);
+        hnswIndex.setFlatVectors(FaissEmptyIndex.INSTANCE);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(hnswIndex);
+
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertNotNull(hnswIndex.getFlatVectors());
+        assertFalse(FaissEmptyIndex.isEmptyIndex(hnswIndex.getFlatVectors()));
+        assertTrue(hnswIndex.getFlatVectors() instanceof FaissFP32FlatIndex);
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenFloatHnswWithExistingFlatVectors_thenNoOp() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        // A normal (non-deduped) float HNSW already has real flat storage; it must not be overwritten.
+        FaissHNSWIndex hnswIndex = new FaissHNSWIndex(FaissHNSWIndex.IHNF);
+        FaissIndex existingFlat = mock(FaissIndex.class);
+        hnswIndex.setFlatVectors(existingFlat);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(hnswIndex);
+
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertSame(existingFlat, hnswIndex.getFlatVectors());
     }
 }


### PR DESCRIPTION
 > [!IMPORTANT]
> **Part 2 of 2. Draft - do not merge to `main`.** Stacks on Part 1 (#3527, memory-optimized search). Opened against `main` temporarily; it will be retargeted to a `flat-vector-dedup` feature branch, and the feature merges to `main` only when both parts are in.
> Because there is no feature branch yet, this diff currently **includes the MOS changes from #3527** - review the single non-MOS commit (`Add non-MOS support for FP32 flat-vector dedup`); the diff cleans up to the non-MOS delta once retargeted onto the feature branch.

Relates to #3526 (sub-task of #2823).

## What this PR does

Completes FP32 flat-vector deduplication by adding the **default (non memory-optimized) search path**. #3527 enabled dedup only for memory-optimized search (which reads vectors straight from Lucene's `.vec`). This PR makes a graph-only `.faiss` usable on the default path too, so `index.knn.advanced.flat_vector_dedup` no longer requires memory-optimized search.

- **Reconstruct native flat storage from `.vec` at load.** A graph-only `.faiss` (written with `IO_FLAG_SKIP_STORAGE`) has no embedded vectors, so at load we stream the field's full-precision vectors from `.vec` and rebuild the native `IndexFlat` in RAM. Vectors are consumed in FAISS-ordinal order, which matches their `.vec` layout. The reconstructed index is **byte-identical** to a normal build - recall and scores are unchanged.
- **Sequential read advice (the key perf fix).** The flat reader opens `.vec` with `DataAccessHint.RANDOM`, which disables OS readahead - so cold reconstruction faulted the file in 4 KB pages, one at a time (~754k faults, ~435 s). For the one-shot forward reconstruction scan we flip the slice to `DataAccessHint.SEQUENTIAL` via `IndexInput.updateIOContext(...)` (kernel then reads ahead in large chunks), and restore `RANDOM` when the scan finishes so query-time random access is not penalized. Mirrors Lucene's own full-file scan.
- **Native-memory accounting.** A graph-only `.faiss` is small on disk, but the loaded index holds the reconstructed vectors in native RAM. The native-memory cache entry size now adds the segment `.vec` size when dedup is enabled, so the circuit breaker sizes and evicts correctly. *(Conservative: counts the segment `.vec`, exact for the common single-vector-field case; see "Open question" below.)*
- **Relaxes the MOS-only guard** #3527 added (validator + write-gate), since reconstruction makes the default path safe.

## Benchmark (Linux, gp3, 1M × 768-d, FAISS HNSW m=16/ef 100, inner-product; cold = restart + drop page cache)

Cold-start load, dedup ON, non-MOS:

| Build | Cold load | Major faults |
|---|---|---|
| Original reconstruction (RANDOM) | ~435 s | ~754k |
| **This PR (SEQUENTIAL)** | **~23.8 s** | **~67** |
| no-dedup baseline | ~23.8 s | ~68 |

Query latency (OSB search-only, single client, k=100), P50 / P90 / P99 ms - unchanged (advisory hint is load-only, RANDOM restored):

| Config | P50 | P90 | P99 |
|---|---|---|---|
| no-dedup baseline | 15.6 | 18.0 | 21.4 |
| dedup | 13.9 | 16.0 | 20.6 |

Disk: 6.98 GB → 3.26 GB. Recall unchanged (identical vectors).

## Caveat (memory pressure)

Under heavy memory pressure the non-MOS load can be slower than baseline: reconstruction transiently holds both the mmap'd `.vec` pages and the native `IndexFlat` being built, and if the kernel trashes readahead pages the cold start rises. Steady-state search is unaffected (it uses the native index, not `.vec`).

## Open question for reviewers

Cache accounting uses the segment `.vec` size (cheap, safe - never under-counts). Exact per-field sizing (count × dim × 4) would avoid over-counting when a segment has multiple vector fields, but needs the vector reader in the sizing path (`calculateSizeInKB` runs pre-load for capacity checks). Preference?

## Testing
- Non-MOS parity IT (`FaissHNSWFlatE2EIT`, dedup ON): identical docIds/scores vs a normal build, dense + delete-docs, ± ef_search.
- MOS parity IT unchanged and passing.
- Full unit suite + JNI rebuild green; cold-start numbers above.
