### PR TITLE
Add configurable nproc count to build script (#3539)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -139,22 +139,22 @@ echo "Building faiss / simd lib without hardware acceleration"
 if [ "$PLATFORM" != "windows" ] && [ "$ARCHITECTURE" = "x64" ]; then
   echo "Building k-NN library nmslib on non-windows x64"
   rm -rf jni/build/CMakeCache.txt jni/build/CMakeFiles
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
   echo "Building k-NN library faiss lib after enabling AVX2"
   # Skip applying patches as patches were applied already from previous :buildJniLib task
   # If we apply patches again, it fails with conflict
   rm -rf jni/build/CMakeCache.txt jni/build/CMakeFiles
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx2.enabled=true -Davx512.enabled=false -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx2.enabled=true -Davx512.enabled=false -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
   echo "Building k-NN library faiss lib after enabling AVX512"
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512.enabled=true -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512.enabled=true -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
   echo "Building k-NN library faiss lib after enabling AVX512_SPR"
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512_spr.enabled=true -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512_spr.enabled=true -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 else
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 fi
 
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER


### PR DESCRIPTION
### Description
`scripts/build.sh` accepts `-j NPROC_COUNT` to parallelize the JNI library build, but only forwarded it to the first `:buildJniLib` invocation (the non-accelerated faiss/simd build). The 5 remaining `buildJniLib` calls (nmslib, and the AVX2 / AVX512 / AVX512_SPR faiss+simd variants) silently fell back to `-Dnproc.count=1` in `build.gradle`, so `cmake --build --parallel 1` ran serially. This adds `-Dnproc.count=${NPROC_COUNT:-1}` to every `buildJniLib` invocation in the script.

### Related Issues
Resolves #3539 

### Check List
- [×] New functionality includes testing. — N/A, build script change, covered by existing Linux/MacOS/Windows CI
- [×] New functionality has been documented. — N/A
- [×] API changes companion pull request created. — N/A
- [✓] Commits are signed per the DCO using `--signoff`.
- [×] Public documentation issue/PR created. — N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
