### PR TITLE
Add multi-bit SQ (bits ∈ {2, 4}) for Faiss, and make method=flat engine-agnostic with x16 / x8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
-* Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4} [#3432](https://github.com/opensearch-project/k-NN/pull/3432)
 * Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4} [#3459](https://github.com/opensearch-project/k-NN/pull/3459)
+* Set default oversample factor to 1 for SQ 2-bit and 4-bit encoders (x16 / x8 compression) [#3463](https://github.com/opensearch-project/k-NN/pull/3463)
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
 * Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4} [#3459](https://github.com/opensearch-project/k-NN/pull/3459)
 * Set default oversample factor to 1 for SQ 2-bit and 4-bit encoders (x16 / x8 compression) [#3463](https://github.com/opensearch-project/k-NN/pull/3463)
+* Support flat with x8 and x16 compression and make `method=flat` engine-agnostic [#3471](https://github.com/opensearch-project/k-NN/pull/3471)
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)
 * Refactor engine field mapper, deprecate mode parameter, add encoder validation [#3436](https://github.com/opensearch-project/k-NN/pull/3436)
 * Centralize rescore and MOS logic in ResolvedIndexSpec [#3466](https://github.com/opensearch-project/k-NN/pull/3466)
+* Add ScalarEncodingResolver and parameterize Faiss SQ format by encoding to unblock multi-bit SQ support [#3428](https://github.com/opensearch-project/k-NN/pull/3428)
 
 ### Enhancements
 * Support `index.knn.advanced.approximate_threshold` for the Lucene engine [#3451](https://github.com/opensearch-project/k-NN/pull/3451)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.9](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
+* Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
+* Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4} [#3432](https://github.com/opensearch-project/k-NN/pull/3432)
+* Enable remote vector index build for multi-bit SQ - bits ∈ {2, 4} [#3459](https://github.com/opensearch-project/k-NN/pull/3459)
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
+* Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
 
 ### Maintenance
 * Fixed multiple forbidden api warnings from the code []()

--- a/jni/include/faiss_index_service.h
+++ b/jni/include/faiss_index_service.h
@@ -106,7 +106,7 @@ public:
 
     jlong initFaissSQIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, faiss::MetricType metric,
                             std::string indexDescription, int dim, int numVectors, int threadCount,
-                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes);
+                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes, int docBits);
 
     /**
      * Add vectors to index

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -28,7 +28,8 @@ namespace knn_jni {
                                 jobject parametersJ,
                                 BinaryIndexService *indexService,
                                 jfloat centroidDp,
-                                jint quantizedVecBytes);
+                                jint quantizedVecBytes,
+                                jint docBits);
 
         void InsertToIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jintArray idsJ, jlong vectorsAddressJ, jint dimJ, jlong indexAddr, jint threadCount, IndexService *indexService);
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -286,10 +286,10 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterrup
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    initFaissSQIndex
- * Signature: (IILjava/util/Map;FI)J
+ * Signature: (IILjava/util/Map;FII)J
  */
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initFaissSQIndex
-  (JNIEnv *, jclass, jint, jint, jobject, jfloat, jint);
+  (JNIEnv *, jclass, jint, jint, jobject, jfloat, jint, jint);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService

--- a/jni/include/sq/faiss_sq_flat.h
+++ b/jni/include/sq/faiss_sq_flat.h
@@ -41,10 +41,54 @@ namespace knn_jni {
         quantizedComponentSum = static_cast<float>(componentSum);
     }
 
+    // Only bit widths supported by the memory-optimized-search (MOS) path.
+    // Kept in sync with FaissSQEncoder.isMosBits on the Java side and with
+    // ScalarEncodingResolver.SUPPORTED_DOC_BITS.
+    static inline bool isMosDocBits(int32_t bits) {
+        return bits == 1 || bits == 2 || bits == 4;
+    }
+
+    // Validates a docBits value and returns it unchanged when supported. Called from
+    // FaissSQDistanceComputer's initializer list so the throw beats the `qvb / docBits`
+    // computation in `planeBytes`, which would otherwise trigger a SIGFPE for docBits == 0.
+    static inline int32_t validateDocBits(int32_t bits) {
+        if (!isMosDocBits(bits)) {
+            throw std::runtime_error(
+                "FaissSQDistanceComputer: unsupported docBits=" + std::to_string(bits)
+                + ". Supported: 1, 2, 4."
+            );
+        }
+        return bits;
+    }
+
+    // Validates that quantizedVectorBytes is compatible with the given docBits and returns it
+    // unchanged. For docBits == 2 the bit-plane kernel requires equal-length planes (qvb must
+    // be even). For docBits ∈ {1, 4} any positive qvb is valid — B=1 is a single plane, and
+    // B=4 uses PACKED_NIBBLE where each byte independently carries two elements.
+    static inline uint64_t validateQvbForDocBits(uint64_t qvb, int32_t bits) {
+        if (bits == 2 && qvb % 2 != 0) {
+            throw std::runtime_error(
+                "FaissSQDistanceComputer: quantizedVectorBytes=" + std::to_string(qvb)
+                + " must be even for docBits=2 (two bit planes of equal length)"
+            );
+        }
+        return qvb;
+    }
+
     template <bool IsMaxIP, bool IsBytesMultipleOf8>
     struct FaissSQDistanceComputer final : faiss::DistanceComputer {
         const int64_t oneElementByteSize;
         const uint64_t quantizedVectorBytes;
+        // Number of bits used to quantize each document dimension (1, 2, or 4).
+        const int32_t docBits;
+        // Byte length of a single bit plane. Only meaningful for the bit-plane popcount path
+        // (B=1, B=2): the quantized code is docBits contiguous planes, each planeBytes long,
+        // so quantizedVectorBytes == docBits * planeBytes. Unused for B=4 (PACKED_NIBBLE),
+        // where `bothPackedNibbleDp` iterates over quantizedVectorBytes directly.
+        const uint64_t planeBytes;
+        // Reconstruction scale for the quantization interval: 1 / (2^docBits - 1). For docBits == 1
+        // this is 1, preserving the legacy single-bit behavior.
+        const float dataScale;
         const uint8_t* data;
         const uint8_t* query;
         const float centroidDp;
@@ -55,11 +99,22 @@ namespace knn_jni {
         int32_t dimension;
         int32_t numVectors;
 
-        FaissSQDistanceComputer(int32_t _oneElementByteSize, const void* _data, float _centroidDp, int32_t _dimension, int32_t _numVectors)
+        FaissSQDistanceComputer(int32_t _oneElementByteSize, const void* _data, float _centroidDp, int32_t _dimension, int32_t _numVectors, int32_t _docBits)
           : faiss::DistanceComputer(),
             oneElementByteSize(_oneElementByteSize),
             // Memory layout : [Quantized Vector | lowerInterval (float) | upperInterval (float) | additionalCorrection (float) | quantizedComponentSum (int)]
-            quantizedVectorBytes(_oneElementByteSize - (sizeof(float) * 3 + sizeof(int32_t))),
+            quantizedVectorBytes(
+                validateQvbForDocBits(
+                    _oneElementByteSize - (sizeof(float) * 3 + sizeof(int32_t)),
+                    validateDocBits(_docBits))),
+            // validateDocBits above already rejected _docBits ∉ {1,2,4}, so:
+            //   - docBits / 0 division in `planeBytes` is unreachable
+            //   - `1 << _docBits` signed-shift UB (would need _docBits > 30) is unreachable
+            //   - silent wrong reconstruction for _docBits ∈ {3,5,6,7,...} is unreachable
+            // Fields below are computed only when validation has passed.
+            docBits(_docBits),
+            planeBytes(quantizedVectorBytes / _docBits),
+            dataScale(1.0f / static_cast<float>((1 << _docBits) - 1)),
             data((const uint8_t*) _data),
             query(),
             centroidDp(_centroidDp),
@@ -69,6 +124,74 @@ namespace knn_jni {
             y1(),
             dimension(_dimension),
             numVectors(_numVectors) {
+        }
+
+        // Popcount of (a AND b) over `planeBytes` bytes. Uses std::memcpy for 8-byte word loads so
+        // it is safe regardless of plane alignment (planeBytes need not be a multiple of 8 for B>1),
+        // with a byte remainder loop for the trailing bytes.
+        static inline uint64_t popcountAndPlane(const uint8_t* a, const uint8_t* b, const uint64_t planeBytes) {
+            const uint64_t words = planeBytes >> 3;
+            uint64_t pc = 0;
+            for (uint64_t w = 0; w < words; ++w) {
+                uint64_t wa, wb;
+                std::memcpy(&wa, a + w * 8, sizeof(uint64_t));
+                std::memcpy(&wb, b + w * 8, sizeof(uint64_t));
+                pc += __builtin_popcountll(wa & wb);
+            }
+            for (uint64_t r = words * 8; r < planeBytes; ++r) {
+                pc += __builtin_popcount((a[r] & b[r]) & 0xFF);
+            }
+            return pc;
+        }
+
+        // Byte-wise dot product over Lucene's PACKED_NIBBLE doc layout.
+        // packed[i] high nibble = element i, low nibble = element (packedBytes + i).
+        // Mirrors Lucene's VectorUtil.int4DotProductBothPacked. For each byte we extract two
+        // 4-bit values per side and accumulate two products. The compiler's auto-vectorizer
+        // turns this into wide 16-bit multiplies on x86 (PMULLW) and ARM (NEON MUL).
+        //
+        // WHY NOT a bit-plane popcount for B=4? PACKED_NIBBLE bytes are NOT bit planes — each
+        // byte carries two elements at four different bit-positions each. popcount-AND on that
+        // layout mixes place values (1, 2, 4, 8) into a uniform count and destroys the dot
+        // product.
+        static inline uint64_t bothPackedNibbleDp(const uint8_t* a, const uint8_t* b, const uint64_t packedBytes) {
+            uint64_t total = 0;
+            for (uint64_t i = 0; i < packedBytes; ++i) {
+                const uint32_t aLo = a[i] & 0x0Fu;
+                const uint32_t aHi = (a[i] >> 4) & 0x0Fu;
+                const uint32_t bLo = b[i] & 0x0Fu;
+                const uint32_t bHi = (b[i] >> 4) & 0x0Fu;
+                total += aLo * bLo + aHi * bHi;
+            }
+            return total;
+        }
+
+        // Multi-bit dot product between two quantized codes. The kernel shape depends on docBits:
+        //   B=1: single popcount(a AND b)                          — bit-plane (1 plane)
+        //   B=2: 2x2 popcount-AND-shift double sum across planes   — bit-plane (2 planes)
+        //   B=4: byte-wise nibble multiply-accumulate              — Lucene's PACKED_NIBBLE layout
+        //
+        // Performance trade-off: for B=4 the bit-plane formulation would need 16 popcount calls
+        // per distance (and a Java-side repack, since Lucene stores PACKED_NIBBLE not bit planes),
+        // while the byte-wise multiply matches Lucene's int4DotProductBothPacked and avoids both.
+        // The math is the same (Σ A_n B_n with A_n, B_n in [0, 2^B - 1]); only the byte layout differs.
+        uint64_t multiBitDp(const uint8_t* a, const uint8_t* b) const {
+            if (docBits == 1) {
+                return popcountAndPlane(a, b, planeBytes);
+            }
+            if (docBits == 4) {
+                return bothPackedNibbleDp(a, b, quantizedVectorBytes);
+            }
+            // docBits == 2: bit-plane popcount path.
+            uint64_t dp = 0;
+            for (int32_t i = 0; i < docBits; ++i) {
+                const uint8_t* pa = a + (uint64_t) i * planeBytes;
+                for (int32_t j = 0; j < docBits; ++j) {
+                    const uint8_t* pb = b + (uint64_t) j * planeBytes;
+                    dp += popcountAndPlane(pa, pb, planeBytes) << (i + j);
+                }
+            }
+            return dp;
         }
 
         void set_query(const float* x) final {
@@ -88,6 +211,9 @@ namespace knn_jni {
             } else {
                 readCorrectionFactorsSafe(ptr, lowerInterval, intervalLength, additionalCorrection, quantizedComponentSum);
             }
+            // Scale (upper - lower) by 1/(2^docBits - 1) so the reconstruction delta matches the
+            // quantization level range [0, 2^docBits - 1]. For docBits == 1 this is a no-op.
+            intervalLength *= dataScale;
         }
 
         float scoringSecondPart(const void* target, const float dp) {
@@ -120,30 +246,8 @@ namespace knn_jni {
         /// compute distance of vector i to current query
         float operator()(faiss::idx_t i) final {
             const uint8_t* target = data + i * oneElementByteSize;
-            const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-            uint32_t dp = 0;
-
-            if constexpr (IsBytesMultipleOf8) {
-                const auto* q = reinterpret_cast<const uint64_t*>(query);
-                const auto* t = reinterpret_cast<const uint64_t*>(target);
-                for (size_t j = 0; j < words; ++j) {
-                    dp += __builtin_popcountll(q[j] & t[j]);
-                }
-            } else {
-                for (size_t j = 0; j < words; ++j) {
-                    uint64_t queryWord, targetWord;
-                    std::memcpy(&queryWord, query + j * 8, sizeof(uint64_t));
-                    std::memcpy(&targetWord, target + j * 8, sizeof(uint64_t));
-                    dp += __builtin_popcountll(queryWord & targetWord);
-                }
-                // Remainder bytes that don't fill a full 8-byte word
-                const uint64_t remainStart = words * 8;
-                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
-                    dp += __builtin_popcount((query[r] & target[r]) & 0xFF);
-                }
-            }
-
-            return scoringSecondPart(target, dp);
+            const uint64_t dp = multiBitDp(query, target);
+            return scoringSecondPart(target, static_cast<float>(dp));
         }
 
         /// compute distances of current query to 4 stored vectors.
@@ -161,51 +265,10 @@ namespace knn_jni {
             const uint8_t* target3 = data + idx2 * oneElementByteSize;
             const uint8_t* target4 = data + idx3 * oneElementByteSize;
 
-            const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-
-            uint32_t dp1 = 0, dp2 = 0, dp3 = 0, dp4 = 0;
-
-            if constexpr (IsBytesMultipleOf8) {
-                const auto* q = reinterpret_cast<const uint64_t*>(query);
-                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
-                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
-                const auto* t3 = reinterpret_cast<const uint64_t*>(target3);
-                const auto* t4 = reinterpret_cast<const uint64_t*>(target4);
-                for (size_t i = 0; i < words; ++i) {
-                    dp1 += __builtin_popcountll(q[i] & t1[i]);
-                    dp2 += __builtin_popcountll(q[i] & t2[i]);
-                    dp3 += __builtin_popcountll(q[i] & t3[i]);
-                    dp4 += __builtin_popcountll(q[i] & t4[i]);
-                }
-            } else {
-                for (size_t i = 0; i < words; ++i) {
-                    uint64_t queryWord;
-                    std::memcpy(&queryWord, query + i * 8, sizeof(uint64_t));
-                    uint64_t w1, w2, w3, w4;
-                    std::memcpy(&w1, target1 + i * 8, sizeof(uint64_t));
-                    std::memcpy(&w2, target2 + i * 8, sizeof(uint64_t));
-                    std::memcpy(&w3, target3 + i * 8, sizeof(uint64_t));
-                    std::memcpy(&w4, target4 + i * 8, sizeof(uint64_t));
-                    dp1 += __builtin_popcountll(queryWord & w1);
-                    dp2 += __builtin_popcountll(queryWord & w2);
-                    dp3 += __builtin_popcountll(queryWord & w3);
-                    dp4 += __builtin_popcountll(queryWord & w4);
-                }
-                // Remainder bytes that don't fill a full 8-byte word
-                const uint64_t remainStart = words * 8;
-                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
-                    const uint8_t qb = query[r];
-                    dp1 += __builtin_popcount((qb & target1[r]) & 0xFF);
-                    dp2 += __builtin_popcount((qb & target2[r]) & 0xFF);
-                    dp3 += __builtin_popcount((qb & target3[r]) & 0xFF);
-                    dp4 += __builtin_popcount((qb & target4[r]) & 0xFF);
-                }
-            }
-
-            dis0 = scoringSecondPart(target1, dp1);
-            dis1 = scoringSecondPart(target2, dp2);
-            dis2 = scoringSecondPart(target3, dp3);
-            dis3 = scoringSecondPart(target4, dp4);
+            dis0 = scoringSecondPart(target1, static_cast<float>(multiBitDp(query, target1)));
+            dis1 = scoringSecondPart(target2, static_cast<float>(multiBitDp(query, target2)));
+            dis2 = scoringSecondPart(target3, static_cast<float>(multiBitDp(query, target3)));
+            dis3 = scoringSecondPart(target4, static_cast<float>(multiBitDp(query, target4)));
         }
 
         /// compute distance between two stored vectors
@@ -213,28 +276,7 @@ namespace knn_jni {
             const uint8_t* target1 = data + i * oneElementByteSize;
             const uint8_t* target2 = data + j * oneElementByteSize;
 
-            const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-            uint32_t dp = 0;
-
-            if constexpr (IsBytesMultipleOf8) {
-                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
-                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
-                for (size_t k = 0; k < words; ++k) {
-                    dp += __builtin_popcountll(t1[k] & t2[k]);
-                }
-            } else {
-                for (size_t k = 0; k < words; ++k) {
-                    uint64_t w1, w2;
-                    std::memcpy(&w1, target1 + k * 8, sizeof(uint64_t));
-                    std::memcpy(&w2, target2 + k * 8, sizeof(uint64_t));
-                    dp += __builtin_popcountll(w1 & w2);
-                }
-                // Remainder bytes that don't fill a full 8-byte word
-                const uint64_t remainStart = words * 8;
-                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
-                    dp += __builtin_popcount((target1[r] & target2[r]) & 0xFF);
-                }
-            }
+            const uint64_t dp = multiBitDp(target1, target2);
 
             // Get correction factors
             float ax, lx, additional, x1;
@@ -247,7 +289,7 @@ namespace knn_jni {
             float score = ax * az * dimension
                    + az * lx * x1
                    + ax * lz * z1
-                   + lx * lz * dp;
+                   + lx * lz * static_cast<float>(dp);
 
             if constexpr (IsMaxIP) {
                 // Negate: Faiss HNSW always minimizes distance (CMax comparator).
@@ -269,8 +311,10 @@ namespace knn_jni {
         // For safely casting uint8_t* to float*, we should enforce 8-byte alignment for the vector.
         std::vector<uint8_t, knn_jni::NBytesAlignedAllocator<uint8_t, 8>> quantizedVectorsAndCorrectionFactors;
         int32_t dimension;
+        // Document bit width (1, 2, or 4). quantizedVectorBytes == docBits * binaryCodeBytes.
+        int32_t docBits;
 
-        FaissSQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric)
+        FaissSQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric, int32_t _docBits)
           : faiss::IndexBinary(_dimension, _metric, true),
             numVectors(_numVectors),
             quantizedVectorBytes(_quantizedVectorBytes),
@@ -278,7 +322,8 @@ namespace knn_jni {
             oneElementSize(_quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t)),
             // Pre allocate vector storage space
             quantizedVectorsAndCorrectionFactors(_numVectors * oneElementSize),
-            dimension(_dimension) {
+            dimension(_dimension),
+            docBits(_docBits) {
 
             // Just changing the size, not shrinking, thus allocated memory capacity remains the same.
             // This is to avoid reallocations when adding elements later on since we know the exact required memory space upfront.
@@ -300,15 +345,15 @@ namespace knn_jni {
             const bool aligned = (oneElementSize % 8) == 0;
             if (metric_type == faiss::MetricType::METRIC_L2) {
                 if (aligned) {
-                    return new FaissSQDistanceComputer<false, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<false, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 } else {
-                    return new FaissSQDistanceComputer<false, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<false, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 }
             } else if (metric_type == faiss::MetricType::METRIC_INNER_PRODUCT) {
                 if (aligned) {
-                    return new FaissSQDistanceComputer<true, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<true, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 } else {
-                    return new FaissSQDistanceComputer<true, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<true, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 }
             }
 

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -208,7 +208,7 @@ jlong BinaryIndexService::initIndex(
 
 jlong BinaryIndexService::initFaissSQIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, faiss::MetricType metric,
                                             std::string indexDescription, int dim, int numVectors, int threadCount,
-                                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes) {
+                                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes, int docBits) {
     if (auto it = parameters.find(M); it == parameters.end()) {
         throw std::runtime_error("Parameter [" + M + "] is required for Faiss scalar optimized index");
     }
@@ -218,7 +218,7 @@ jlong BinaryIndexService::initFaissSQIndex(knn_jni::JNIUtilInterface *jniUtil, J
 
     // Create Faiss SQ HNSW Index
     std::unique_ptr<knn_jni::FaissSQHnsw> faissSQHnsw (new knn_jni::FaissSQHnsw(
-        m, new knn_jni::FaissSQFlat(numVectors, quantizedVectorBytes, centroidDp, dim, metric)));
+        m, new knn_jni::FaissSQFlat(numVectors, quantizedVectorBytes, centroidDp, dim, metric, docBits)));
 
     // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
     if (threadCount != 0) {

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -207,7 +207,8 @@ jlong knn_jni::faiss_wrapper::InitFaissSQIndex(knn_jni::JNIUtilInterface *jniUti
                                                 jobject parametersJ,
                                                 BinaryIndexService *indexService,
                                                 jfloat centroidDp,
-                                                jint quantizedVecBytes) {
+                                                jint quantizedVecBytes,
+                                                jint docBits) {
     if (dimJ <= 0) {
         throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
     }
@@ -253,7 +254,8 @@ jlong knn_jni::faiss_wrapper::InitFaissSQIndex(knn_jni::JNIUtilInterface *jniUti
                                            threadCount,
                                            std::move(subParametersCpp),
                                            centroidDp,
-                                           quantizedVecBytes);
+                                           quantizedVecBytes,
+                                           docBits);
 }
 
 void knn_jni::faiss_wrapper::InsertToIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ, jlong vectorsAddressJ, jint dimJ,

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -577,11 +577,11 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterrup
 }
 
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initFaissSQIndex(
-    JNIEnv * env, jclass cls, jint totalLiveDocs, jint dimJ, jobject parametersJ, jfloat centroidDp, jint quantizedVecBytes) {
+    JNIEnv * env, jclass cls, jint totalLiveDocs, jint dimJ, jobject parametersJ, jfloat centroidDp, jint quantizedVecBytes, jint docBits) {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
         knn_jni::faiss_wrapper::BinaryIndexService binaryIndexService(std::move(faissMethods));
-        return knn_jni::faiss_wrapper::InitFaissSQIndex(&jniUtil, env, totalLiveDocs, dimJ, parametersJ, &binaryIndexService, centroidDp, quantizedVecBytes);
+        return knn_jni::faiss_wrapper::InitFaissSQIndex(&jniUtil, env, totalLiveDocs, dimJ, parametersJ, &binaryIndexService, centroidDp, quantizedVecBytes, docBits);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_sq_distance_computer_test.cpp
+++ b/jni/tests/faiss_sq_distance_computer_test.cpp
@@ -189,13 +189,13 @@ TEST_P(FaissSQDistanceComputerTest, OperatorSingleVector) {
     // Create distance computer via template
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -234,13 +234,13 @@ TEST_P(FaissSQDistanceComputerTest, DistancesBatch4) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -276,13 +276,13 @@ TEST_P(FaissSQDistanceComputerTest, SymmetricDis) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     // symmetric_dis doesn't need set_query, it works on stored vectors only
     for (int i = 0; i < NUM_VECS; ++i) {
@@ -328,13 +328,13 @@ TEST_P(FaissSQDistanceComputerTest, CorrectionFactorsExtraction) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     // Verify correction factor extraction indirectly: set_query reads query correction
     // factors, then operator() uses both query and target correction factors in the
@@ -371,7 +371,7 @@ TEST_P(FaissSQDistanceComputerTest, GetDistanceComputerIntegration) {
     constexpr int NUM_VECS = 4;
 
     faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
-    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric, 1);
 
     // Populate the storage
     auto buf = makeBuffer(NUM_VECS, qvb);
@@ -439,9 +439,9 @@ TEST_P(FaissSQDistanceComputerTest, OperatorNonMultipleOf8Bytes) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -478,9 +478,9 @@ TEST_P(FaissSQDistanceComputerTest, DistancesBatch4NonMultipleOf8Bytes) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -505,9 +505,9 @@ TEST_P(FaissSQDistanceComputerTest, SymmetricDisNonMultipleOf8Bytes) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     for (int i = 0; i < NUM_VECS; ++i) {
         for (int j = i; j < NUM_VECS; ++j) {
@@ -548,7 +548,7 @@ TEST_P(FaissSQDistanceComputerTest, GetDistanceComputerIntegrationNonMultipleOf8
     constexpr int NUM_VECS = 4;
 
     faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
-    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric, 1);
 
     auto buf = makeBuffer(NUM_VECS, qvb);
     flat.quantizedVectorsAndCorrectionFactors.assign(buf.data.begin(), buf.data.end());
@@ -595,5 +595,376 @@ INSTANTIATE_TEST_SUITE_P(
         return info.param.name();
     }
 );
+
+// ---------------------------------------------------------------------------
+// Multi-bit tests (docBits in {1, 2, 4})
+// ---------------------------------------------------------------------------
+//
+// The tests above all pass docBits=1. These new tests cover B=2 and B=4 by
+// comparing FaissSQDistanceComputer output against a scalar reference that
+// mirrors the production formula:
+//   dp = Σ_{i,j<docBits} popcount(planeA_i AND planeB_j) << (i + j)
+// and validates that the intervalLength scaling by 1/(2^docBits - 1) applies
+// correctly (no-op for B=1, 1/3 for B=2, 1/15 for B=4).
+
+struct MultiBitParams {
+    bool isMaxIP;
+    int32_t docBits;
+    std::string name() const {
+        return std::string(isMaxIP ? "MaxIP" : "L2") + "_B" + std::to_string(docBits);
+    }
+};
+
+class FaissSQDistanceComputerMultiBitTest : public ::testing::TestWithParam<MultiBitParams> {
+protected:
+    static constexpr float CENTROID_DP = 0.5f;
+    static constexpr float TOLERANCE  = 1e-4f;
+
+    std::mt19937 rng{123};
+
+    struct Buffer {
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> data;
+        int32_t oneElementSize;
+        int32_t quantizedVectorBytes;
+    };
+
+    // qvb must be a multiple of docBits so `planeBytes = qvb / docBits` is exact.
+    // Aligned qvb (multiple of 8) also exercises the fast reinterpret_cast path.
+    Buffer makeBuffer(int numVecs, int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        Buffer buf;
+        buf.oneElementSize = oneElementSize;
+        buf.quantizedVectorBytes = quantizedVectorBytes;
+        buf.data.resize(numVecs * oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int v = 0; v < numVecs; ++v) {
+            uint8_t* base = buf.data.data() + v * oneElementSize;
+            for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+                base[b] = static_cast<uint8_t>(byteDist(rng));
+            }
+            float lower = floatDist(rng);
+            float upper = lower + std::abs(floatDist(rng)) + 0.01f;
+            float additional = floatDist(rng);
+            int32_t componentSum = intDist(rng);
+            writeCorrectionFactors(base + quantizedVectorBytes, lower, upper, additional, componentSum);
+        }
+        return buf;
+    }
+
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> makeQuery(int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> q(oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+            q[b] = static_cast<uint8_t>(byteDist(rng));
+        }
+        float lower = floatDist(rng);
+        float upper = lower + std::abs(floatDist(rng)) + 0.01f;
+        float additional = floatDist(rng);
+        int32_t componentSum = intDist(rng);
+        writeCorrectionFactors(q.data() + quantizedVectorBytes, lower, upper, additional, componentSum);
+        return q;
+    }
+
+    // Reference multiBitDp. The formula depends on the docBits Lucene layout:
+    //   B=1, B=2 (bit-plane popcount): Σ_{i,j} popcount(planeA_i AND planeB_j) << (i + j)
+    //   B=4 (PACKED_NIBBLE):           Σ_i (aHi_i * bHi_i + aLo_i * bLo_i)
+    // We dispatch on docBits so this reference matches production for every supported width.
+    static uint64_t referenceMultiBitDp(const uint8_t* a, const uint8_t* b, int32_t quantizedVectorBytes, int32_t docBits) {
+        if (docBits == 4) {
+            // PACKED_NIBBLE byte-wise multiply: each byte holds two 4-bit elements.
+            uint64_t total = 0;
+            for (int32_t k = 0; k < quantizedVectorBytes; ++k) {
+                const uint32_t aLo = a[k] & 0x0Fu;
+                const uint32_t aHi = (a[k] >> 4) & 0x0Fu;
+                const uint32_t bLo = b[k] & 0x0Fu;
+                const uint32_t bHi = (b[k] >> 4) & 0x0Fu;
+                total += aLo * bLo + aHi * bHi;
+            }
+            return total;
+        }
+        // B=1, B=2: bit-plane popcount-AND-shift double sum.
+        const uint64_t planeBytes = static_cast<uint64_t>(quantizedVectorBytes) / static_cast<uint64_t>(docBits);
+        uint64_t dp = 0;
+        for (int32_t i = 0; i < docBits; ++i) {
+            const uint8_t* pa = a + static_cast<uint64_t>(i) * planeBytes;
+            for (int32_t j = 0; j < docBits; ++j) {
+                const uint8_t* pb = b + static_cast<uint64_t>(j) * planeBytes;
+                uint64_t pc = 0;
+                for (uint64_t k = 0; k < planeBytes; ++k) {
+                    pc += __builtin_popcount((pa[k] & pb[k]) & 0xFF);
+                }
+                dp += pc << (i + j);
+            }
+        }
+        return dp;
+    }
+
+    // Reference score using the docBits-scaled intervalLength.
+    static float referenceScoreMultiBit(bool isMaxIP, int32_t dim, float centroidDp,
+                                         float lowerY, float rawIntervalY, float additionalY, float y1,
+                                         float lowerX, float rawIntervalX, float additionalX, float x1,
+                                         uint64_t dp, int32_t docBits) {
+        const float scale = 1.0f / static_cast<float>((1 << docBits) - 1);
+        const float ay = lowerY;
+        const float ly = rawIntervalY * scale;
+        const float ax = lowerX;
+        const float lx = rawIntervalX * scale;
+        float score = ax * ay * dim + ay * lx * x1 + ax * ly * y1 + lx * ly * static_cast<float>(dp);
+        if (isMaxIP) {
+            score += additionalY + additionalX - centroidDp;
+            return -score;
+        } else {
+            return additionalY + additionalX - 2.0f * score;
+        }
+    }
+
+    struct RawCorr { float lower, rawInterval, additional; float componentSum; };
+    static RawCorr readRawCorr(const uint8_t* ptr) {
+        RawCorr c;
+        float lower, upper;
+        std::memcpy(&lower, ptr, sizeof(float));
+        std::memcpy(&upper, ptr + 4, sizeof(float));
+        std::memcpy(&c.additional, ptr + 8, sizeof(float));
+        int32_t cs;
+        std::memcpy(&cs, ptr + 12, sizeof(int32_t));
+        c.lower = lower;
+        c.rawInterval = upper - lower;
+        c.componentSum = static_cast<float>(cs);
+        return c;
+    }
+};
+
+// Operator() bit-identical to scalar reference across docBits ∈ {1, 2, 4}.
+TEST_P(FaissSQDistanceComputerMultiBitTest, OperatorMatchesReference) {
+    auto [isMaxIP, docBits] = GetParam();
+    // planeBytes must divide quantizedVectorBytes cleanly. Pick qvb = docBits * 16 (multiple of 8 → aligned path).
+    const int32_t qvb = docBits * 16;
+    const int32_t planeBytes = qvb / docBits;
+    // dim doesn't matter for correctness beyond feeding the score formula; use planeBytes*8.
+    const int32_t dim = planeBytes * 8;
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    // Use the aligned template path (qvb is a multiple of 8 by construction here).
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP) {
+        dc.reset(new FaissSQDistanceComputer<true,  true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    } else {
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    }
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readRawCorr(queryBuf.data() + qvb);
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        const uint64_t refDp = referenceMultiBitDp(queryBuf.data(), target, qvb, docBits);
+        auto tCorr = readRawCorr(target + qvb);
+        float expected = referenceScoreMultiBit(
+            isMaxIP, dim, CENTROID_DP,
+            qCorr.lower, qCorr.rawInterval, qCorr.additional, qCorr.componentSum,
+            tCorr.lower, tCorr.rawInterval, tCorr.additional, tCorr.componentSum,
+            refDp, docBits);
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "docBits=" << docBits << ", isMaxIP=" << isMaxIP << ", i=" << i;
+    }
+}
+
+// symmetric_dis (build-time distance between two stored codes) bit-identical to reference.
+TEST_P(FaissSQDistanceComputerMultiBitTest, SymmetricDisMatchesReference) {
+    auto [isMaxIP, docBits] = GetParam();
+    const int32_t qvb = docBits * 16;
+    const int32_t planeBytes = qvb / docBits;
+    const int32_t dim = planeBytes * 8;
+    constexpr int NUM_VECS = 6;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<FaissSQDistanceComputer<true, true>> dcMax;
+    std::unique_ptr<FaissSQDistanceComputer<false, true>> dcL2;
+    // We need the concrete type to call symmetric_dis (which isn't a virtual).
+    if (isMaxIP) {
+        dcMax.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    } else {
+        dcL2.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    }
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        for (int j = i; j < NUM_VECS; ++j) {
+            const uint8_t* a = buf.data.data() + i * buf.oneElementSize;
+            const uint8_t* b = buf.data.data() + j * buf.oneElementSize;
+            const uint64_t refDp = referenceMultiBitDp(a, b, qvb, docBits);
+            auto aCorr = readRawCorr(a + qvb);
+            auto bCorr = readRawCorr(b + qvb);
+
+            // symmetric_dis mirrors scoringSecondPart structure but with both sides scaled.
+            const float scale = 1.0f / static_cast<float>((1 << docBits) - 1);
+            const float ax = aCorr.lower;
+            const float lx = aCorr.rawInterval * scale;
+            const float az = bCorr.lower;
+            const float lz = bCorr.rawInterval * scale;
+            float score = ax * az * dim + az * lx * aCorr.componentSum + ax * lz * bCorr.componentSum
+                        + lx * lz * static_cast<float>(refDp);
+            float expected;
+            if (isMaxIP) {
+                score += aCorr.additional + bCorr.additional - CENTROID_DP;
+                expected = -score;
+            } else {
+                expected = aCorr.additional + bCorr.additional - 2.0f * score;
+            }
+
+            float actual = isMaxIP ? dcMax->symmetric_dis(i, j) : dcL2->symmetric_dis(i, j);
+            EXPECT_NEAR(actual, expected, TOLERANCE)
+                << "docBits=" << docBits << ", isMaxIP=" << isMaxIP << ", (i,j)=(" << i << "," << j << ")";
+        }
+    }
+}
+
+// distances_batch_4 must agree with per-element operator() at each docBits.
+TEST_P(FaissSQDistanceComputerMultiBitTest, DistancesBatch4MatchesSingle) {
+    auto [isMaxIP, docBits] = GetParam();
+    const int32_t qvb = docBits * 16;
+    const int32_t planeBytes = qvb / docBits;
+    const int32_t dim = planeBytes * 8;
+    constexpr int NUM_VECS = 6;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP) {
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    } else {
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    }
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    float d0, d1, d2, d3;
+    dc->distances_batch_4(0, 1, 2, 3, d0, d1, d2, d3);
+    EXPECT_NEAR(d0, (*dc)(0), TOLERANCE) << "docBits=" << docBits;
+    EXPECT_NEAR(d1, (*dc)(1), TOLERANCE) << "docBits=" << docBits;
+    EXPECT_NEAR(d2, (*dc)(2), TOLERANCE) << "docBits=" << docBits;
+    EXPECT_NEAR(d3, (*dc)(3), TOLERANCE) << "docBits=" << docBits;
+}
+
+// docBits=1 must produce results bit-identical to the legacy single-bit path,
+// which is the "no regression on existing 1-bit graphs" invariant the POC commit relies on.
+TEST_P(FaissSQDistanceComputerMultiBitTest, DocBits1MatchesLegacyPopcount) {
+    auto [isMaxIP, docBits] = GetParam();
+    if (docBits != 1) {
+        GTEST_SKIP() << "This invariant only applies to docBits=1";
+    }
+    const int32_t qvb = 24;
+    const int32_t dim = qvb * 32;
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP) {
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
+    } else {
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
+    }
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    // For docBits=1, dataScale = 1.0 so intervalLength is unchanged, and multiBitDp reduces
+    // to popcount(a AND b). So the legacy referencePopcount + referenceScore path (used in
+    // the SQTestParams tests above) must agree with the multi-bit reference too.
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t legacyDp = referencePopcount(queryBuf.data(), target, qvb);
+        uint64_t multiBitRef = referenceMultiBitDp(queryBuf.data(), target, qvb, 1);
+        EXPECT_EQ(legacyDp, multiBitRef)
+            << "docBits=1 multi-bit dp must equal legacy popcount, i=" << i;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MultiBit,
+    FaissSQDistanceComputerMultiBitTest,
+    ::testing::Values(
+        MultiBitParams{false, 1}, MultiBitParams{false, 2}, MultiBitParams{false, 4},
+        MultiBitParams{true,  1}, MultiBitParams{true,  2}, MultiBitParams{true,  4}
+    ),
+    [](const ::testing::TestParamInfo<MultiBitParams>& info) { return info.param.name(); }
+);
+
+// ---------------------------------------------------------------------------
+// docBits validation — constructor must reject unsupported / dangerous values
+// ---------------------------------------------------------------------------
+
+TEST(FaissSQDistanceComputerValidation, RejectsUnsupportedDocBits) {
+    // We only need a dummy buffer big enough to compute oneElementByteSize; nothing is dereferenced
+    // because the constructor validates docBits before touching any data.
+    // oneElementByteSize must be > 16 (correction factors) for quantizedVectorBytes to be positive.
+    constexpr int32_t qvb = 8;
+    constexpr int32_t oneElementByteSize = qvb + 3 * sizeof(float) + sizeof(int32_t);
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> dummy(oneElementByteSize, 0);
+
+    // docBits=0 would trigger div-by-zero in planeBytes computation.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/0)),
+        std::runtime_error);
+    // docBits=3 is not a supported MOS width.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/3)),
+        std::runtime_error);
+    // docBits=8 exceeds Lucene's MOS bit widths.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/8)),
+        std::runtime_error);
+    // Negative docBits — the (1 << bits) computation would be UB.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/-1)),
+        std::runtime_error);
+}
+
+TEST(FaissSQDistanceComputerValidation, RejectsOddQuantizedVectorBytesAtB2) {
+    // qvb=9 is not divisible by docBits=2. B=2 requires two bit planes of equal length,
+    // so quantizedVectorBytes must be even. B=1 and B=4 have no such requirement.
+    constexpr int32_t qvb = 9;
+    constexpr int32_t oneElementByteSize = qvb + 3 * sizeof(float) + sizeof(int32_t);
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> dummy(oneElementByteSize, 0);
+
+    // B=2 must throw because 9 is odd.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, false>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/2)),
+        std::runtime_error);
+
+    // B=1 is fine (any qvb is valid — planeBytes == qvb).
+    EXPECT_NO_THROW(
+        (FaissSQDistanceComputer<false, false>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/1)));
+
+    // B=4 is fine too — PACKED_NIBBLE bytes are independent (each byte holds 2 elements),
+    // so qvb=9 doesn't need any divisibility property beyond "positive".
+    EXPECT_NO_THROW(
+        (FaissSQDistanceComputer<false, false>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/4)));
+}
+
+TEST(FaissSQDistanceComputerValidation, AcceptsAllSupportedDocBits) {
+    // Verify the happy path for each supported docBits width. qvb must be a multiple of docBits.
+    for (int32_t docBits : {1, 2, 4}) {
+        const int32_t qvb = docBits * 16; // multiple of docBits AND multiple of 8
+        const int32_t oneElementByteSize = qvb + 3 * sizeof(float) + sizeof(int32_t);
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> dummy(oneElementByteSize, 0);
+
+        EXPECT_NO_THROW(
+            (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 128, 1, docBits))
+        ) << "docBits=" << docBits << " must be accepted";
+    }
+}
 
 } // namespace knn_jni

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class LuceneFlatBWCIT extends AbstractRestartUpgradeTestCase {
+
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 8;
+    private static final int NUM_DOCS = 10;
+    private static final int K = 5;
+
+    /**
+     * Old cluster creates a flat mapping WITH engine=lucene explicitly set (legal on the old cluster).
+     * After upgrade to a version that enforces engine-agnostic flat, the persisted mapping — which
+     * still carries engine=lucene — must continue to load, be searchable, and accept new docs.
+     */
+    public void testFlatWithExplicitLuceneEngine_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        // Only meaningful when the old cluster still accepts engine on method=flat.
+        // Once the old cluster is on the engine-agnostic gate version or later, it rejects the
+        // mapping itself and there is no pre-gate → post-gate transition to exercise.
+        if (isFlatMethodEnginePermittedOnOldCluster(getBWCVersion()) == false) {
+            logger.info("Skipping test — flat + explicit engine not accepted by old cluster in version: {}", getBWCVersion());
+            return;
+        }
+
+        if (isRunningAgainstOldCluster()) {
+            XContentBuilder mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(TEST_FIELD)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(NAME, METHOD_FLAT)
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping.toString());
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+            forceMergeKnnIndex(testIndex);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+            deleteKNNIndex(testIndex);
+        }
+    }
+}

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFlatBWCIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class LuceneFlatBWCIT extends AbstractRollingUpgradeTestCase {
+
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 8;
+    private static final int NUM_DOCS = 10;
+    private static final int K = 5;
+
+    /**
+     * Rolling upgrade variant of the flat + explicit engine BWC check. The old cluster creates a
+     * flat mapping with engine=lucene explicitly set. As nodes roll to the new version that
+     * enforces engine-agnostic flat, the mapping (which still carries engine=lucene) must
+     * continue to load, be searchable in mixed and upgraded phases.
+     */
+    public void testRollingUpgrade_flatWithExplicitLuceneEngine() throws Exception {
+        // Only meaningful when the old cluster still accepts engine on method=flat.
+        // Once the old cluster is on the engine-agnostic gate version or later, it rejects the
+        // mapping itself and there is no pre-gate → post-gate transition to exercise.
+        if (isFlatMethodEnginePermittedOnOldCluster(getBWCVersion()) == false) {
+            logger.info("Skipping test — flat + explicit engine not accepted by old cluster in version: {}", getBWCVersion());
+            return;
+        }
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        switch (getClusterType()) {
+            case OLD:
+                XContentBuilder mapping = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(TEST_FIELD)
+                    .field("type", "knn_vector")
+                    .field("dimension", DIMENSION)
+                    .startObject(KNN_METHOD)
+                    .field(NAME, METHOD_FLAT)
+                    .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                    .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping.toString());
+                addKNNDocs(testIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+                flush(testIndex, true);
+                break;
+
+            case MIXED:
+                validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+                break;
+
+            case UPGRADED:
+                validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+                addKNNDocs(testIndex, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+                forceMergeKnnIndex(testIndex);
+                validateKNNSearch(testIndex, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+                deleteKNNIndex(testIndex);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -230,4 +230,9 @@ public class KNNConstants {
     public static final int BYTE_ALIGNMENT_MASK = 7; // Used for rounding up to nearest byte (Byte.SIZE - 1)
     // Define here: https://github.com/opensearch-project/remote-vector-index-builder/blob/main/API.md#index-parameters
     public static final int MIN_DOCS_FOR_REMOTE_INDEX_BUILD = 4;
+
+    // Version gate for rejecting user-supplied engine on method=flat mappings. Indices created
+    // before this version may have engine=lucene persisted in their flat mapping — they must
+    // continue to load without error. New indices reject any engine setting on flat.
+    public static final Version FLAT_METHOD_ENGINE_AGNOSTIC_VERSION = Version.V_3_9_0;
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -18,17 +18,21 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Dedicated format for Faiss SQ vector fields.
  *
- * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} with 1-bit quantization
- * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for flat vector storage (.vec/.veq files),
- * while HNSW graph construction is delegated to the native Faiss engine (.faiss files).
+ * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} for flat vector storage (.vec/.veq files),
+ * while HNSW graph construction is delegated to the native Faiss engine (.faiss files). The
+ * {@link ScalarEncoding} determines the document bit width (1, 2, or 4) and is resolved from the
+ * field's configured bits via {@link ScalarEncodingResolver}; it defaults to 1-bit
+ * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for backward compatibility.
  *
- * <p>A field is routed to this format when its method parameters contain
- * {@code "encoder": {"name": "sq", "bits": 1}}. See {@code FaissCodecFormatResolver} for the
- * routing logic in {@code BasePerFieldKnnVectorsFormat.getKnnVectorsFormatForField}.
+ * <p>A field is routed to this format when its method parameters contain an {@code sq} encoder
+ * with a supported bit width. See {@code FaissCodecFormatResolver} for the routing logic.
  *
  * @see Faiss1040ScalarQuantizedKnnVectorsWriter
  * @see Faiss1040ScalarQuantizedKnnVectorsReader
@@ -38,31 +42,49 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
 
     private static final String FORMAT_NAME = "Faiss1040ScalarQuantizedKnnVectorsFormat";
 
-    // Shared across all format instances; KNN1040ScalarQuantizedVectorsFormat is stateless.
-    // TODO : We have to make it scalable for other encoding types, not limit this on `ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE`.
-    private static final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat = new KNN1040ScalarQuantizedVectorsFormat(
-        ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE
-    );
+    private static final ScalarEncoding DEFAULT_ENCODING = ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
 
+    // KNN1040ScalarQuantizedVectorsFormat is stateless per encoding, so we cache one instance per
+    // encoding and share it across all format instances.
+    private static final Map<ScalarEncoding, KNN1040ScalarQuantizedVectorsFormat> FLAT_FORMAT_CACHE = new ConcurrentHashMap<>();
+
+    private final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
     private final int approximateThreshold;
 
+    /**
+     * Returns the flat format for the default (1-bit) encoding. Retained as a static accessor for tests.
+     */
     @VisibleForTesting
     static KNN1040ScalarQuantizedVectorsFormat getFaissSqFlatFormat() {
-        return faissSqFlatFormat;
+        return flatFormatFor(DEFAULT_ENCODING);
+    }
+
+    private static KNN1040ScalarQuantizedVectorsFormat flatFormatFor(final ScalarEncoding encoding) {
+        return FLAT_FORMAT_CACHE.computeIfAbsent(encoding, KNN1040ScalarQuantizedVectorsFormat::new);
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
-        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory());
+        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory(), DEFAULT_ENCODING);
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat(
         final int approximateThreshold,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
+        this(approximateThreshold, nativeIndexBuildStrategyFactory, DEFAULT_ENCODING);
+    }
+
+    public Faiss1040ScalarQuantizedKnnVectorsFormat(
+        final int approximateThreshold,
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        final ScalarEncoding encoding
+    ) {
         super(FORMAT_NAME);
+        Objects.requireNonNull(encoding, "ScalarEncoding must not be null");
         this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.faissSqFlatFormat = flatFormatFor(encoding);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -9,30 +9,46 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
-import com.google.common.annotations.VisibleForTesting;
 import org.opensearch.knn.index.KNNSettings;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 
 /**
  * Dedicated format for Faiss SQ vector fields.
  *
  * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} for flat vector storage (.vec/.veq files),
  * while HNSW graph construction is delegated to the native Faiss engine (.faiss files). The
- * {@link ScalarEncoding} determines the document bit width (1, 2, or 4) and is resolved from the
- * field's configured bits via {@link ScalarEncodingResolver}; it defaults to 1-bit
- * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for backward compatibility.
+ * {@link ScalarEncoding} is resolved <b>per-field at write time</b> from the segment's
+ * {@link FieldInfo} attributes ({@code SQ_CONFIG}, populated by {@code EngineFieldMapper}) —
+ * <b>not</b> from a value baked into the format instance at construction time.
  *
- * <p>A field is routed to this format when its method parameters contain an {@code sq} encoder
- * with a supported bit width. See {@code FaissCodecFormatResolver} for the routing logic.
+ * <p>This matters because Lucene's SPI machinery ({@link KnnVectorsFormat#forName(String)},
+ * invoked by {@code PerFieldKnnVectorsFormat.FieldsReader}) reopens codecs via the mandatory
+ * no-arg constructor whenever segments are opened on a new reader (index open, shard relocation,
+ * node bootup). If encoding were carried on the instance, an SPI-instantiated format would hold
+ * a constructor default (previously {@code SINGLE_BIT_QUERY_NIBBLE}) and any writer produced by
+ * it would silently miswrite non-1-bit fields as 1-bit. Resolving encoding per-field from
+ * {@code SQ_CONFIG} makes the format instance encoding-agnostic.
+ *
+ * <p>On the <b>read path</b>, {@link org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat#fieldsReader} never
+ * threads its format-instance encoding through to
+ * {@code Lucene104ScalarQuantizedVectorsReader} — the reader resolves per-field encoding by
+ * reading the wire number from each field's {@code .vemq} meta sidecar (scoped by
+ * {@code SegmentReadState.segmentSuffix} at the Lucene layer). So the encoding we pass to
+ * {@link KNN1040ScalarQuantizedVectorsFormat} on the read path is unused — we intentionally use
+ * a default-encoding instance rather than pretend to resolve it.
  *
  * @see Faiss1040ScalarQuantizedKnnVectorsWriter
  * @see Faiss1040ScalarQuantizedKnnVectorsReader
@@ -42,57 +58,78 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
 
     private static final String FORMAT_NAME = "Faiss1040ScalarQuantizedKnnVectorsFormat";
 
-    private static final ScalarEncoding DEFAULT_ENCODING = ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
-
     // KNN1040ScalarQuantizedVectorsFormat is stateless per encoding, so we cache one instance per
     // encoding and share it across all format instances.
     private static final Map<ScalarEncoding, KNN1040ScalarQuantizedVectorsFormat> FLAT_FORMAT_CACHE = new ConcurrentHashMap<>();
 
-    private final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
     private final int approximateThreshold;
-
-    /**
-     * Returns the flat format for the default (1-bit) encoding. Retained as a static accessor for tests.
-     */
-    @VisibleForTesting
-    static KNN1040ScalarQuantizedVectorsFormat getFaissSqFlatFormat() {
-        return flatFormatFor(DEFAULT_ENCODING);
-    }
 
     private static KNN1040ScalarQuantizedVectorsFormat flatFormatFor(final ScalarEncoding encoding) {
         return FLAT_FORMAT_CACHE.computeIfAbsent(encoding, KNN1040ScalarQuantizedVectorsFormat::new);
     }
 
+    /**
+     * Returns a fresh {@link KNN1040ScalarQuantizedVectorsFormat} with the default encoding. Used
+     * on the read path, where the encoding is unused downstream (see {@link #fieldsReader}).
+     */
+    private static KNN1040ScalarQuantizedVectorsFormat flatFormatFor() {
+        return new KNN1040ScalarQuantizedVectorsFormat();
+    }
+
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
-        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory(), DEFAULT_ENCODING);
+        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory());
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat(
         final int approximateThreshold,
         final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
-        this(approximateThreshold, nativeIndexBuildStrategyFactory, DEFAULT_ENCODING);
-    }
-
-    public Faiss1040ScalarQuantizedKnnVectorsFormat(
-        final int approximateThreshold,
-        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        final ScalarEncoding encoding
-    ) {
         super(FORMAT_NAME);
-        Objects.requireNonNull(encoding, "ScalarEncoding must not be null");
         this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
-        this.faissSqFlatFormat = flatFormatFor(encoding);
+    }
+
+    /**
+     * Resolves the {@link ScalarEncoding} for {@code fieldInfo} by reading the field's
+     * {@code SQ_CONFIG} attribute (set by {@code EngineFieldMapper}). Used only by the write
+     * path — the read path does not consume format-instance encoding (see class javadoc).
+     *
+     * <p>Contract: every field routed to this format is expected to be an SQ field carrying
+     * {@code SQ_CONFIG} with a positive {@code bits} value (1, 2, or 4).
+     * {@code EngineFieldMapper} sets this attribute unconditionally on the mapping side, and
+     * Lucene's {@code PerFieldKnnVectorsFormat} only routes a field to this format when the
+     * mapper decided this format applies. So reaching this method with a bits {@code <= 0}
+     * field indicates an upstream invariant violation — we fail loud rather than silently
+     * defaulting to 1-bit (the silent-default was exactly the class of bug this refactor was
+     * written to eliminate).
+     */
+    private static ScalarEncoding resolveEncodingForField(final FieldInfo fieldInfo) {
+        final int bits = FieldInfoExtractor.extractSQConfig(fieldInfo).getBits();
+        if (bits <= 0) {
+            throw new IllegalStateException(
+                String.format(
+                    Locale.ROOT,
+                    "%s: SQ field [%s] has no bits set in its %s attribute; bits must be populated for every SQ field. Supported bits: %s",
+                    FORMAT_NAME,
+                    fieldInfo.getName(),
+                    SQ_CONFIG,
+                    ScalarEncodingResolver.supportedDocBitsString()
+                )
+            );
+        }
+        return ScalarEncodingResolver.forDocBits(bits);
     }
 
     @Override
     public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        // Encoding is resolved LAZILY inside the wrapper writer, on the first addField() or
+        // mergeOneField() call (that's when Lucene hands us the exact FieldInfo). We cannot
+        // resolve here because state.fieldInfos may be null on the initial-write path — Lucene's
+        // IndexingChain calls fieldsWriter() before FieldInfos is populated.
         return new Faiss1040ScalarQuantizedKnnVectorsWriter(
             state,
-            faissSqFlatFormat.fieldsWriter(state),
-            faissSqFlatFormat::fieldsReader,
+            fieldInfo -> flatFormatFor(resolveEncodingForField(fieldInfo)),
             nativeIndexBuildStrategyFactory,
             approximateThreshold
         );
@@ -104,12 +141,23 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
      * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}. This is required because Lucene's
      * HNSW traversal expects all vector values to expose an {@link org.apache.lucene.store.IndexInput},
      * but Lucene's {@code ScalarQuantizedVectorValues} does not implement that interface.
+     *
+     * <p><b>Encoding is not resolved on the read path.</b> {@link org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat#fieldsReader}
+     * ({@code Lucene104ScalarQuantizedVectorsFormat.java:133}) constructs {@code Lucene104ScalarQuantizedVectorsReader}
+     * <i>without</i> threading in the format instance's encoding — the reader instead resolves the encoding for
+     * each field by reading the wire number from the field's own {@code .vemq} meta sidecar
+     * ({@code Lucene104ScalarQuantizedVectorsReader.FieldEntry.create}, {@code input.readVInt()} →
+     * {@code ScalarEncoding.fromWireNumber}).
+     *
+     * <p>Therefore, passing a specific encoding to {@link KNN1040ScalarQuantizedVectorsFormat} here would
+     * be dead code — the value is unused downstream. We deliberately use the default no-arg constructor
+     * to avoid implying a per-field resolution that isn't happening.
      */
     @Override
     public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
         return new Faiss1040ScalarQuantizedKnnVectorsReader(
             state,
-            new Faiss1040ScalarQuantizedFlatVectorsReader(faissSqFlatFormat.fieldsReader(state))
+            new Faiss1040ScalarQuantizedFlatVectorsReader(flatFormatFor().fieldsReader(state))
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -27,6 +27,7 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexWriter;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.function.Function;
 
 /**
@@ -62,6 +63,9 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
     private FlatFieldVectorsWriter<?> fieldWriter;
     private FieldInfo fieldInfo;
     private boolean finished;
+    // Set to true once the flat writer has been finished+closed (inline in flush/mergeOneField)
+    // so subsequent calls fail loud instead of writing to (or re-closing) a closed writer.
+    private boolean flatWriterDone;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
     private final Integer approximateThreshold;
 
@@ -83,6 +87,17 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
      * {@link #addField(FieldInfo)} and {@link #mergeOneField(FieldInfo, MergeState)}.
      */
     private FlatVectorsWriter getOrInitFlatVectorsWriter(final FieldInfo fieldInfoForResolution) throws IOException {
+        if (flatWriterDone) {
+            throw new IllegalStateException(
+                String.format(
+                    Locale.ROOT,
+                    "%s flat writer has already been finished and closed; cannot access it again for field [%s]. "
+                        + "This writer supports only a single field per instance.",
+                    Faiss1040ScalarQuantizedKnnVectorsWriter.class.getSimpleName(),
+                    fieldInfoForResolution.name
+                )
+            );
+        }
         if (flatVectorsWriter == null) {
             this.resolvedFlatFormat = flatFormatResolver.apply(fieldInfoForResolution);
             this.flatVectorsWriter = resolvedFlatFormat.fieldsWriter(segmentWriteState);
@@ -126,10 +141,13 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             return;
         }
         // Flush, finish, and close the flat vectors writer so that the .vec and .veb files
-        // are fully written and file handles are released.
+        // are fully written and file handles are released. Mark the writer done so any later
+        // access (subsequent mergeOneField, or close()) fails loud instead of touching a
+        // closed writer.
         flatVectorsWriter.flush(maxDoc, sortMap);
         flatVectorsWriter.finish();
         IOUtils.close(flatVectorsWriter);
+        this.flatWriterDone = true;
 
         if (fieldWriter == null) {
             return;
@@ -169,12 +187,15 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // paths don't go through addField, so this is where lazy init happens for merges.
         final FlatVectorsWriter writer = getOrInitFlatVectorsWriter(fieldInfo);
 
-        // Merge, finish, and close the flat writer so that files are readable.
+        // Merge, finish, and close the flat writer so that files are readable. Mark the writer
+        // done so a subsequent mergeOneField (or close()) can't write to / re-close it — the
+        // instance is expected to handle only one field.
         IORunnable mergeRunnable = writer.mergeOneField(fieldInfo, mergeState);
 
         if (mergeRunnable != null) mergeRunnable.run();
         writer.finish();
         IOUtils.close(writer);
+        this.flatWriterDone = true;
 
         // Open a reader on the merged flat files, extract QuantizedByteVectorValues,
         // and pass it to the build strategy. The writer owns the reader lifecycle.
@@ -215,8 +236,13 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
 
     @Override
     public void close() throws IOException {
-        // flatVectorsWriter is already closed in flush/mergeOneField.
-        // IOUtils.close is safe to call on an already-closed resource.
+        // flush/mergeOneField already finished and closed the flat writer inline. Guard on
+        // flatWriterDone so we don't re-close (which some FlatVectorsWriter implementations
+        // may not tolerate) — and still handle the flush/merge-never-called case by closing
+        // the still-open writer if flatVectorsWriter was allocated but never finalized.
+        if (flatWriterDone) {
+            return;
+        }
         IOUtils.close(flatVectorsWriter);
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -20,7 +20,6 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
-import org.apache.lucene.util.IOFunction;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.knn.index.codec.nativeindex.AbstractNativeEnginesKnnVectorsWriter;
@@ -28,6 +27,7 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexWriter;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 /**
  * Writer for Faiss SQ vector fields. Unlike {@link org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsWriter}
@@ -47,27 +47,47 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Faiss1040ScalarQuantizedKnnVectorsWriter.class);
 
     private final SegmentWriteState segmentWriteState;
-    private final FlatVectorsWriter flatVectorsWriter;
+    // Supplies a Lucene flat format for a given FieldInfo. Called lazily on the first addField()
+    // or mergeOneField() call — this is when Lucene hands us the exact FieldInfo, so we can
+    // resolve the correct ScalarEncoding from its SQ_CONFIG attribute rather than relying on a
+    // pre-baked encoding at construction time. Deferring is required because at
+    // Faiss1040ScalarQuantizedKnnVectorsFormat.fieldsWriter(state) time, state.fieldInfos may
+    // still be null on the initial-write path (Lucene's IndexingChain calls fieldsWriter before
+    // fieldInfos is populated).
+    private final Function<FieldInfo, KNN1040ScalarQuantizedVectorsFormat> flatFormatResolver;
+    // The lazily-constructed flat writer — non-null after the first addField/mergeOneField call.
+    private FlatVectorsWriter flatVectorsWriter;
+    private KNN1040ScalarQuantizedVectorsFormat resolvedFlatFormat;
     // Single field — SQ gets a dedicated format per field via BasePerFieldKnnVectorsFormat
     private FlatFieldVectorsWriter<?> fieldWriter;
     private FieldInfo fieldInfo;
     private boolean finished;
-    private final IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
     private final Integer approximateThreshold;
 
     Faiss1040ScalarQuantizedKnnVectorsWriter(
         @NonNull SegmentWriteState segmentWriteState,
-        @NonNull FlatVectorsWriter flatVectorsWriter,
-        @NonNull IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier,
+        @NonNull Function<FieldInfo, KNN1040ScalarQuantizedVectorsFormat> flatFormatResolver,
         @NonNull NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
         Integer approximateThreshold
     ) {
         this.segmentWriteState = segmentWriteState;
-        this.flatVectorsWriter = flatVectorsWriter;
-        this.quantizedFlatVectorsReaderSupplier = quantizedFlatVectorsReaderSupplier;
+        this.flatFormatResolver = flatFormatResolver;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
         this.approximateThreshold = approximateThreshold;
+    }
+
+    /**
+     * Resolves the flat format from the given field on first call, constructs the underlying
+     * Lucene flat writer, and caches both for subsequent operations (flush, close). Called from
+     * {@link #addField(FieldInfo)} and {@link #mergeOneField(FieldInfo, MergeState)}.
+     */
+    private FlatVectorsWriter getOrInitFlatVectorsWriter(final FieldInfo fieldInfoForResolution) throws IOException {
+        if (flatVectorsWriter == null) {
+            this.resolvedFlatFormat = flatFormatResolver.apply(fieldInfoForResolution);
+            this.flatVectorsWriter = resolvedFlatFormat.fieldsWriter(segmentWriteState);
+        }
+        return flatVectorsWriter;
     }
 
     /**
@@ -86,7 +106,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             );
         }
         this.fieldInfo = newFieldInfo;
-        this.fieldWriter = flatVectorsWriter.addField(newFieldInfo);
+        this.fieldWriter = getOrInitFlatVectorsWriter(newFieldInfo).addField(newFieldInfo);
         return fieldWriter;
     }
 
@@ -101,6 +121,10 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
      */
     @Override
     public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+        if (flatVectorsWriter == null) {
+            // No field was added — nothing to flush and no native build to run.
+            return;
+        }
         // Flush, finish, and close the flat vectors writer so that the .vec and .veb files
         // are fully written and file handles are released.
         flatVectorsWriter.flush(maxDoc, sortMap);
@@ -141,12 +165,16 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // Setting field info
         this.fieldInfo = fieldInfo;
 
+        // Resolve the flat format from the merged field's SQ_CONFIG on the first call. Merge
+        // paths don't go through addField, so this is where lazy init happens for merges.
+        final FlatVectorsWriter writer = getOrInitFlatVectorsWriter(fieldInfo);
+
         // Merge, finish, and close the flat writer so that files are readable.
-        IORunnable mergeRunnable = flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+        IORunnable mergeRunnable = writer.mergeOneField(fieldInfo, mergeState);
 
         if (mergeRunnable != null) mergeRunnable.run();
-        flatVectorsWriter.finish();
-        IOUtils.close(flatVectorsWriter);
+        writer.finish();
+        IOUtils.close(writer);
 
         // Open a reader on the merged flat files, extract QuantizedByteVectorValues,
         // and pass it to the build strategy. The writer owns the reader lifecycle.
@@ -194,11 +222,14 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
 
     @Override
     public long ramBytesUsed() {
-        return SHALLOW_SIZE + flatVectorsWriter.ramBytesUsed() + (fieldWriter != null ? fieldWriter.ramBytesUsed() : 0);
+        return SHALLOW_SIZE + (flatVectorsWriter != null ? flatVectorsWriter.ramBytesUsed() : 0) + (fieldWriter != null
+            ? fieldWriter.ramBytesUsed()
+            : 0);
     }
 
     /**
      * Opens a FlatVectorsReader scoped to this single field from the already-written flat files.
+     * Uses the resolved flat format from the write phase to ensure encoding matches.
      */
     private FlatVectorsReader openFlatVectorsReader() throws IOException {
         final SegmentReadState readState = new SegmentReadState(
@@ -208,6 +239,6 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             segmentWriteState.context,
             segmentWriteState.segmentSuffix
         );
-        return quantizedFlatVectorsReaderSupplier.apply(readState);
+        return resolvedFlatFormat.fieldsReader(readState);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -26,6 +26,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.faiss.FaissCodecFormatResolver;
 import org.opensearch.knn.index.engine.lucene.LuceneCodecFormatResolver;
 import org.opensearch.knn.index.engine.lucene.LuceneSQEncoder;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 import java.util.Optional;
@@ -120,7 +121,10 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 merge.v2(),
                 threshold
             );
-        }, LuceneVectorsFormatType.FLAT, ctx -> new KNN1040ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE));
+        },
+            LuceneVectorsFormatType.FLAT,
+            ctx -> new KNN1040ScalarQuantizedVectorsFormat(resolveFlatScalarEncoding(ctx.getCompressionLevel()))
+        );
     }
 
     @Override
@@ -134,5 +138,23 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
         }
         return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
+    }
+
+    /**
+     * Picks the {@link ScalarEncoding} for the FLAT format from the field's compression level.
+     * x32 → 1-bit ({@code SINGLE_BIT_QUERY_NIBBLE}), x16 → 2-bit ({@code DIBIT_QUERY_NIBBLE}),
+     * x8 → 4-bit ({@code PACKED_NIBBLE}). Any other value (including {@code NOT_CONFIGURED},
+     * which the resolver maps to x32) falls back to 1-bit. {@link LuceneFlatMethodResolver}
+     * rejects unsupported compression levels at mapping time so an unexpected value here would
+     * indicate an upstream invariant violation.
+     */
+    private static ScalarEncoding resolveFlatScalarEncoding(final CompressionLevel compressionLevel) {
+        if (compressionLevel == CompressionLevel.x8) {
+            return ScalarEncodingResolver.forDocBits(4);
+        }
+        if (compressionLevel == CompressionLevel.x16) {
+            return ScalarEncodingResolver.forDocBits(2);
+        }
+        return ScalarEncodingResolver.forDocBits(1);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -111,6 +111,19 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         final QuantizedByteVectorValues quantizedByteVectorValues,
         final float[] target
     ) throws IOException {
+        // Native bulk-SIMD scoring is implemented for 1-bit documents only. Multi-bit docs
+        // (B=2, B=4) share the same .veq layout but need width-specific kernels that are not
+        // yet in the native SIMD path — route them to Lucene's pure-Java reference scorer,
+        // which scores the same codes correctly.
+        final ScalarEncoding scalarEncoding = quantizedByteVectorValues.getScalarEncoding();
+        if (ScalarEncodingResolver.docBits(scalarEncoding) != 1) {
+            return (RandomVectorScorer.AbstractRandomVectorScorer) super.getRandomVectorScorer(
+                similarityFunction,
+                quantizedByteVectorValues,
+                target
+            );
+        }
+
         final IndexInput indexInput = quantizedByteVectorValues.getSlice();
         final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(indexInput, 0, indexInput.length());
         if (addressAndSize != null) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
@@ -139,7 +139,10 @@ public final class ScalarEncodingResolver {
         return bits;
     }
 
-    private static String supportedDocBitsString() {
+    /**
+     * Returns the supported document bit widths as a printable string (e.g. {@code "[1, 2, 4]"}).
+     */
+    public static String supportedDocBitsString() {
         return Arrays.toString(SUPPORTED_DOC_BITS);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Single decision point that maps a document bit width (the number of bits used to quantize each
+ * dimension of a stored vector) to the Lucene {@link ScalarEncoding} used by the FAISS SQ
+ * memory-optimized-search path, and back.
+ *
+ * <p>The FAISS SQ path always uses a 4-bit (nibble) query, so the relevant encodings are exactly
+ * those whose query bit width is {@link #QUERY_BITS}. In Lucene 10.4 these are:
+ * <ul>
+ *   <li>1-bit document → {@code SINGLE_BIT_QUERY_NIBBLE} (x32)</li>
+ *   <li>2-bit document → {@code DIBIT_QUERY_NIBBLE} (x16)</li>
+ *   <li>4-bit document → {@code PACKED_NIBBLE} (x8)</li>
+ * </ul>
+ *
+ * <p>The mapping is resolved dynamically from {@link ScalarEncoding#getBits()} and
+ * {@link ScalarEncoding#getQueryBits()} rather than by hardcoding enum names, so it stays correct
+ * if Lucene renames constants and so adding a new supported bit width only requires updating
+ * {@link #SUPPORTED_DOC_BITS}. This keeps the {@code SINGLE_BIT_QUERY_NIBBLE} reference out of the
+ * codec format, the build strategy, and the scorer (Requirement 11.4).
+ */
+public final class ScalarEncodingResolver {
+
+    private ScalarEncodingResolver() {
+        // Utility class; not instantiable.
+    }
+
+    /** The FAISS SQ path always quantizes the query to a 4-bit nibble. */
+    public static final int QUERY_BITS = 4;
+
+    /** Document bit widths supported by the FAISS SQ memory-optimized-search path. */
+    private static final int[] SUPPORTED_DOC_BITS = { 1, 2, 4 };
+
+    /** docBits -> ScalarEncoding, resolved once from the enum metadata. */
+    private static final Map<Integer, ScalarEncoding> DOC_BITS_TO_ENCODING = buildDocBitsToEncoding();
+
+    /**
+     * Builds the docBits → {@link ScalarEncoding} lookup table by matching entries in
+     * {@link ScalarEncoding#values()} against each supported width paired with the fixed
+     * {@link #QUERY_BITS} (4). Called once at class-load; the returned map is stored in
+     * {@link #DOC_BITS_TO_ENCODING} and consulted for every {@link #forDocBits(int)} call.
+     *
+     * <p>Current mapping (Lucene 10.4, kept here for reference and to track deviations
+     * over time — if this diverges, either Lucene renamed constants or the enum's
+     * {@code getBits()}/{@code getQueryBits()} metadata changed):
+     * <table>
+     *   <caption>Current docBits → ScalarEncoding mapping</caption>
+     *   <tr><th>docBits</th><th>ScalarEncoding</th><th>Compression</th></tr>
+     *   <tr><td>1</td><td>{@code SINGLE_BIT_QUERY_NIBBLE}</td><td>x32</td></tr>
+     *   <tr><td>2</td><td>{@code DIBIT_QUERY_NIBBLE}</td><td>x16</td></tr>
+     *   <tr><td>4</td><td>{@code PACKED_NIBBLE}</td><td>x8</td></tr>
+     * </table>
+     *
+     * <p>Throws at class-load time (via the static initializer of {@link #DOC_BITS_TO_ENCODING})
+     * if any supported width is missing from the installed Lucene version, so upgrades that
+     * silently drop an encoding fail fast rather than corrupting on-disk segments.
+     */
+    private static Map<Integer, ScalarEncoding> buildDocBitsToEncoding() {
+        final Map<Integer, ScalarEncoding> map = new HashMap<>();
+        for (int docBits : SUPPORTED_DOC_BITS) {
+            for (ScalarEncoding encoding : ScalarEncoding.values()) {
+                if (encoding.getBits() == docBits && encoding.getQueryBits() == QUERY_BITS) {
+                    map.put(docBits, encoding);
+                    break;
+                }
+            }
+            if (map.containsKey(docBits) == false) {
+                throw new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "No Lucene ScalarEncoding found for document bits=%d with a %d-bit query. "
+                            + "The installed Lucene version may not expose this encoding.",
+                        docBits,
+                        QUERY_BITS
+                    )
+                );
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Returns the {@link ScalarEncoding} used to store documents quantized to {@code docBits} bits
+     * per dimension with a 4-bit nibble query.
+     *
+     * @param docBits the document bit width (1, 2, or 4)
+     * @return the corresponding Lucene scalar encoding
+     * @throws IllegalArgumentException if {@code docBits} is not a supported document bit width
+     */
+    public static ScalarEncoding forDocBits(final int docBits) {
+        final ScalarEncoding encoding = DOC_BITS_TO_ENCODING.get(docBits);
+        if (encoding == null) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Unsupported SQ document bit width: %d. Supported: %s", docBits, supportedDocBitsString())
+            );
+        }
+        return encoding;
+    }
+
+    /**
+     * Inverse of {@link #forDocBits(int)} — returns the document bit width for {@code encoding},
+     * rejecting encodings outside the {@link #SUPPORTED_DOC_BITS} set (1, 2, 4). {@link ScalarEncoding}
+     * exposes bit widths for encodings the FAISS SQ path doesn't support (e.g. {@code SEVEN_BIT},
+     * {@code UNSIGNED_BYTE}); validating here keeps the round-trip guarantee symmetric with
+     * {@link #forDocBits(int)} and fails loud if a caller ever passes an unexpected encoding.
+     *
+     * @param encoding a Lucene scalar encoding
+     * @return the document bit width ({@link ScalarEncoding#getBits()})
+     * @throws NullPointerException if {@code encoding} is {@code null}
+     * @throws IllegalArgumentException if {@code encoding} is not one of the supported FAISS SQ encodings
+     */
+    public static int docBits(final ScalarEncoding encoding) {
+        Objects.requireNonNull(encoding, "ScalarEncoding must not be null");
+        final int bits = encoding.getBits();
+        if (DOC_BITS_TO_ENCODING.containsKey(bits) == false) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Unsupported SQ scalar encoding: %s (bits=%d). Supported bits: %s",
+                    encoding,
+                    bits,
+                    supportedDocBitsString()
+                )
+            );
+        }
+        return bits;
+    }
+
+    private static String supportedDocBitsString() {
+        return Arrays.toString(SUPPORTED_DOC_BITS);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KnnVectorsFormatContext.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KnnVectorsFormatContext.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec;
 
 import lombok.Value;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 
@@ -55,4 +56,10 @@ public class KnnVectorsFormatContext {
      * </ul>
      */
     int approximateThreshold;
+
+    /**
+     * Resolved compression level for the field (may be {@link CompressionLevel#NOT_CONFIGURED}).
+     * Used by the FLAT format factory to pick the correct scalar-quantization encoding.
+     */
+    CompressionLevel compressionLevel;
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.KNN1040Codec.ScalarEncodingResolver;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
@@ -125,6 +126,9 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategy implements NativeInde
         // The centroid dot-product is a precomputed scalar used in the ADC scoring formula.
         // It appears as a correction term: score += additionalCorrection + indexCorrection - centroidDp
         final float centroidDp = binarizedVectorValues.getCentroidDP();
+        // Document bit width (1, 2, or 4), derived from the stored encoding. The native build path
+        // splits the quantized code into docBits bit planes for the symmetric distance computation.
+        final int docBits = ScalarEncodingResolver.docBits(binarizedVectorValues.getScalarEncoding());
         final Map<String, Object> indexParameters = new HashMap<>(indexInfo.getIndexParameters());
         // Force override vector data type as binary so that Faiss can treat it as binary index.
         indexParameters.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.BINARY.getValue());
@@ -140,6 +144,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategy implements NativeInde
                 indexParameters,
                 centroidDp,
                 quantizedVecBytes,
+                docBits,
                 indexInfo.getKnnEngine()
             )
         );

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
@@ -113,9 +113,13 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategy implements NativeInde
         final QuantizedByteVectorValues binarizedVectorValues = indexInfo.getQuantizedByteVectorValues();
         Objects.requireNonNull(binarizedVectorValues, "QuantizedByteVectorValues was null in BuildIndexParams");
 
-        // The byte length of a single quantized vector. For 1-bit quantization of D dimensions,
-        // this is ceil(D/8) bytes, padded to 64-bit alignment: ((D + 63) / 64) * 64 / 8.
-        // TODO : This needs to be made generic for other quantization.
+        // Byte length of a single quantized vector as written to Lucene's .veq file. This is
+        // data-driven — Lucene's encoder decides the layout per ScalarEncoding, and each
+        // supported bit width produces a different length:
+        // B=1 (SINGLE_BIT_QUERY_NIBBLE): ceil(D/8) bytes, padded to 64-bit alignment
+        // B=2 (DIBIT_QUERY_NIBBLE): two bit-planes, 2 * planeBytes
+        // B=4 (PACKED_NIBBLE): two 4-bit values per byte, packedBytes
+        // We simply consume the resulting length; the strategy is generic across all three.
         final int quantizedVecBytes = binarizedVectorValues.vectorValue(0).length;
 
         // The centroid dot-product is a precomputed scalar used in the ADC scoring formula.

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
@@ -10,9 +10,9 @@ import org.apache.lucene.index.FieldInfo;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy;
-import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.repositories.RepositoriesService;
 
@@ -60,12 +60,12 @@ public final class NativeIndexBuildStrategyFactory {
         final KNNEngine knnEngine = extractKNNEngine(fieldInfo);
         final boolean isTemplate = fieldInfo.attributes().containsKey(MODEL_ID);
         final boolean iterative = !isTemplate && knnEngine.supportsIterativeBuild();
-        final boolean isFaissSQOneBitField = FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue();
+        final boolean isFaissSQMosField = FieldInfoExtractor.isSQField(fieldInfo)
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits());
 
         // Determine build strategy
         final NativeIndexBuildStrategy strategy;
-        if (isFaissSQOneBitField) {
+        if (isFaissSQMosField) {
             strategy = MemOptimizedScalarQuantizedIndexBuildStrategy.getInstance();
         } else if (iterative) {
             strategy = MemOptimizedNativeIndexBuildStrategy.getInstance();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -385,9 +385,10 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
 
     private static String determineVectorDataType(final VectorDataType dataType, @NonNull final ResolvedIndexSpec resolvedSpec) {
         if (dataType == VectorDataType.FLOAT) {
-            // SQ 1-bit sends fp32 vectors. Once support is added for building 1 bit SQ graphs
-            // in the Remote Vector Index Builder, then this can be modified to send 1 bit SQ vectors.
-            if (resolvedSpec.isFaissSQOneBit()) {
+            // SQ memory-optimized-search (bits ∈ {1, 2, 4}) sends fp32 vectors. The remote builder
+            // constructs an HNSW graph over fp32 neighbors — quantization happens locally on the
+            // data node, and the graph is stitched with the locally-quantized .veq at search time.
+            if (resolvedSpec.isFaissSQMultiBit()) {
                 return dataType.getValue();
             }
             if (resolvedSpec.isFP16QuantizedIndex()) {
@@ -404,7 +405,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
      * flat vectors at search time via {@link org.opensearch.knn.memoryoptsearch.faiss.FaissFlatIndexFactory}.
      */
     private static boolean shouldSkipStoredVectors(final VectorDataType vectorDataType, @NonNull final ResolvedIndexSpec resolvedSpec) {
-        return resolvedSpec.isFaissSQOneBit();
+        return resolvedSpec.isFaissSQMultiBit();
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/CodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/CodecFormatResolver.java
@@ -23,7 +23,8 @@ public interface CodecFormatResolver {
      * @param params                the method component parameters; may be null
      * @param defaultMaxConnections default max connections for HNSW
      * @param defaultBeamWidth      default beam width for HNSW
-     * @param resolvedSpec          the resolved index spec
+     * @param resolvedSpec          the resolved index spec; implementations can derive
+     *                              {@code compressionLevel} from it via {@code resolvedSpec.getCompressionLevel()}
      * @return the resolved {@link KnnVectorsFormat}
      */
     KnnVectorsFormat resolve(

--- a/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
@@ -16,7 +16,9 @@ import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.Locale;
 
+import static org.opensearch.knn.common.KNNConstants.FLAT_METHOD_ENGINE_AGNOSTIC_VERSION;
 import static org.opensearch.knn.common.KNNConstants.KNN_DEFAULT_COMPRESSION_FLIP_VERSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.index.engine.KNNEngine.DEPRECATED_ENGINES;
 
@@ -80,6 +82,13 @@ public final class EngineResolver {
         boolean requiresTraining,
         Version version
     ) {
+        // Flat method is engine-agnostic from the user's perspective: it always resolves to
+        // Lucene internally. Reject ANY user-provided engine (method-level or top-level, even if
+        // it happens to be Lucene) — but only for indices created on/after the gate version.
+        // Pre-gate indices may have engine=lucene persisted in their flat mapping and must
+        // continue to load without error.
+        rejectEngineForMethodFlat(knnMethodContext, topLevelEngineString, version);
+
         KNNEngine userConfiguredEngine = resolveAndValidateUserConfiguredEngine(
             knnMethodContext,
             topLevelEngineString,
@@ -128,6 +137,26 @@ public final class EngineResolver {
             return resolveEngineForX1OrNoCompression(mode, version);
         }
         return KNNEngine.FAISS;
+    }
+
+    private void rejectEngineForMethodFlat(KNNMethodContext knnMethodContext, String topLevelEngineString, Version version) {
+        final boolean isFlatMethod = knnMethodContext != null
+            && METHOD_FLAT.equalsIgnoreCase(knnMethodContext.getMethodComponentContext().getName());
+        if (isFlatMethod == false) {
+            return;
+        }
+        // Skip the reject for pre-gate indices so existing flat mappings with engine=lucene
+        // persisted from earlier versions keep loading.
+        if (version != null && version.before(FLAT_METHOD_ENGINE_AGNOSTIC_VERSION)) {
+            return;
+        }
+        // Flat is engine-agnostic — do not accept any user-provided engine, even if it happens
+        // to match the internally-resolved one.
+        if (hasUserConfiguredMethodEngine(knnMethodContext) || hasUserConfiguredTopLevelEngine(topLevelEngineString)) {
+            throw new MapperParsingException(
+                String.format(Locale.ROOT, "[%s] method does not support [%s] parameter", METHOD_FLAT, KNN_ENGINE)
+            );
+        }
     }
 
     private boolean hasUserConfiguredMethodEngine(KNNMethodContext knnMethodContext) {

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -228,9 +228,14 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        // Flat is engine-agnostic; do not serialize a resolved engine — the round-trip parse
-        // would otherwise be flagged as a user-supplied engine and rejected.
-        if (METHOD_FLAT.equalsIgnoreCase(methodComponentContext.getName()) == false) {
+        // Flat is engine-agnostic on new indices (created on/after FLAT_METHOD_ENGINE_AGNOSTIC_VERSION):
+        // the resolver rejects any user-supplied engine and always resolves internally to Lucene, so we
+        // omit KNN_ENGINE to avoid a re-parse rejection. Pre-gate indices persisted engine=lucene in
+        // their flat mapping explicitly; we preserve that emission (isEngineConfigured=true) so
+        // rolling-upgrade round-trips of cluster state / snapshot metadata don't drop the attribute
+        // and cause mapping divergence between old and new nodes.
+        final boolean isFlatMethod = METHOD_FLAT.equalsIgnoreCase(methodComponentContext.getName());
+        if (isFlatMethod == false || isEngineConfigured) {
             builder.field(KNN_ENGINE, knnEngine.getName());
         }
         builder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -102,8 +102,13 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         if (isEngineConfigured) {
             throw new IllegalArgumentException("Cannot configure KNNEngine if it has already been configured");
         }
+        // Note: we intentionally do NOT set isEngineConfigured=true here. That flag reflects
+        // "engine was explicitly provided in the user's mapping" and is consumed by
+        // EngineResolver.rejectEngineForMethodFlat + KNNMethodContext.toXContent to preserve
+        // BWC round-trips. Internal resolvers that call setKnnEngine (KNNVectorFieldMapper,
+        // RestTrainModelHandler) already gate on isEngineConfigured() before calling, so
+        // there's no risk of double-set even though the flag no longer guards it.
         this.knnEngine = knnEngine;
-        this.isEngineConfigured = true;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
@@ -227,7 +228,11 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(KNN_ENGINE, knnEngine.getName());
+        // Flat is engine-agnostic; do not serialize a resolved engine — the round-trip parse
+        // would otherwise be flagged as a user-supplied engine and rejected.
+        if (METHOD_FLAT.equalsIgnoreCase(methodComponentContext.getName()) == false) {
+            builder.field(KNN_ENGINE, knnEngine.getName());
+        }
         builder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
         builder = methodComponentContext.toXContent(builder, params);
         return builder;

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -284,7 +284,7 @@ public final class ResolvedIndexSpec {
             return false;
         }
 
-        if (isSQOneBit() || isFP16QuantizedIndex()) {
+        if (isSQMultiBit() || isFP16QuantizedIndex()) {
             return true;
         }
 
@@ -292,15 +292,6 @@ public final class ResolvedIndexSpec {
             return vectorDataType == VectorDataType.FLOAT
                 || vectorDataType == VectorDataType.BINARY
                 || vectorDataType == VectorDataType.BYTE;
-        }
-
-        if (vectorDataType == VectorDataType.FLOAT
-            && encoderType == Encoder.EncoderType.SQ
-            && quantizationBits != null
-            && quantizationBits != Encoder.QuantizationBits.ONE
-            && quantizationBits != Encoder.QuantizationBits.SIXTEEN
-            && quantizationBits != Encoder.QuantizationBits.FULL_PRECISION) {
-            return true;
         }
 
         return false;

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -220,6 +220,13 @@ public final class ResolvedIndexSpec {
             return RescoreContext.builder().oversampleFactor(FLAT_OVERSAMPLE_FACTOR).userProvided(false).build();
         }
 
+        if (isMethodFlat() && (compressionLevel == CompressionLevel.x16 || compressionLevel == CompressionLevel.x8)) {
+            return RescoreContext.builder()
+                .oversampleFactor(RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR)
+                .userProvided(false)
+                .build();
+        }
+
         if (compressionLevel.isModeValidForRescore(mode)) {
             Version version = indexVersionCreated != null ? indexVersionCreated : Version.CURRENT;
 

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -181,7 +181,10 @@ public final class ResolvedIndexSpec {
      *
      * <p>Resolution order:</p>
      * <ol>
-     *   <li>SQ 1-bit: fixed 2x oversample (quantized distances need full-precision rescoring)</li>
+     *   <li>SQ multi-bit (bits ∈ {1, 2, 4}): fixed oversample, overrides disallowed.
+     *       bits=1 (x32) uses the Faiss scalar-quantized factor; bits=2 (x16) and bits=4 (x8) use
+     *       {@link RescoreContext#SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR} — the higher-bit codes
+     *       recover most recall on their own.</li>
      *   <li>x32 compression with the flat method: 2x oversample</li>
      *   <li>Otherwise, only when the compression level requires rescoring for the resolved mode
      *       ({@link CompressionLevel#isModeValidForRescore}):
@@ -202,9 +205,12 @@ public final class ResolvedIndexSpec {
         if (rescoreDefaultOverride != null) {
             return rescoreDefaultOverride;
         }
-        if (isSQOneBit()) {
+        if (isSQMultiBit()) {
+            final float oversampleFactor = quantizationBits == Encoder.QuantizationBits.ONE
+                ? RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR
+                : RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR;
             return RescoreContext.builder()
-                .oversampleFactor(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR)
+                .oversampleFactor(oversampleFactor)
                 .allowOverrideOversampleFactor(false)
                 .userProvided(false)
                 .build();

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -104,13 +104,17 @@ public final class ResolvedIndexSpec {
 
     /**
      * Whether this configuration always uses memory optimized search.
-     * SQ 1-bit indices require memory optimized search for correctness, regardless of engine
-     * (both Faiss and Lucene SQ 1-bit rely on it). The one exclusion is IVF: IVF-based SQ 1-bit
-     * models (e.g. trained with on_disk/32x) produce IVF Faiss indices that the memory optimized
-     * reader cannot load, so forcing memory optimized search for them would fail at query time.
+     * Multi-bit SQ indices (bits ∈ {1, 2, 4}) require memory optimized search for correctness,
+     * regardless of engine — document vectors are stored as integer-coded scalar-quantization
+     * codes in Lucene's flat SQ files, and only the memory-optimized reader knows how to
+     * score against those codes. The one exclusion is IVF: IVF-based SQ 1-bit models
+     * (e.g. trained with on_disk/32x) produce IVF Faiss indices that the memory optimized
+     * reader cannot load, so forcing memory optimized search for them would fail at query
+     * time. Multi-bit SQ + IVF is not a supported combination, so the same exclusion is safe
+     * for bits=2 and bits=4.
      */
     public boolean alwaysUseMemoryOptimizedSearch() {
-        return isSQOneBit() && METHOD_IVF.equals(methodName) == false;
+        return isSQMultiBit() && METHOD_IVF.equals(methodName) == false;
     }
 
     /**
@@ -306,8 +310,24 @@ public final class ResolvedIndexSpec {
         return encoderType == Encoder.EncoderType.SQ && quantizationBits == Encoder.QuantizationBits.ONE;
     }
 
+    /**
+     * True when the encoder is SQ configured for the memory-optimized multi-bit path
+     * (bits ∈ {1, 2, 4}). Document vectors are stored as integer-coded scalar-quantization
+     * codes in Lucene's flat SQ files; Faiss only builds the HNSW graph.
+     */
+    public boolean isSQMultiBit() {
+        return encoderType == Encoder.EncoderType.SQ
+            && (quantizationBits == Encoder.QuantizationBits.ONE
+                || quantizationBits == Encoder.QuantizationBits.TWO
+                || quantizationBits == Encoder.QuantizationBits.FOUR);
+    }
+
     public boolean isFaissSQOneBit() {
         return engine == KNNEngine.FAISS && isSQOneBit();
+    }
+
+    public boolean isFaissSQMultiBit() {
+        return engine == KNNEngine.FAISS && isSQMultiBit();
     }
 
     private boolean isMethodFlat() {

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -42,7 +42,10 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
 
     /**
      * Resolves the format for a specific field. Returns {@link Faiss1040ScalarQuantizedKnnVectorsFormat} when
-     * the encoder is sq with bits=1, otherwise falls back to the default native format.
+     * the encoder is sq with bits in {1, 2, 4} (the multi-bit MOS path), otherwise falls back to the default
+     * native format. The document bit width is resolved per-field at write time by the format itself from
+     * {@code SQ_CONFIG}, so the format instance stays encoding-agnostic and SPI-instantiated instances
+     * cannot silently miswrite fields.
      */
     @Override
     public KnnVectorsFormat resolve(
@@ -53,7 +56,7 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
         int defaultBeamWidth,
         ResolvedIndexSpec resolvedSpec
     ) {
-        if (resolvedSpec.isFaissSQOneBit()) {
+        if (resolvedSpec.isFaissSQMultiBit()) {
             return new Faiss1040ScalarQuantizedKnnVectorsFormat(
                 KNNSettings.getApproximateThresholdValue(mapperService),
                 nativeIndexBuildStrategyFactory

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -45,10 +45,15 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
  * <p>Starting with 3.6.0, this encoder supports a {@code bits} parameter that controls the
  * quantization bit width:
  * <ul>
- *   <li>{@code bits=1} — 1-bit quantization, x32 compression. Uses a dedicated
- *       per-field format backed by Lucene's 1-bit scalar quantization. The {@code type} parameter
- *       is not allowed when bits=1.</li>
- *   <li>{@code bits=16} — equivalent to the existing {@code type=fp16} behavior, x2 compression</li>
+ *   <li>{@code bits=1} — 1-bit quantization, x32 compression. Document vectors are stored as
+ *       integer-coded scalar quantization codes in Lucene's flat SQ format; Faiss only builds
+ *       the HNSW graph. The {@code type} and {@code clip} parameters are not allowed.</li>
+ *   <li>{@code bits=2} — 2-bit quantization, x16 compression. Same coded-flat path as bits=1.
+ *       The {@code type} and {@code clip} parameters are not allowed.</li>
+ *   <li>{@code bits=4} — 4-bit quantization, x8 compression. Same coded-flat path as bits=1.
+ *       The {@code type} and {@code clip} parameters are not allowed.</li>
+ *   <li>{@code bits=16} — equivalent to the existing {@code type=fp16} behavior, x2 compression.
+ *       Uses the standard Faiss SQ description.</li>
  * </ul>
  *
  * <p>For indices created before 3.6.0, the encoder works as before with just the {@code type}
@@ -59,7 +64,13 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 public class FaissSQEncoder implements Encoder {
 
     private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT);
-    private static final Set<Integer> VALID_BITS = Set.of(QuantizationBits.ONE.getValue(), QuantizationBits.SIXTEEN.getValue());
+
+    private static final Set<Integer> VALID_BITS = Set.of(
+        QuantizationBits.ONE.getValue(),
+        QuantizationBits.TWO.getValue(),
+        QuantizationBits.FOUR.getValue(),
+        QuantizationBits.SIXTEEN.getValue()
+    );
 
     private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(ENCODER_SQ)
         .addSupportedDataTypes(SUPPORTED_DATA_TYPES)
@@ -79,8 +90,10 @@ public class FaissSQEncoder implements Encoder {
             Map<String, Object> params = methodComponentContext.getParameters();
             Object bitsObj = params.get(SQ_BITS);
 
-            // bits=1 path: 1-bit quantization — use flat description, Faiss only builds the HNSW graph
-            if (bitsObj instanceof Integer && (Integer) bitsObj == QuantizationBits.ONE.getValue()) {
+            // Multi-bit MOS path (bits in {1,2,4}): document vectors are scalar-quantized to B bits and
+            // stored in Lucene's flat SQ files; Faiss only builds the HNSW graph. Use the flat description
+            // and carry SQ_BITS = B so the codec/build path can resolve the document bit width.
+            if (bitsObj instanceof Integer && isSQCodedBits((Integer) bitsObj)) {
                 int bits = (Integer) bitsObj;
                 return KNNLibraryIndexingContextImpl.builder().parameters(new HashMap<>() {
                     {
@@ -233,6 +246,21 @@ public class FaissSQEncoder implements Encoder {
 
     @Override
     public Set<QuantizationBits> getSupportedBits() {
-        return EnumSet.of(QuantizationBits.ONE, QuantizationBits.SIXTEEN);
+        return EnumSet.of(QuantizationBits.ONE, QuantizationBits.TWO, QuantizationBits.FOUR, QuantizationBits.SIXTEEN);
+    }
+
+    /**
+     * Returns true if {@code bits} is a document bit width stored as integer-coded scalar quantization
+     * codes in Lucene's flat SQ format. These are the widths {1, 2, 4} — HNSW construction is
+     * delegated to native Faiss over the coded bytes. fp16 (16) is excluded — it is a compressed
+     * float representation (not integer-quantized codes) and takes the standard Faiss SQ description.
+     *
+     * @param bits the configured sq encoder bit width
+     * @return true for bits in {1, 2, 4}
+     */
+    public static boolean isSQCodedBits(final int bits) {
+        return bits == QuantizationBits.ONE.getValue()
+            || bits == QuantizationBits.TWO.getValue()
+            || bits == QuantizationBits.FOUR.getValue();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
@@ -8,17 +8,20 @@ package org.opensearch.knn.index.engine.faiss;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.opensearch.knn.index.engine.Encoder;
 
 /**
  * Configuration for the SQ (Scalar Quantization) encoder stored as a field attribute.
+ *
+ * <p>The {@code bits} field must be set explicitly by callers — there is no default. The supported
+ * MOS bit widths are {@code 1}, {@code 2}, and {@code 4}; {@link #EMPTY} carries {@code bits=0} as
+ * a sentinel. Callers that treat the value as a doc bit width should validate it through
+ * {@link FaissSQEncoder#isSQCodedBits(int)}.
  */
 @Builder
 @Getter
 @EqualsAndHashCode
 public class SQConfig {
-    @Builder.Default
-    private int bits = Encoder.QuantizationBits.ONE.getValue();
+    private int bits;
 
     public static final SQConfig EMPTY = SQConfig.builder().bits(0).build();
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.index.codec.params.KNNScalarQuantizedVectorsFormatPara
 import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -74,8 +75,19 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
             throw new IllegalStateException(String.format(Locale.ROOT, "No Lucene vectors format registered for type [%s]", formatType));
         }
         final int approximateThreshold = KNNSettings.getApproximateThresholdValue(mapperService);
+        final CompressionLevel compressionLevel = resolvedSpec != null
+            ? resolvedSpec.getCompressionLevel()
+            : CompressionLevel.NOT_CONFIGURED;
         return factory.apply(
-            new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth, approximateThreshold)
+            new KnnVectorsFormatContext(
+                field,
+                methodContext,
+                params,
+                defaultMaxConnections,
+                defaultBeamWidth,
+                approximateThreshold,
+                compressionLevel
+            )
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolver.java
@@ -24,13 +24,20 @@ import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 import static org.opensearch.knn.index.engine.lucene.LuceneFlatMethod.FLAT_METHOD_COMPONENT;
 
 /**
- * Resolves method configuration for the Lucene flat method. The flat method uses SQ (1-bit quantization)
- * without an HNSW graph, supporting only {@link org.opensearch.knn.index.mapper.CompressionLevel#x32} compression
- * and does not support {@link org.opensearch.knn.index.mapper.Mode}.
+ * Resolves method configuration for the Lucene flat method. The flat method uses scalar quantization
+ * without an HNSW graph (brute-force scan). Supported compression levels are
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel#x32} (SQ 1-bit),
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel#x16} (SQ 2-bit), and
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel#x8} (SQ 4-bit).
+ * {@link org.opensearch.knn.index.mapper.Mode} is not supported.
  */
 public class LuceneFlatMethodResolver extends AbstractMethodResolver {
 
-    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS = Set.of(CompressionLevel.x32);
+    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS = Set.of(
+        CompressionLevel.x32,
+        CompressionLevel.x16,
+        CompressionLevel.x8
+    );
     static final CompressionLevel DEFAULT_COMPRESSION = CompressionLevel.x32;
 
     @Override
@@ -92,7 +99,12 @@ public class LuceneFlatMethodResolver extends AbstractMethodResolver {
             if (!SUPPORTED_COMPRESSION_LEVELS.contains(compressionLevel)) {
                 ValidationException validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format(Locale.ROOT, "\"%s\" method only supports \"%s\" compression", METHOD_FLAT, DEFAULT_COMPRESSION.getName())
+                    String.format(
+                        Locale.ROOT,
+                        "[%s] method only supports these compression levels: [%s] ",
+                        METHOD_FLAT,
+                        SUPPORTED_COMPRESSION_LEVELS.stream().map(CompressionLevel::getName).sorted().toList()
+                    )
                 );
                 throw validationException;
             }

--- a/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
@@ -66,9 +66,9 @@ public final class FaissFieldStrategy implements EngineFieldStrategy {
         fieldType.putAttribute(SPACE_TYPE, resolvedKnnMethodContext.getSpaceType().getValue());
 
         ResolvedIndexSpec spec = knnLibraryIndexingContext.getResolvedSpec();
-        // 1-bit quantization has its own per-field format that handles quantization internally,
-        // so we set sq_config instead of qframe_config
-        if (spec.isSQOneBit()) {
+        // The sq (1/2/4-bit) MOS path has its own per-field format that handles quantization
+        // internally, so we set sq_config (carrying the bit width) instead of qframe_config.
+        if (spec.isSQMultiBit()) {
             SQConfig sqConfig = SQConfig.builder().bits(spec.getQuantizationBits().getValue()).build();
             fieldType.putAttribute(SQ_CONFIG, SQConfigParser.toCsv(sqConfig));
         } else {

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -26,6 +26,7 @@ public final class RescoreContext {
 
     public static final float OVERSAMPLE_FACTOR_DEFAULT_FOR_LUCENE_SCALAR_QUANTIZER_AFTER_V360 = 2.0f;
     public static final float OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD = 5.0f;
+    public static final float SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR = 1.0f;
 
     // Dimension thresholds for adjusting oversample factor
     public static final int DIMENSION_THRESHOLD_1000 = 1000;

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -506,7 +506,8 @@ class FaissService {
         final int dimension,
         final Map<String, Object> indexParameters,
         final float centroidDp,
-        final int quantizedVecBytes
+        final int quantizedVecBytes,
+        final int docBits
     );
 
     /**

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -546,10 +546,11 @@ public class JNIService {
         final Map<String, Object> indexParameters,
         final float centroidDp,
         final int quantizedVecBytes,
+        final int docBits,
         final KNNEngine knnEngine
     ) {
         if (KNNEngine.FAISS == knnEngine) {
-            return FaissService.initFaissSQIndex(totalLiveDocs, dimension, indexParameters, centroidDp, quantizedVecBytes);
+            return FaissService.initFaissSQIndex(totalLiveDocs, dimension, indexParameters, centroidDp, quantizedVecBytes, docBits);
         }
 
         throw new IllegalArgumentException(

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -12,7 +12,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
@@ -31,12 +31,13 @@ public class FaissFlatIndexFactory {
      * indices where flat storage was skipped (IO_FLAG_SKIP_STORAGE). Returns {@code null} if the field
      * does not require externally-provided flat storage.
      *
-     * <p>Currently supports SQ 1-bit. To add support for other flat storage types (e.g., fp32 flat),
-     * add new conditions here.
+     * <p>Supports the SQ memory-optimized-search path for bits in {1, 2, 4} — for all of these the
+     * .faiss file holds only the HNSW graph and the quantized codes live in Lucene's flat .veq file.
+     * To add support for other flat storage types (e.g., fp32 flat), add new conditions here.
      */
     static FaissIndex createFlatIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
         if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue()) {
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
         }
         return null;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -19,7 +19,7 @@ import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorScorer;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
-import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
@@ -86,7 +86,7 @@ public class FlatVectorsScorerProvider {
             // Since Lucene doesn't provide hamming distance scorer, we return our own hamming distance scorer
             return HAMMING_VECTOR_SCORER;
         } else if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue()) {
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
                 return getKNN1040ScalarQuantizedVectorScorer(delegateScorer);
             } else if (delegateScorer != null) {
                 // For all other cases, return the delegate scorer

--- a/src/test/java/org/opensearch/knn/index/LuceneSQFlatIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneSQFlatIT.java
@@ -119,22 +119,29 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testFlatMethod_withFaissEngine_thenFail() {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject(PROPERTIES_FIELD)
-            .startObject(FIELD_NAME)
-            .field(TYPE_FIELD, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, METHOD_FLAT)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
-        expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, builder.toString()));
+    public void testFlatMethod_withExplicitEngine_thenFail() {
+        // Flat method is engine-agnostic — any user-supplied engine (even lucene) must be rejected.
+        for (KNNEngine engine : new KNNEngine[] { KNNEngine.LUCENE, KNNEngine.FAISS }) {
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(FIELD_NAME)
+                .field(TYPE_FIELD, KNN_VECTOR_TYPE)
+                .field(DIMENSION_FIELD, DIMENSION)
+                .startObject(KNNConstants.KNN_METHOD)
+                .field(KNNConstants.NAME, METHOD_FLAT)
+                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .field(KNNConstants.KNN_ENGINE, engine.getName())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            expectThrows(
+                ResponseException.class,
+                String.format(Locale.ROOT, "Expected failure for engine %s with flat method", engine.getName()),
+                () -> createKnnIndex(INDEX_NAME, builder.toString())
+            );
+        }
     }
 
     @SneakyThrows
@@ -148,7 +155,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .startObject(KNNConstants.PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, 16)
             .endObject()
@@ -161,7 +167,7 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testFlatMethod_withUnsupportedCompression_thenFail() {
-        String[] unsupportedCompressions = { "1x", "2x", "4x", "8x", "16x", "64x" };
+        String[] unsupportedCompressions = { "1x", "2x", "4x", "64x" };
         for (String compression : unsupportedCompressions) {
             XContentBuilder builder = XContentFactory.jsonBuilder()
                 .startObject()
@@ -173,7 +179,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, METHOD_FLAT)
                 .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-                .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .endObject()
                 .endObject()
                 .endObject()
@@ -200,7 +205,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, METHOD_FLAT)
                 .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-                .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .endObject()
                 .endObject()
                 .endObject()
@@ -262,7 +266,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .startObject(COLOR_FIELD_NAME)
@@ -322,7 +325,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -370,7 +372,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -397,7 +398,6 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_FLAT)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .endObject()
             .endObject()
             .endObject()

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
@@ -6,12 +6,14 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -24,25 +26,25 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
-import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.KNNSettings;
-import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
 
 @Log4j2
 public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
@@ -72,7 +74,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
             0,
             false,
             false,
-            mock(org.apache.lucene.codecs.Codec.class),
+            mock(Codec.class),
             mock(Map.class),
             new byte[16],
             mock(Map.class),
@@ -84,35 +86,31 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         Mockito.when(directory.openInput(any(), any())).thenReturn(input);
         Mockito.when(directory.createOutput(anyString(), any())).thenReturn(mock(IndexOutput.class));
 
-        final FieldInfos fieldInfos = mock(FieldInfos.class);
-        final FieldInfo fieldInfo = mock(FieldInfo.class);
-        Mockito.when(fieldInfo.getName()).thenReturn("test-field");
-        Mockito.when(fieldInfos.fieldInfo(anyInt())).thenReturn(fieldInfo);
-        Mockito.when(fieldInfos.iterator()).thenReturn(new Iterator<FieldInfo>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
+        // Segment carries a single SQ field with bits=1 (matches Lucene's per-field routing —
+        // this format instance is only ever asked to handle its routed SQ field).
+        final FieldInfo sqFieldInfo = mock(FieldInfo.class);
+        Mockito.when(sqFieldInfo.getName()).thenReturn("test-field");
+        Mockito.when(sqFieldInfo.getAttribute(SQ_CONFIG)).thenReturn(SQConfigParser.toCsv(SQConfig.builder().bits(1).build()));
 
-            @Override
-            public FieldInfo next() {
-                return null;
-            }
-        });
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        Mockito.when(fieldInfos.fieldInfo(anyInt())).thenReturn(sqFieldInfo);
+        Mockito.when(fieldInfos.iterator()).thenReturn(List.of(sqFieldInfo).iterator());
 
         final SegmentReadState mockedSegmentReadState = new SegmentReadState(
             directory,
             mockedSegmentInfo,
             fieldInfos,
             mock(IOContext.class),
-            "test-segment-suffix"
+            ""
         );
 
+        final FieldInfos writeFieldInfos = mock(FieldInfos.class);
+        Mockito.when(writeFieldInfos.iterator()).thenReturn(List.of(sqFieldInfo).iterator());
         final SegmentWriteState mockedSegmentWriteState = new SegmentWriteState(
             mock(InfoStream.class),
             directory,
             mockedSegmentInfo,
-            mock(FieldInfos.class),
+            writeFieldInfos,
             null,
             mock(IOContext.class)
         );
@@ -139,57 +137,113 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         assertTrue(str.contains(Faiss1040ScalarQuantizedKnnVectorsFormat.class.getSimpleName()));
     }
 
-    public void testDefaultConstructor_usesOneBitEncoding() {
-        // Backward-compatibility: no-arg and single-arg constructors must still resolve to the
-        // 1-bit flat format that shipped in 3.x. Any change here would silently switch existing
-        // indices to a different encoding on the next segment write.
-        assertSame(
-            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
-            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat())
-        );
-        assertSame(
-            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
-            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory()))
-        );
-    }
-
-    public void testExplicitEncoding_selectsMatchingFlatFormat() {
-        // Verify each supported encoding wires through to a distinct flat format instance.
-        // Cache-sharing means repeated construction with the same encoding returns the same
-        // underlying format; different encodings return different instances.
-        for (ScalarEncoding encoding : new ScalarEncoding[] {
-            ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE,
-            ScalarEncoding.DIBIT_QUERY_NIBBLE,
-            ScalarEncoding.PACKED_NIBBLE }) {
-            Faiss1040ScalarQuantizedKnnVectorsFormat first = new Faiss1040ScalarQuantizedKnnVectorsFormat(
-                    INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
-                new NativeIndexBuildStrategyFactory(),
-                encoding
-            );
-            Faiss1040ScalarQuantizedKnnVectorsFormat second = new Faiss1040ScalarQuantizedKnnVectorsFormat(
-                    INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
-                new NativeIndexBuildStrategyFactory(),
-                encoding
-            );
-            assertSame("Flat format for " + encoding + " should be cached and reused", reflectFlatFormat(first), reflectFlatFormat(second));
-        }
-
-        // Different encodings must produce different flat format instances.
-        assertNotSame(
-            reflectFlatFormat(
-                new Faiss1040ScalarQuantizedKnnVectorsFormat(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory(), ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
-            ),
-            reflectFlatFormat(
-                new Faiss1040ScalarQuantizedKnnVectorsFormat(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory(), ScalarEncoding.DIBIT_QUERY_NIBBLE)
-            )
-        );
-    }
-
+    /**
+     * Regression guard for the "SPI-instantiated format silently miswrites 2/4-bit fields as
+     * 1-bit" bug: verifies that a format constructed via the no-arg SPI constructor resolves
+     * the correct per-field encoding from the field's {@code SQ_CONFIG} attribute at the moment
+     * Lucene calls {@code fieldsWriter().addField()}. The encoding lives on the cached
+     * {@code KNN1040ScalarQuantizedVectorsFormat} instance the writer resolves.
+     */
     @SneakyThrows
-    private static KNN1040ScalarQuantizedVectorsFormat reflectFlatFormat(Faiss1040ScalarQuantizedKnnVectorsFormat format) {
-        java.lang.reflect.Field field = Faiss1040ScalarQuantizedKnnVectorsFormat.class.getDeclaredField("faissSqFlatFormat");
-        field.setAccessible(true);
-        return (KNN1040ScalarQuantizedVectorsFormat) field.get(format);
+    public void testFieldsWriter_encodingResolvedPerFieldFromSQConfig() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            for (int bits : new int[] { 1, 2, 4 }) {
+                // Write a segment through the same flat format the wrapper resolves to, with
+                // SQ_CONFIG=bits=<bits>. Then open a reader via the no-arg SPI constructor and
+                // verify the round-trip works: writer resolved the correct encoding, and reader
+                // picked it up from the .vemq header end-to-end.
+                final SegmentReadState readState = KNN1040ScalarQuantizedTestUtils.writeQuantizedVectors(
+                    dir,
+                    "seg_bits_" + bits,
+                    new KNN1040ScalarQuantizedVectorsFormat(ScalarEncodingResolver.forDocBits(bits)),
+                    bits,
+                    random()
+                );
+
+                try (KnnVectorsReader rawReader = new Faiss1040ScalarQuantizedKnnVectorsFormat().fieldsReader(readState)) {
+                    assertTrue(rawReader instanceof Faiss1040ScalarQuantizedKnnVectorsReader);
+                    final FlatVectorsReader flatReader = ((Faiss1040ScalarQuantizedKnnVectorsReader) rawReader).getFlatVectorsReader();
+                    final FloatVectorValues values = flatReader.getFloatVectorValues(KNN1040ScalarQuantizedTestUtils.FIELD_NAME);
+                    assertNotNull("Values must exist for field written with bits=" + bits, values);
+                    assertEquals(
+                        "bits=" + bits + " must produce " + KNN1040ScalarQuantizedTestUtils.NUM_VECTORS + " vectors",
+                        KNN1040ScalarQuantizedTestUtils.NUM_VECTORS,
+                        values.size()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Fail-loud invariant: if an SQ field with {@code bits=0} reaches the writer via
+     * {@code addField()}, the lazy encoding resolver must throw rather than silently default to
+     * 1-bit. This is the exact silent-default failure mode this refactor was written to eliminate.
+     */
+    @SneakyThrows
+    public void testFieldsWriter_addFieldWithBitsZero_thenThrows() {
+        final FieldInfo malformedSqField = mock(FieldInfo.class);
+        Mockito.when(malformedSqField.getName()).thenReturn("malformed_sq_field");
+        // Syntactically valid SQ_CONFIG with a zero-bits payload — bypasses SQConfigParser's
+        // "empty means SQConfig.EMPTY" shortcut and hits the fail-loud guard in the resolver.
+        Mockito.when(malformedSqField.getAttribute(SQ_CONFIG)).thenReturn("bits=0");
+
+        final KnnVectorsWriter writer = buildWriterForSegmentWithField(malformedSqField);
+        try {
+            final IllegalStateException ex = expectThrows(IllegalStateException.class, () -> writer.addField(malformedSqField));
+            assertTrue(
+                "Expected fail-loud message mentioning bits and the field name, got: " + ex.getMessage(),
+                ex.getMessage().contains("bits") && ex.getMessage().contains("malformed_sq_field")
+            );
+        } finally {
+            writer.close();
+        }
+    }
+
+    /**
+     * Builds a writer through the no-arg (SPI) constructor path, with a segment containing the
+     * given field. Encoding resolution is deferred until {@code addField()} is called on the
+     * returned writer — this mirrors the actual Lucene write path.
+     */
+    @SneakyThrows
+    private KnnVectorsWriter buildWriterForSegmentWithField(FieldInfo fieldInfo) {
+        final SegmentInfo segmentInfo = new SegmentInfo(
+            mock(Directory.class),
+            mock(Version.class),
+            mock(Version.class),
+            "test-segment",
+            0,
+            false,
+            false,
+            mock(Codec.class),
+            mock(Map.class),
+            new byte[16],
+            mock(Map.class),
+            mock(Sort.class)
+        );
+
+        final Directory directory = mock(Directory.class);
+        Mockito.when(directory.createOutput(anyString(), any())).thenReturn(mock(IndexOutput.class));
+
+        final FieldInfos writeFieldInfos = mock(FieldInfos.class);
+        Mockito.when(writeFieldInfos.iterator()).thenReturn(List.of(fieldInfo).iterator());
+
+        final SegmentWriteState writeState = new SegmentWriteState(
+            mock(InfoStream.class),
+            directory,
+            segmentInfo,
+            writeFieldInfos,
+            null,
+            mock(IOContext.class)
+        );
+
+        final Faiss1040ScalarQuantizedKnnVectorsFormat format = new Faiss1040ScalarQuantizedKnnVectorsFormat();
+        try (MockedStatic<CodecUtil> mockedCodecUtil = Mockito.mockStatic(CodecUtil.class)) {
+            mockedCodecUtil.when(
+                () -> CodecUtil.writeIndexHeader(any(IndexOutput.class), anyString(), anyInt(), any(byte[].class), anyString())
+            ).thenAnswer((Answer<Void>) invocation -> null);
+            return format.fieldsWriter(writeState);
+        }
     }
 
     @SneakyThrows
@@ -202,7 +256,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
             0,
             false,
             false,
-            mock(org.apache.lucene.codecs.Codec.class),
+            mock(Codec.class),
             mock(Map.class),
             new byte[16],
             mock(Map.class),
@@ -213,25 +267,21 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         final IndexInput input = mock(IndexInput.class);
         Mockito.when(directory.openInput(any(), any())).thenReturn(input);
 
-        final FieldInfos fieldInfos = mock(FieldInfos.class);
-        Mockito.when(fieldInfos.iterator()).thenReturn(new Iterator<FieldInfo>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
+        // Segment carries a single SQ field (bits=1) — the format's read path resolves encoding
+        // per-field from SQ_CONFIG just like the write path.
+        final FieldInfo sqFieldInfo = mock(FieldInfo.class);
+        Mockito.when(sqFieldInfo.getName()).thenReturn("test-field");
+        Mockito.when(sqFieldInfo.getAttribute(SQ_CONFIG)).thenReturn(SQConfigParser.toCsv(SQConfig.builder().bits(1).build()));
 
-            @Override
-            public FieldInfo next() {
-                return null;
-            }
-        });
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        Mockito.when(fieldInfos.iterator()).thenReturn(List.of(sqFieldInfo).iterator());
 
         final SegmentReadState mockedSegmentReadState = new SegmentReadState(
             directory,
             mockedSegmentInfo,
             fieldInfos,
             mock(IOContext.class),
-            "test-segment-suffix"
+            ""
         );
 
         final Faiss1040ScalarQuantizedKnnVectorsFormat format = new Faiss1040ScalarQuantizedKnnVectorsFormat();
@@ -256,7 +306,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
             SegmentReadState readState = KNN1040ScalarQuantizedTestUtils.writeQuantizedVectors(
                 dir,
-                Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+                new KNN1040ScalarQuantizedVectorsFormat(),
                 random()
             );
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
@@ -24,11 +24,14 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -39,6 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
 
 @Log4j2
 public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
@@ -133,6 +137,59 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
     public void testToString_thenContainsFormatInfo() {
         final String str = new Faiss1040ScalarQuantizedKnnVectorsFormat().toString();
         assertTrue(str.contains(Faiss1040ScalarQuantizedKnnVectorsFormat.class.getSimpleName()));
+    }
+
+    public void testDefaultConstructor_usesOneBitEncoding() {
+        // Backward-compatibility: no-arg and single-arg constructors must still resolve to the
+        // 1-bit flat format that shipped in 3.x. Any change here would silently switch existing
+        // indices to a different encoding on the next segment write.
+        assertSame(
+            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat())
+        );
+        assertSame(
+            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory()))
+        );
+    }
+
+    public void testExplicitEncoding_selectsMatchingFlatFormat() {
+        // Verify each supported encoding wires through to a distinct flat format instance.
+        // Cache-sharing means repeated construction with the same encoding returns the same
+        // underlying format; different encodings return different instances.
+        for (ScalarEncoding encoding : new ScalarEncoding[] {
+            ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE,
+            ScalarEncoding.DIBIT_QUERY_NIBBLE,
+            ScalarEncoding.PACKED_NIBBLE }) {
+            Faiss1040ScalarQuantizedKnnVectorsFormat first = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                    INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
+                new NativeIndexBuildStrategyFactory(),
+                encoding
+            );
+            Faiss1040ScalarQuantizedKnnVectorsFormat second = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                    INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
+                new NativeIndexBuildStrategyFactory(),
+                encoding
+            );
+            assertSame("Flat format for " + encoding + " should be cached and reused", reflectFlatFormat(first), reflectFlatFormat(second));
+        }
+
+        // Different encodings must produce different flat format instances.
+        assertNotSame(
+            reflectFlatFormat(
+                new Faiss1040ScalarQuantizedKnnVectorsFormat(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory(), ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
+            ),
+            reflectFlatFormat(
+                new Faiss1040ScalarQuantizedKnnVectorsFormat(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory(), ScalarEncoding.DIBIT_QUERY_NIBBLE)
+            )
+        );
+    }
+
+    @SneakyThrows
+    private static KNN1040ScalarQuantizedVectorsFormat reflectFlatFormat(Faiss1040ScalarQuantizedKnnVectorsFormat format) {
+        java.lang.reflect.Field field = Faiss1040ScalarQuantizedKnnVectorsFormat.class.getDeclaredField("faissSqFlatFormat");
+        field.setAccessible(true);
+        return (KNN1040ScalarQuantizedVectorsFormat) field.get(format);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -264,6 +264,93 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
         verify(flatVectorsWriter, Mockito.never()).close();
     }
 
+    /**
+     * Test: after flush() finished + closed the flat writer inline, a subsequent close() is a
+     * no-op — must NOT re-close the writer. Guards the "flat writer done" invariant.
+     */
+    @SneakyThrows
+    public void testClose_afterFlush_thenNoOp() {
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
+        try {
+            objectUnderTest.flush(0, null);
+        } catch (Exception ignored) {
+            // The mocked FieldInfo doesn't wire indexOptions, so the native-build path inside
+            // flush() throws — but the flat-writer finish+close (and flatWriterDone flag) run
+            // BEFORE that, which is what this test exercises.
+        }
+        // flush() already closed the writer once — reset to distinguish the second call.
+        Mockito.reset(flatVectorsWriter);
+
+        objectUnderTest.close();
+        verify(flatVectorsWriter, Mockito.never()).close();
+    }
+
+    /**
+     * Test: after mergeOneField() finished + closed the flat writer inline, a subsequent
+     * close() is a no-op — must NOT re-close the writer.
+     */
+    @SneakyThrows
+    public void testClose_afterMergeOneField_thenNoOp() {
+        final FieldInfo fi = mockFieldInfo(0);
+        try {
+            objectUnderTest.mergeOneField(fi, mock(MergeState.class));
+        } catch (Exception ignored) {
+            // Mock plumbing may throw during native build — we only care that flatWriterDone
+            // is set by the finish+close block that precedes the native build.
+        }
+        Mockito.reset(flatVectorsWriter);
+
+        objectUnderTest.close();
+        verify(flatVectorsWriter, Mockito.never()).close();
+    }
+
+    /**
+     * Test: calling mergeOneField() after flush() has finished+closed the flat writer must fail
+     * loud rather than silently write to a closed writer. The flatWriterDone guard in
+     * getOrInitFlatVectorsWriter is the enforcement point.
+     */
+    @SneakyThrows
+    public void testMergeOneField_afterFlush_thenThrowsIllegalState() {
+        final FieldInfo fi1 = mockFieldInfo(0);
+        objectUnderTest.addField(fi1);
+        try {
+            objectUnderTest.flush(0, null);
+        } catch (Exception ignored) {
+            // The mocked FieldInfo doesn't wire indexOptions, so the native-build path inside
+            // flush() throws — but the flat-writer finish+close (and flatWriterDone flag) run
+            // BEFORE that, which is what this test exercises.
+        }
+
+        final FieldInfo fi2 = mockFieldInfo(1);
+        IllegalStateException ex = expectThrows(
+            IllegalStateException.class,
+            () -> objectUnderTest.mergeOneField(fi2, mock(MergeState.class))
+        );
+        assertTrue("Expected error to mention 'flat writer'; got: " + ex.getMessage(), ex.getMessage().contains("flat writer"));
+    }
+
+    /**
+     * Test: a second mergeOneField call on the same writer instance must fail loud — the writer
+     * only supports a single field, and the flat writer is closed inline after the first merge.
+     */
+    @SneakyThrows
+    public void testMergeOneField_calledTwice_thenThrowsIllegalState() {
+        final FieldInfo fi1 = mockFieldInfo(0);
+        try {
+            objectUnderTest.mergeOneField(fi1, mock(MergeState.class));
+        } catch (Exception ignored) {
+            // Mock plumbing may throw during native build — flatWriterDone is set beforehand.
+        }
+
+        final FieldInfo fi2 = mockFieldInfo(1);
+        IllegalStateException ex = expectThrows(
+            IllegalStateException.class,
+            () -> objectUnderTest.mergeOneField(fi2, mock(MergeState.class))
+        );
+        assertTrue("Expected error to mention 'flat writer'; got: " + ex.getMessage(), ex.getMessage().contains("flat writer"));
+    }
+
     // ===================== ramBytesUsed =====================
 
     /**

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
@@ -93,10 +94,16 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
+        // Stub flat format that returns the mocked writer/reader — bypasses per-field resolution
+        // so this test can focus on the wrapper writer's behavior.
+        final KNN1040ScalarQuantizedVectorsFormat stubFlatFormat = mock(KNN1040ScalarQuantizedVectorsFormat.class);
+        when(stubFlatFormat.fieldsWriter(any(SegmentWriteState.class))).thenReturn(flatVectorsWriter);
+        when(stubFlatFormat.fieldsReader(any(SegmentReadState.class))).thenAnswer(
+            invocation -> quantizedFlatVectorsReaderSupplier.apply(invocation.getArgument(0))
+        );
         objectUnderTest = new Faiss1040ScalarQuantizedKnnVectorsWriter(
             segmentWriteState,
-            flatVectorsWriter,
-            quantizedFlatVectorsReaderSupplier,
+            fieldInfo -> stubFlatFormat,
             new NativeIndexBuildStrategyFactory(),
             ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
         );
@@ -144,23 +151,28 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
     // ===================== flush (mocked — tests that don't reach openFlatVectorsReader) =====================
 
     /**
-     * Test: flush with no field added delegates flush/finish/close to flat writer, skips native build.
+     * Test: flush before any addField() is a no-op — the flat writer is only lazily constructed
+     * on the first addField()/mergeOneField(), so nothing to flush and no native build to run.
      */
     @SneakyThrows
-    public void testFlush_whenNoFieldAdded_thenOnlyDelegatesFlat() {
+    public void testFlush_whenNoFieldAdded_thenNoOp() {
         objectUnderTest.flush(5, null);
-        verify(flatVectorsWriter).flush(5, null);
-        verify(flatVectorsWriter).finish();
-        verify(flatVectorsWriter).close();
+        verify(flatVectorsWriter, Mockito.never()).flush(anyInt(), any());
+        verify(flatVectorsWriter, Mockito.never()).finish();
+        verify(flatVectorsWriter, Mockito.never()).close();
     }
 
     /**
-     * Test: flush passes a non-null sortMap through to the flat writer.
+     * Test: flush passes a non-null sortMap through to the flat writer once a field has been added.
      */
     @SneakyThrows
     public void testFlush_withSortMap_passesThroughToFlatWriter() {
-        org.apache.lucene.index.Sorter.DocMap sortMap = mock(org.apache.lucene.index.Sorter.DocMap.class);
-        objectUnderTest.flush(10, sortMap);
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
+        // Stub the flat reader open so flush() doesn't blow up trying to reflect real files.
+        doThrow(new IOException("stop after flat flush")).when(flatVectorsWriter).flush(anyInt(), any());
+        final Sorter.DocMap sortMap = mock(Sorter.DocMap.class);
+        expectThrows(IOException.class, () -> objectUnderTest.flush(10, sortMap));
         verify(flatVectorsWriter).flush(10, sortMap);
     }
 
@@ -223,28 +235,45 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
      * Test: close delegates to IOUtils.close(flatVectorsWriter).
      */
     @SneakyThrows
-    public void testClose_thenClosesFlatWriter() {
+    public void testClose_afterAddField_thenClosesFlatWriter() {
+        // Under lazy encoding resolution, close() only touches the flat writer if one exists —
+        // and one only exists after addField(). Seed a field first.
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
         objectUnderTest.close();
         verify(flatVectorsWriter).close();
     }
 
     /**
-     * Test: IOException from flatVectorsWriter.close() propagates.
+     * Test: IOException from flatVectorsWriter.close() propagates once a field has been added.
      */
     @SneakyThrows
     public void testClose_whenFlatWriterThrows_thenPropagates() {
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
         doThrow(new IOException("close failed")).when(flatVectorsWriter).close();
         expectThrows(IOException.class, () -> objectUnderTest.close());
+    }
+
+    /**
+     * Test: close() without any addField() is a no-op — the flat writer was never constructed.
+     */
+    @SneakyThrows
+    public void testClose_whenNoFieldAdded_thenNoOp() {
+        objectUnderTest.close();
+        verify(flatVectorsWriter, Mockito.never()).close();
     }
 
     // ===================== ramBytesUsed =====================
 
     /**
-     * Test: ramBytesUsed without a field returns SHALLOW_SIZE + flat writer's usage.
+     * Test: ramBytesUsed without a field returns only SHALLOW_SIZE — no flat writer allocated yet.
      */
-    public void testRamBytesUsed_whenNoField_thenReturnsShallowPlusFlatWriter() {
-        when(flatVectorsWriter.ramBytesUsed()).thenReturn(100L);
-        assertTrue(objectUnderTest.ramBytesUsed() > 100L);
+    public void testRamBytesUsed_whenNoField_thenShallowOnly() {
+        // Sanity: mock is untouched, so the return value doesn't include the flat writer.
+        final long ramUsed = objectUnderTest.ramBytesUsed();
+        assertTrue("Expected only SHALLOW_SIZE (>0) with no field added, got " + ramUsed, ramUsed > 0);
+        verify(flatVectorsWriter, Mockito.never()).ramBytesUsed();
     }
 
     /**
@@ -435,10 +464,14 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
                 FIELD_NAME
             );
 
+            final KNN1040ScalarQuantizedVectorsFormat stubFlatFormat = mock(KNN1040ScalarQuantizedVectorsFormat.class);
+            when(stubFlatFormat.fieldsWriter(any(SegmentWriteState.class))).thenReturn(flatVectorsWriter);
+            when(stubFlatFormat.fieldsReader(any(SegmentReadState.class))).thenAnswer(
+                invocation -> quantizedFlatVectorsReaderSupplier.apply(invocation.getArgument(0))
+            );
             Faiss1040ScalarQuantizedKnnVectorsWriter writer = new Faiss1040ScalarQuantizedKnnVectorsWriter(
                 realWriteState,
-                flatVectorsWriter,
-                quantizedFlatVectorsReaderSupplier,
+                fieldInfo -> stubFlatFormat,
                 new NativeIndexBuildStrategyFactory(),
                 ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
             );

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedTestUtils.java
@@ -22,11 +22,15 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 
 final class KNN1040ScalarQuantizedTestUtils {
 
@@ -42,6 +46,23 @@ final class KNN1040ScalarQuantizedTestUtils {
     // the directory outlives any readers opened from this state.
     static SegmentReadState writeQuantizedVectors(MMapDirectory dir, KNN1040ScalarQuantizedVectorsFormat format, Random random)
         throws Exception {
+        return writeQuantizedVectors(dir, "_0", format, 1, random);
+    }
+
+    /**
+     * Overload for tests that need to control the {@code SQ_CONFIG bits} attribute and the
+     * segment name (to write multiple segments in the same directory without collision).
+     */
+    static SegmentReadState writeQuantizedVectors(
+        MMapDirectory dir,
+        String segmentName,
+        KNN1040ScalarQuantizedVectorsFormat format,
+        int bits,
+        Random random
+    ) throws Exception {
+        // Set SQ_CONFIG so Faiss1040ScalarQuantizedKnnVectorsFormat can resolve the per-field
+        // encoding at fieldsReader() / addField() time.
+        final Map<String, String> attributes = Map.of(SQ_CONFIG, SQConfigParser.toCsv(SQConfig.builder().bits(bits).build()));
         final FieldInfo fieldInfo = new FieldInfo(
             FIELD_NAME,
             0,
@@ -52,7 +73,7 @@ final class KNN1040ScalarQuantizedTestUtils {
             DocValuesType.NONE,
             DocValuesSkipIndexType.NONE,
             -1,
-            Map.of(),
+            attributes,
             0,
             0,
             0,
@@ -68,7 +89,7 @@ final class KNN1040ScalarQuantizedTestUtils {
             dir,
             Version.LATEST,
             Version.LATEST,
-            "_0",
+            segmentName,
             NUM_VECTORS,
             false,
             false,

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
@@ -59,6 +59,61 @@ public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
         }
     }
 
+    /**
+     * For multi-bit encodings (B=2, B=4) the scorer must route to Lucene's reference scorer without
+     * touching {@code MemorySegmentAddressExtractorUtil} — native bulk SIMD is not wired for
+     * multi-bit yet. Parameterizing over {@link ScalarEncoding#DIBIT_QUERY_NIBBLE} and
+     * {@link ScalarEncoding#PACKED_NIBBLE} verifies the gate for both widths.
+     */
+    @SneakyThrows
+    private void assertMultiBitFallback(final ScalarEncoding encoding) {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040ScalarQuantizedVectorScorer scorer = new KNN1040ScalarQuantizedVectorScorer(mockDelegate);
+
+        final int dimension = 8;
+        final QuantizedByteVectorValues mockQuantizedValues = mock(QuantizedByteVectorValues.class);
+        when(mockQuantizedValues.dimension()).thenReturn(dimension);
+        when(mockQuantizedValues.getScalarEncoding()).thenReturn(encoding);
+
+        // Parent Lucene104ScalarQuantizedVectorScorer's reference path also runs a quantization —
+        // supply the same mocks the null-address test uses so it can complete without NPEs.
+        final OptimizedScalarQuantizer mockQuantizer = mock(OptimizedScalarQuantizer.class);
+        when(mockQuantizedValues.getQuantizer()).thenReturn(mockQuantizer);
+        when(mockQuantizedValues.getCentroid()).thenReturn(new float[dimension]);
+        final OptimizedScalarQuantizer.QuantizationResult quantizationResult = new OptimizedScalarQuantizer.QuantizationResult(
+            0.0f,
+            1.0f,
+            0.0f,
+            0
+        );
+        when(mockQuantizer.scalarQuantize(any(float[].class), any(byte[].class), anyByte(), any(float[].class))).thenReturn(
+            quantizationResult
+        );
+
+        final StubVectorValues stub = new StubVectorValues();
+        final java.lang.reflect.Field field = StubVectorValues.class.getDeclaredField("quantizedVectorValues");
+        field.setAccessible(true);
+        field.set(stub, mockQuantizedValues);
+
+        try (MockedStatic<MemorySegmentAddressExtractorUtil> mockedStatic = Mockito.mockStatic(MemorySegmentAddressExtractorUtil.class)) {
+            final RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, stub, new float[dimension]);
+
+            assertNotNull(result);
+            // The multi-bit gate must fire before we even ask about the address — no interaction.
+            mockedStatic.verifyNoInteractions();
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_whenTwoBitEncoding_thenRoutesToLuceneScorerWithoutAddressExtraction() {
+        assertMultiBitFallback(ScalarEncoding.DIBIT_QUERY_NIBBLE);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_whenFourBitEncoding_thenRoutesToLuceneScorerWithoutAddressExtraction() {
+        assertMultiBitFallback(ScalarEncoding.PACKED_NIBBLE);
+    }
+
     @SneakyThrows
     public void testGetRandomVectorScorer_whenAddressExtractionReturnsNull_thenFallsBackToLuceneScorer() {
         // Arrange: set up the mock delegate scorer
@@ -74,9 +129,11 @@ public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
         when(mockQuantizedValues.getSlice()).thenReturn(mockIndexInput);
         when(mockIndexInput.length()).thenReturn(1024L);
 
-        // Set up quantization mocks needed by the parent Lucene104ScalarQuantizedVectorScorer
+        // Set up quantization mocks needed by the parent Lucene104ScalarQuantizedVectorScorer.
+        // Encoding is SINGLE_BIT_QUERY_NIBBLE (docBits == 1) so the multi-bit fallback gate does
+        // not fire — this test exercises the address-extractor null fallback specifically.
         when(mockQuantizedValues.dimension()).thenReturn(dimension);
-        when(mockQuantizedValues.getScalarEncoding()).thenReturn(ScalarEncoding.UNSIGNED_BYTE);
+        when(mockQuantizedValues.getScalarEncoding()).thenReturn(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
 
         final OptimizedScalarQuantizer mockQuantizer = mock(OptimizedScalarQuantizer.class);
         when(mockQuantizedValues.getQuantizer()).thenReturn(mockQuantizer);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolverTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.opensearch.knn.KNNTestCase;
+
+public class ScalarEncodingResolverTests extends KNNTestCase {
+
+    public void testForDocBits_returnsExpectedEncoding() {
+        assertEquals(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, ScalarEncodingResolver.forDocBits(1));
+        assertEquals(ScalarEncoding.DIBIT_QUERY_NIBBLE, ScalarEncodingResolver.forDocBits(2));
+        assertEquals(ScalarEncoding.PACKED_NIBBLE, ScalarEncodingResolver.forDocBits(4));
+    }
+
+    public void testForDocBits_unsupportedBits_throws() {
+        for (int docBits : new int[] { 0, 3, 5, 7, 8, 16, -1 }) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> ScalarEncodingResolver.forDocBits(docBits));
+            assertTrue(
+                "Expected message to mention the unsupported bit width, got: " + ex.getMessage(),
+                ex.getMessage().contains(String.valueOf(docBits))
+            );
+            assertTrue("Expected message to list supported widths, got: " + ex.getMessage(), ex.getMessage().contains("[1, 2, 4]"));
+        }
+    }
+
+    public void testDocBits_isInverseOfForDocBits() {
+        for (int docBits : new int[] { 1, 2, 4 }) {
+            ScalarEncoding encoding = ScalarEncodingResolver.forDocBits(docBits);
+            assertEquals(docBits, ScalarEncodingResolver.docBits(encoding));
+        }
+    }
+
+    public void testDocBits_rejectsUnsupportedEncodings() {
+        // Encodings whose bit widths are not in SUPPORTED_DOC_BITS must fail loud so that unexpected
+        // Lucene encodings can never leak into downstream code that assumes bits ∈ {1, 2, 4}.
+        for (ScalarEncoding encoding : new ScalarEncoding[] { ScalarEncoding.SEVEN_BIT, ScalarEncoding.UNSIGNED_BYTE }) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> ScalarEncodingResolver.docBits(encoding));
+            assertTrue("Expected message to name the encoding, got: " + ex.getMessage(), ex.getMessage().contains(encoding.name()));
+            assertTrue("Expected message to list supported widths, got: " + ex.getMessage(), ex.getMessage().contains("[1, 2, 4]"));
+        }
+    }
+
+    public void testDocBits_nullEncoding_throwsNPE() {
+        expectThrows(NullPointerException.class, () -> ScalarEncodingResolver.docBits(null));
+    }
+
+    public void testQueryBits_isFourForAllSupportedEncodings() {
+        assertEquals(4, ScalarEncodingResolver.QUERY_BITS);
+        for (int docBits : new int[] { 1, 2, 4 }) {
+            ScalarEncoding encoding = ScalarEncodingResolver.forDocBits(docBits);
+            assertEquals(
+                "Encoding " + encoding + " should use " + ScalarEncodingResolver.QUERY_BITS + "-bit query",
+                ScalarEncodingResolver.QUERY_BITS,
+                encoding.getQueryBits()
+            );
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
@@ -275,6 +275,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
         when(quantizedValues.vectorValue(0)).thenReturn(new byte[] { 0x01 });
         when(quantizedValues.getCentroidDP()).thenReturn(1.0f);
         when(quantizedValues.size()).thenReturn(1);
+        when(quantizedValues.getScalarEncoding()).thenReturn(SINGLE_BIT_QUERY_NIBBLE);
         when(quantizedValues.getCorrectiveTerms(0)).thenReturn(new OptimizedScalarQuantizer.QuantizationResult(0.0f, 1.0f, 0.0f, 0));
 
         IndexOutputWithBuffer indexOutputWithBuffer = mock(IndexOutputWithBuffer.class);
@@ -294,7 +295,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
 
         try (MockedStatic<JNIService> mockedJNIService = Mockito.mockStatic(JNIService.class)) {
             mockedJNIService.when(
-                () -> JNIService.initFaissSQIndex(anyInt(), anyInt(), anyMap(), anyFloat(), anyInt(), any(KNNEngine.class))
+                () -> JNIService.initFaissSQIndex(anyInt(), anyInt(), anyMap(), anyFloat(), anyInt(), anyInt(), any(KNNEngine.class))
             ).thenReturn(fakeIndexAddress);
 
             // Phase 1 throws

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -408,12 +408,22 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
     public void testBuildRequestSQTwoBit() throws IOException {
         // Same wire contract as SQ 1-bit: fp32 vectors uploaded, RVIB builds the HNSW graph over
         // fp32 neighbors, data node stitches with locally-quantized .veq (2-bit) at search time.
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.TWO)
+            .compressionLevel(CompressionLevel.x16)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(2)
+            .build();
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
-            getMockSQParameterMap(2)
+            getMockSQParameterMap(2),
+            resolvedSpec
         );
         assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
         assertTrue(request.isSkipStoredVectors());
@@ -422,12 +432,22 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
     public void testBuildRequestSQFourBit() throws IOException {
         // Same wire contract as SQ 1-bit/2-bit — the data node quantizes to 4-bit codes locally
         // and uploads fp32 to RVIB, which produces an HNSW graph over the fp32 neighbors.
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x8)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(2)
+            .build();
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
-            getMockSQParameterMap(4)
+            getMockSQParameterMap(4),
+            resolvedSpec
         );
         assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
         assertTrue(request.isSkipStoredVectors());
@@ -436,12 +456,22 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
     public void testBuildRequestSQFP16_thenNoSkipStoredVectors() throws IOException {
         // Sanity: fp16 is not the MOS path, so skipStoredVectors must remain false — RVIB writes
         // its own flat storage in this case.
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x2)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(2)
+            .build();
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
-            getMockSQParameterMap(16)
+            getMockSQParameterMap(16),
+            resolvedSpec
         );
         assertFalse(request.isSkipStoredVectors());
     }

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -405,6 +405,73 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
         assertTrue(request.isSkipStoredVectors());
     }
 
+    public void testBuildRequestSQTwoBit() throws IOException {
+        // Same wire contract as SQ 1-bit: fp32 vectors uploaded, RVIB builds the HNSW graph over
+        // fp32 neighbors, data node stitches with locally-quantized .veq (2-bit) at search time.
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQParameterMap(2)
+        );
+        assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
+        assertTrue(request.isSkipStoredVectors());
+    }
+
+    public void testBuildRequestSQFourBit() throws IOException {
+        // Same wire contract as SQ 1-bit/2-bit — the data node quantizes to 4-bit codes locally
+        // and uploads fp32 to RVIB, which produces an HNSW graph over the fp32 neighbors.
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQParameterMap(4)
+        );
+        assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
+        assertTrue(request.isSkipStoredVectors());
+    }
+
+    public void testBuildRequestSQFP16_thenNoSkipStoredVectors() throws IOException {
+        // Sanity: fp16 is not the MOS path, so skipStoredVectors must remain false — RVIB writes
+        // its own flat storage in this case.
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQParameterMap(16)
+        );
+        assertFalse(request.isSkipStoredVectors());
+    }
+
+    private Map<String, Object> getMockSQParameterMap(int bits) {
+        Map<String, Object> encoderParams = Map.of(NAME, ENCODER_SQ, SQ_BITS, bits);
+        Map<String, Object> innerParams = Map.of(
+            METHOD_PARAMETER_EF_SEARCH,
+            24,
+            METHOD_PARAMETER_EF_CONSTRUCTION,
+            28,
+            METHOD_PARAMETER_M,
+            12,
+            METHOD_ENCODER_PARAMETER,
+            encoderParams
+        );
+        return Map.of(
+            INDEX_DESCRIPTION_PARAMETER,
+            "HNSW12,Flat",
+            SPACE_TYPE,
+            INNER_PRODUCT.getValue(),
+            NAME,
+            METHOD_HNSW,
+            VECTOR_DATA_TYPE_FIELD,
+            VectorDataType.FLOAT.getValue(),
+            PARAMETERS,
+            innerParams
+        );
+    }
+
     public void testBuildRequestFP16() throws IOException {
         ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
             .engine(KNNEngine.FAISS)

--- a/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
@@ -23,9 +23,12 @@ public class EncoderInterfaceTests extends KNNTestCase {
     public void testFaissSQEncoderType() {
         FaissSQEncoder encoder = new FaissSQEncoder();
         assertEquals(Encoder.EncoderType.SQ, encoder.getEncoderType());
+        // Multi-bit MOS (bits ∈ {1, 2, 4}) and legacy fp16 (bits=16) are supported.
         assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.ONE));
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.TWO));
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.FOUR));
         assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.SIXTEEN));
-        assertEquals(2, encoder.getSupportedBits().size());
+        assertEquals(4, encoder.getSupportedBits().size());
     }
 
     public void testLuceneSQEncoderType() {

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -301,6 +301,70 @@ public class EngineResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveEngine_whenFlatMethodWithExplicitLuceneEngine_thenThrow() {
+        // Flat is engine-agnostic — passing engine=lucene explicitly is rejected too.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            true
+        );
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, null, false)
+        );
+        assertTrue(ex.getMessage().contains(METHOD_FLAT));
+        assertTrue(ex.getMessage().toLowerCase(java.util.Locale.ROOT).contains("engine"));
+    }
+
+    public void testResolveEngine_whenFlatMethodWithNonLuceneMethodEngine_thenThrow() {
+        // Flat method + engine=faiss → mapping-time error.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            true
+        );
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, null, false)
+        );
+        assertTrue(ex.getMessage().contains(METHOD_FLAT));
+        assertTrue(ex.getMessage().toLowerCase(java.util.Locale.ROOT).contains("engine"));
+    }
+
+    public void testResolveEngine_whenFlatMethodWithTopLevelEngine_thenThrow() {
+        // Flat method + any top-level engine (Lucene or not) → mapping-time error.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.UNDEFINED,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            false
+        );
+        for (KNNEngine topLevel : new KNNEngine[] { KNNEngine.LUCENE, KNNEngine.FAISS }) {
+            MapperParsingException ex = expectThrows(
+                MapperParsingException.class,
+                () -> ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, topLevel.getName(), false)
+            );
+            assertTrue("topLevel=" + topLevel, ex.getMessage().contains(METHOD_FLAT));
+            assertTrue("topLevel=" + topLevel, ex.getMessage().toLowerCase(java.util.Locale.ROOT).contains("engine"));
+        }
+    }
+
+    public void testResolveEngine_whenFlatMethodWithPreGateVersion_thenLucene() {
+        // Pre-gate flat mappings that had engine=lucene persisted must still resolve without throwing.
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of()),
+            true
+        );
+        assertEquals(
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), flatMethodContext, null, false, Version.V_3_7_0)
+        );
+    }
+
     public void testResolveEngine_whenOnDiskWith32xCompression_thenFaiss() {
         assertEquals(
             KNNEngine.FAISS,

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -281,6 +281,36 @@ public class KNNMethodContextTests extends KNNTestCase {
         assertEquals(KNNEngine.LUCENE.getName(), out.get(KNN_ENGINE));
     }
 
+    /**
+     * Regression guard: {@link KNNMethodContext#setKnnEngine} must NOT flip
+     * {@code isEngineConfigured=true} as a side effect. That flag reflects "user provided engine
+     * in the mapping source"; if an internal resolver's {@code setKnnEngine(LUCENE)} call flipped
+     * it, {@code toXContent} would emit {@code engine=lucene} on the mapping's assertSerialization
+     * round-trip, which would then be rejected by
+     * {@code EngineResolver.rejectEngineForMethodFlat} because it looks user-supplied.
+     */
+    public void testSetKnnEngine_doesNotFlipIsEngineConfigured() throws IOException {
+        // Parse a flat mapping WITHOUT engine — isEngineConfigured must start false.
+        XContentBuilder in = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_FLAT)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .endObject();
+        KNNMethodContext ctx = KNNMethodContext.parse(xContentBuilderToMap(in));
+        assertFalse("isEngineConfigured must be false when user's mapping has no engine", ctx.isEngineConfigured());
+
+        // Internal resolver calls setKnnEngine to attach the resolved engine — must NOT flip the flag.
+        ctx.setKnnEngine(KNNEngine.LUCENE);
+        assertEquals("engine should be set to the resolved value", KNNEngine.LUCENE, ctx.getKnnEngine());
+        assertFalse("setKnnEngine must not flip isEngineConfigured", ctx.isEngineConfigured());
+
+        // toXContent round-trip: engine must NOT be emitted since user didn't configure it.
+        XContentBuilder out = XContentFactory.jsonBuilder().startObject();
+        ctx.toXContent(out, ToXContent.EMPTY_PARAMS).endObject();
+        Map<String, Object> serialized = xContentBuilderToMap(out);
+        assertFalse("engine must not be serialized on flat when not user-configured", serialized.containsKey(KNN_ENGINE));
+    }
+
     public void testEquals() {
         SpaceType spaceType1 = SpaceType.L1;
         SpaceType spaceType2 = SpaceType.L2;

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.opensearch.core.common.io.stream.StreamInput;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
@@ -230,6 +231,54 @@ public class KNNMethodContextTests extends KNNTestCase {
         assertEquals(methodName, out.get(NAME));
         assertEquals(spaceType, out.get(METHOD_PARAMETER_SPACE_TYPE));
         assertEquals(knnEngine, out.get(KNN_ENGINE));
+    }
+
+    /**
+     * Flat method with no engine in the source mapping (post-gate index) — engine must NOT be
+     * serialized. Round-trip re-parse would otherwise be rejected by
+     * {@code EngineResolver.rejectEngineForMethodFlat}.
+     */
+    public void testToXContent_flatMethod_whenEngineNotConfigured_thenEngineOmitted() throws IOException {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_FLAT)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        assertFalse("isEngineConfigured should be false for flat without engine", knnMethodContext.isEngineConfigured());
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder = knnMethodContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+
+        Map<String, Object> out = xContentBuilderToMap(builder);
+        assertEquals(METHOD_FLAT, out.get(NAME));
+        assertFalse("KNN_ENGINE must be omitted for flat when not user-configured", out.containsKey(KNN_ENGINE));
+    }
+
+    /**
+     * BWC: a pre-gate index persisted {@code engine=lucene} on its flat mapping. Re-serialization
+     * on a new node must preserve the {@code engine} attribute so rolling-upgrade round-trips
+     * (cluster state, snapshot metadata) don't drop it and cause mapping divergence between
+     * old and new nodes.
+     */
+    public void testToXContent_flatMethod_whenEngineConfigured_thenEnginePreserved() throws IOException {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_FLAT)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        assertTrue("isEngineConfigured should be true when engine was in the source", knnMethodContext.isEngineConfigured());
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder = knnMethodContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+
+        Map<String, Object> out = xContentBuilderToMap(builder);
+        assertEquals(METHOD_FLAT, out.get(NAME));
+        assertEquals(KNNEngine.LUCENE.getName(), out.get(KNN_ENGINE));
     }
 
     public void testEquals() {

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -435,6 +435,72 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
         assertTrue(spec.supportsRemoteIndexBuild());
     }
 
+    public void testSupportsRemoteIndexBuild_FaissSQ2BitSupported() {
+        ResolvedIndexSpec spec = baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).build();
+        assertTrue(spec.supportsRemoteIndexBuild());
+    }
+
+    public void testSupportsRemoteIndexBuild_FaissSQ4BitSupported() {
+        ResolvedIndexSpec spec = baseFaissSQMultiBit(Encoder.QuantizationBits.FOUR, CompressionLevel.x8).build();
+        assertTrue(spec.supportsRemoteIndexBuild());
+    }
+
+    // --- Coverage: isSQMultiBit (bits ∈ {1, 2, 4}) ---
+
+    public void testIsSQMultiBit_true_forBits1() {
+        assertTrue(baseFaissSQ1Bit().build().isSQMultiBit());
+    }
+
+    public void testIsSQMultiBit_true_forBits2() {
+        assertTrue(baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).build().isSQMultiBit());
+    }
+
+    public void testIsSQMultiBit_true_forBits4() {
+        assertTrue(baseFaissSQMultiBit(Encoder.QuantizationBits.FOUR, CompressionLevel.x8).build().isSQMultiBit());
+    }
+
+    public void testIsSQMultiBit_false_forBits16() {
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x2)
+            .build();
+        assertFalse(spec.isSQMultiBit());
+    }
+
+    public void testIsSQMultiBit_false_forFlatEncoder() {
+        // FLAT encoder + bits=TWO (nonsense combination) still returns false — gate requires SQ encoder.
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.FLAT).quantizationBits(Encoder.QuantizationBits.TWO).build();
+        assertFalse(spec.isSQMultiBit());
+    }
+
+    // --- Coverage: isFaissSQMultiBit (Faiss engine + SQ multi-bit) ---
+
+    public void testIsFaissSQMultiBit_FaissSQ2Bit_true() {
+        assertTrue(baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).build().isFaissSQMultiBit());
+    }
+
+    public void testIsFaissSQMultiBit_LuceneSQ2Bit_false() {
+        // Same SQ config on Lucene engine — gate is Faiss-only, mirrors isFaissSQOneBit.
+        ResolvedIndexSpec spec = baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).engine(KNNEngine.LUCENE).build();
+        assertFalse(spec.isFaissSQMultiBit());
+    }
+
+    // --- Coverage: alwaysUseMemoryOptimizedSearch broadened to bits ∈ {1, 2, 4} ---
+
+    public void testAlwaysUseMemoryOptimizedSearch_forBits2() {
+        assertTrue(baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).build().alwaysUseMemoryOptimizedSearch());
+    }
+
+    public void testAlwaysUseMemoryOptimizedSearch_forBits4() {
+        assertTrue(baseFaissSQMultiBit(Encoder.QuantizationBits.FOUR, CompressionLevel.x8).build().alwaysUseMemoryOptimizedSearch());
+    }
+
+    public void testAlwaysUseMemoryOptimizedSearch_forBits2_IVFExcluded() {
+        // Same IVF exclusion applies to bits=2 as to bits=1 — multi-bit + IVF is not a supported combination.
+        ResolvedIndexSpec spec = baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).methodName(METHOD_IVF).build();
+        assertFalse(spec.alwaysUseMemoryOptimizedSearch());
+    }
+
     private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaiss() {
         return ResolvedIndexSpec.builder()
             .engine(KNNEngine.FAISS)
@@ -449,5 +515,12 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
         return baseFaiss().encoderType(Encoder.EncoderType.SQ)
             .quantizationBits(Encoder.QuantizationBits.ONE)
             .compressionLevel(CompressionLevel.x32);
+    }
+
+    private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaissSQMultiBit(
+        final Encoder.QuantizationBits bits,
+        final CompressionLevel compressionLevel
+    ) {
+        return baseFaiss().encoderType(Encoder.EncoderType.SQ).quantizationBits(bits).compressionLevel(compressionLevel);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -163,6 +163,30 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
         assertEquals(expected, spec.getRescoreContext());
     }
 
+    public void testRescoreContext_SQ2Bit_thenOversampleOne() {
+        // bits=2 (x16) uses SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR (=1) since 2-bit codes recover
+        // most recall on their own. Override disallowed, mirrors the SQ 1-bit contract.
+        ResolvedIndexSpec spec = baseFaissSQMultiBit(Encoder.QuantizationBits.TWO, CompressionLevel.x16).build();
+        RescoreContext expected = RescoreContext.builder()
+            .oversampleFactor(RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR)
+            .allowOverrideOversampleFactor(false)
+            .userProvided(false)
+            .build();
+        assertEquals(expected, spec.getRescoreContext());
+    }
+
+    public void testRescoreContext_SQ4Bit_thenOversampleOne() {
+        // bits=4 (x8) uses SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR (=1) since 4-bit codes are
+        // near-lossless. Override disallowed, mirrors the SQ 1-bit contract.
+        ResolvedIndexSpec spec = baseFaissSQMultiBit(Encoder.QuantizationBits.FOUR, CompressionLevel.x8).build();
+        RescoreContext expected = RescoreContext.builder()
+            .oversampleFactor(RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR)
+            .allowOverrideOversampleFactor(false)
+            .userProvided(false)
+            .build();
+        assertEquals(expected, spec.getRescoreContext());
+    }
+
     public void testRescoreContext_x1ReturnsNull() {
         ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
@@ -173,7 +197,9 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRescoreContext_x32OnDiskAboveThreshold() {
-        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
+        // BQ (binary quantization) at x32 — falls through to the compression-level default (3.0f).
+        // Uses BQ (not SQ) so the encoder-type gate on isSQMultiBit() is skipped.
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.BQ)
             .quantizationBits(Encoder.QuantizationBits.FOUR)
             .compressionLevel(CompressionLevel.x32)
             .mode(Mode.ON_DISK)
@@ -184,7 +210,8 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRescoreContext_x32OnDiskBelowThreshold() {
-        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
+        // BQ at x32 with dim below threshold — uses OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD.
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.BQ)
             .quantizationBits(Encoder.QuantizationBits.FOUR)
             .compressionLevel(CompressionLevel.x32)
             .mode(Mode.ON_DISK)
@@ -253,11 +280,14 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRescoreContext_x32LuceneAfterV360_NonSQ1Bit() {
+        // Lucene SQ 7-bit at x32 after V360 — falls through to the Lucene scalar quantizer default.
+        // Uses bits=SEVEN (a real Lucene SQ width) rather than a multi-bit MOS width so the
+        // isSQMultiBit() gate is skipped and the Lucene-specific x32 branch fires.
         ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
             .engine(KNNEngine.LUCENE)
             .methodName(METHOD_HNSW)
             .encoderType(Encoder.EncoderType.SQ)
-            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .quantizationBits(Encoder.QuantizationBits.SEVEN)
             .compressionLevel(CompressionLevel.x32)
             .mode(Mode.ON_DISK)
             .vectorDataType(VectorDataType.FLOAT)
@@ -272,7 +302,8 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRescoreContext_NotOnDiskReturnsNull() {
-        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
+        // BQ at x32 with mode=NOT_CONFIGURED — isModeValidForRescore returns false, so no rescore.
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.BQ)
             .quantizationBits(Encoder.QuantizationBits.FOUR)
             .compressionLevel(CompressionLevel.x32)
             .mode(Mode.NOT_CONFIGURED)

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -187,6 +187,41 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
         assertEquals(expected, spec.getRescoreContext());
     }
 
+    public void testRescoreContext_FlatMethodX16_thenOversampleOne() {
+        // method=flat with x16 (Lucene 2-bit SQ) uses SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR (=1)
+        // for the same reason as the SQ encoder + bits=2 path — 2-bit codes recover most recall on
+        // their own. Overrides allowed (unlike the SQ encoder branch), matching the x32-flat pattern.
+        ResolvedIndexSpec spec = baseFaiss().methodName(METHOD_FLAT)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x16)
+            .mode(Mode.ON_DISK)
+            .dimension(1500)
+            .build();
+        RescoreContext expected = RescoreContext.builder()
+            .oversampleFactor(RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR)
+            .userProvided(false)
+            .build();
+        assertEquals(expected, spec.getRescoreContext());
+    }
+
+    public void testRescoreContext_FlatMethodX8_thenOversampleOne() {
+        // method=flat with x8 (Lucene 4-bit SQ) uses SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR (=1)
+        // for the same reason as the SQ encoder + bits=4 path — 4-bit codes are near-lossless.
+        ResolvedIndexSpec spec = baseFaiss().methodName(METHOD_FLAT)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x8)
+            .mode(Mode.ON_DISK)
+            .dimension(1500)
+            .build();
+        RescoreContext expected = RescoreContext.builder()
+            .oversampleFactor(RescoreContext.SQ_MULTI_BIT_DEFAULT_OVERSAMPLE_FACTOR)
+            .userProvided(false)
+            .build();
+        assertEquals(expected, spec.getRescoreContext());
+    }
+
     public void testRescoreContext_x1ReturnsNull() {
         ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
@@ -138,7 +138,9 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         );
     }
 
-    public void testResolve_whenCalledWithFieldContext_andSQNonOneBitSpec_thenReturnsNativeFormat() {
+    public void testResolve_whenCalledWithFieldContext_andSQSixteenBitSpec_thenReturnsNativeFormat() {
+        // SQ bits=16 (fp16) does NOT go through the multi-bit MOS path — falls through to the
+        // default native format. Only bits ∈ {1, 2, 4} route to Faiss1040ScalarQuantizedKnnVectorsFormat.
         MapperService mapperService = mock(MapperService.class);
         IndexSettings indexSettings = mock(IndexSettings.class);
         when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
@@ -146,13 +148,13 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
 
         FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(mapperService, mock(NativeIndexBuildStrategyFactory.class));
 
-        ResolvedIndexSpec sqFourBitSpec = ResolvedIndexSpec.builder()
+        ResolvedIndexSpec sqSixteenBitSpec = ResolvedIndexSpec.builder()
             .engine(KNNEngine.FAISS)
             .encoderType(Encoder.EncoderType.SQ)
-            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
             .build();
 
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, sqFourBitSpec);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, sqSixteenBitSpec);
         assertTrue(
             "Expected NativeEngines990KnnVectorsFormat but got " + result.getClass().getSimpleName(),
             result instanceof NativeEngines990KnnVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -176,7 +176,8 @@ public class FaissSQEncoderTests extends KNNTestCase {
             .dimension(128)
             .build();
 
-        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 2));
+        // Valid bits are {1, 2, 4, 16}. Use 3 as an unambiguously invalid value.
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 3));
         assertNotNull(methodComponent.validate(mcc, context));
     }
 
@@ -359,4 +360,68 @@ public class FaissSQEncoderTests extends KNNTestCase {
             .compressionLevel(compressionLevel)
             .build();
     }
+
+    // --- bits=2 / bits=4 (multi-bit MOS quantization) ---
+
+    public void testBits2_libraryIndexingContext() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponent methodComponent = encoder.getMethodComponent();
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 2));
+        KNNLibraryIndexingContext indexingContext = methodComponent.getKNNLibraryIndexingContext(mcc, context);
+
+        Map<String, Object> params = indexingContext.getLibraryParameters();
+        assertEquals(FAISS_FLAT_DESCRIPTION, params.get(INDEX_DESCRIPTION_PARAMETER));
+        assertEquals(ENCODER_SQ, params.get("name"));
+        assertEquals(2, params.get(SQ_BITS));
+    }
+
+    public void testBits4_libraryIndexingContext() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponent methodComponent = encoder.getMethodComponent();
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 4));
+        KNNLibraryIndexingContext indexingContext = methodComponent.getKNNLibraryIndexingContext(mcc, context);
+
+        Map<String, Object> params = indexingContext.getLibraryParameters();
+        assertEquals(FAISS_FLAT_DESCRIPTION, params.get(INDEX_DESCRIPTION_PARAMETER));
+        assertEquals(ENCODER_SQ, params.get("name"));
+        assertEquals(4, params.get(SQ_BITS));
+    }
+
+    public void testBits2_compressionLevel() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 2));
+        assertEquals(CompressionLevel.x16, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testBits4_compressionLevel() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 4));
+        assertEquals(CompressionLevel.x8, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    // --- isSQCodedBits utility ---
+
+    public void testIsSQCodedBits() {
+        assertTrue(FaissSQEncoder.isSQCodedBits(1));
+        assertTrue(FaissSQEncoder.isSQCodedBits(2));
+        assertTrue(FaissSQEncoder.isSQCodedBits(4));
+        // fp16 is SQ but stores compressed floats, not integer-coded bits
+        assertFalse(FaissSQEncoder.isSQCodedBits(16));
+        for (int bits : new int[] { 0, 3, 5, 7, 8, -1 }) {
+            assertFalse("Expected " + bits + " to not be SQ-coded bits", FaissSQEncoder.isSQCodedBits(bits));
+        }
+    }
+
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolverTests.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 
@@ -64,9 +65,50 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
         assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
     }
 
+    public void testResolveMethod_whenFlatMethodWithX16Compression_thenResolve() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Map.of())
+        );
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            flatMethodContext,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x16)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(METHOD_FLAT, resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getName());
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenFlatMethodWithX8Compression_thenResolve() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.INNER_PRODUCT,
+            new MethodComponentContext(METHOD_FLAT, Map.of())
+        );
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            flatMethodContext,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x8)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        assertEquals(METHOD_FLAT, resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getName());
+        assertEquals(CompressionLevel.x8, resolvedMethodContext.getCompressionLevel());
+    }
+
     public void testResolveMethod_whenFlatMethodWithUnsupportedCompression_thenThrow() {
+        final Set<CompressionLevel> supported = Set.of(CompressionLevel.x8, CompressionLevel.x16, CompressionLevel.x32);
         for (CompressionLevel level : CompressionLevel.values()) {
-            if (level == CompressionLevel.x32 || level == CompressionLevel.NOT_CONFIGURED) {
+            if (supported.contains(level) || level == CompressionLevel.NOT_CONFIGURED) {
                 continue;
             }
             KNNMethodContext flatMethodContext = new KNNMethodContext(
@@ -74,7 +116,7 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
                 SpaceType.L2,
                 new MethodComponentContext(METHOD_FLAT, Map.of())
             );
-            expectThrows(
+            ValidationException ex = expectThrows(
                 ValidationException.class,
                 () -> TEST_RESOLVER.resolveMethod(
                     flatMethodContext,
@@ -87,6 +129,13 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
                     SpaceType.L2
                 )
             );
+            final String msg = ex.getMessage();
+            assertTrue("level=" + level + " msg=" + msg, msg.contains("[" + METHOD_FLAT + "]"));
+            assertTrue("level=" + level + " msg=" + msg, msg.contains("only supports these compression levels"));
+            // The message should list the supported levels — spot-check each name is present.
+            for (CompressionLevel supportedLevel : supported) {
+                assertTrue("level=" + level + " supportedLevel=" + supportedLevel + " msg=" + msg, msg.contains(supportedLevel.getName()));
+            }
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -239,24 +239,12 @@ public class CompressionLevelTests extends KNNTestCase {
         assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
     }
 
-    public void testGetRescoreContext_whenNonSQOneBitEncoder_thenFallsBackToNormalLogic() {
-        // Non-sq(bits=1) encoder should fall through to normal compression level logic
+    public void testGetRescoreContext_whenNonSQMultiBitEncoder_thenFallsBackToNormalLogic() {
+        // Non-SQ-multi-bit encoders (FLAT, BQ, etc.) should fall through to normal compression-level
+        // logic — dim-below-threshold → OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD.
+        // SQ multi-bit (bits ∈ {1,2,4}) has its own fixed-oversample branch — covered by
+        // ResolvedIndexSpecTests.testRescoreContext_SQ{1,2,4}Bit_*.
         ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
-            .engine(KNNEngine.FAISS)
-            .methodName(METHOD_HNSW)
-            .encoderType(Encoder.EncoderType.SQ)
-            .quantizationBits(Encoder.QuantizationBits.FOUR)
-            .compressionLevel(CompressionLevel.x8)
-            .mode(Mode.ON_DISK)
-            .dimension(500)
-            .indexVersionCreated(Version.CURRENT)
-            .build();
-        RescoreContext rescoreContext = spec.getRescoreContext();
-        assertNotNull(rescoreContext);
-        assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
-
-        // FLAT encoder should also fall through
-        spec = ResolvedIndexSpec.builder()
             .engine(KNNEngine.FAISS)
             .methodName(METHOD_HNSW)
             .encoderType(Encoder.EncoderType.FLAT)
@@ -266,7 +254,7 @@ public class CompressionLevelTests extends KNNTestCase {
             .dimension(500)
             .indexVersionCreated(Version.CURRENT)
             .build();
-        rescoreContext = spec.getRescoreContext();
+        RescoreContext rescoreContext = spec.getRescoreContext();
         assertNotNull(rescoreContext);
         assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
     }

--- a/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
@@ -169,12 +169,19 @@ public class FaissSQMappingIT extends KNNRestTestCase {
         validateMappingFails(mapping, "incompatible");
     }
 
-    // --- invalid bits values ---
+    // --- multi-bit SQ (bits ∈ {2, 4}) ---
 
-    public void testSQEncoder_whenBits2_thenFail() throws Exception {
+    public void testSQEncoder_whenBits2_thenSucceed() throws Exception {
         String mapping = buildSQMapping(2, null, null, null, null);
-        validateMappingFails(mapping, "Unsupported bits value");
+        validateMappingOnly(INDEX_NAME, mapping, 2);
     }
+
+    public void testSQEncoder_whenBits4_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(4, null, null, null, null);
+        validateMappingOnly(INDEX_NAME, mapping, 4);
+    }
+
+    // --- invalid bits values ---
 
     public void testSQEncoder_whenBits8_thenFail() throws Exception {
         String mapping = buildSQMapping(8, null, null, null, null);

--- a/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
@@ -72,6 +72,20 @@ public class FaissSQMappingIT extends KNNRestTestCase {
         deleteKNNIndex(indexName);
     }
 
+    /**
+     * Validates a multi-bit SQ ({@code bits ∈ {2, 4}}) index end-to-end: mapping is applied,
+     * documents index without error, and search returns the requested top-k. Correctness of
+     * ranking is a recall concern owned by benchmark tests; this smoke test only asserts the
+     * search path does not crash and returns k hits.
+     */
+    private void validateMultiBitIndex(String indexName, String mapping, Integer expectedBits) throws Exception {
+        createKnnIndex(indexName, mapping);
+        validateMapping(indexName, expectedBits, null, null);
+        addKNNDocs(indexName, FIELD_NAME, TEST_DIMENSION, 0, NUM_DOCS);
+        validateKNNSearch(indexName, FIELD_NAME, TEST_DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
     @SuppressWarnings("unchecked")
     private void validateMapping(String indexName, Integer expectedBits, String expectedType, Boolean expectedClip) throws Exception {
         Map<String, Object> actualMapping = getIndexMappingAsMap(indexName);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
@@ -12,12 +12,17 @@ import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
 /**
- * This is testing Faiss SQ 32x for all possible combinations.
+ * This is testing Faiss SQ for all supported memory-optimized-search widths
+ * (bits ∈ {1, 2, 4}, corresponding to compression x32, x16, x8).
  */
 public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     // These tests validate MOS off-heap behavior which is specific to the SQ code path.
     private static final String SQ_ENCODER_PARAMS = """
         {"encoder": {"name": "sq", "parameters": {"bits": 1}}}""";
+    private static final String SQ_TWO_BIT_ENCODER_PARAMS = """
+        {"encoder": {"name": "sq", "parameters": {"bits": 2}}}""";
+    private static final String SQ_FOUR_BIT_ENCODER_PARAMS = """
+        {"encoder": {"name": "sq", "parameters": {"bits": 4}}}""";
 
     @ExpectRemoteBuildValidation
     public void testNonNestedDiskBasedIndexWithIP() {
@@ -158,5 +163,153 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
         );
 
         // We don't support radial search for nested index
+    }
+
+    // --- SQ 2-bit (x16 compression) ---
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithIP_SQTwoBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithIP_SQTwoBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithL2_SQTwoBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithL2_SQTwoBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithCosine_SQTwoBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithCosine_SQTwoBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_TWO_BIT_ENCODER_PARAMS,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x16
+        );
+    }
+
+    // --- SQ 4-bit (x8 compression) ---
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithIP_SQFourBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithIP_SQFourBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithL2_SQFourBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithL2_SQFourBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testNonNestedDiskBasedIndexWithCosine_SQFourBit() {
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            false,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
+    }
+
+    public void testNestedDiskBasedIndexWithCosine_SQFourBit() {
+        doTestNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_FOUR_BIT_ENCODER_PARAMS,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x8
+        );
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
@@ -34,6 +34,39 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testCreate_whenSQTwoBitField_thenReturnsFaissScalarQuantizedFlatIndex() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=2").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNotNull(result);
+        assertTrue(result instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenSQFourBitField_thenReturnsFaissScalarQuantizedFlatIndex() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=4").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNotNull(result);
+        assertTrue(result instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenSQFP16Field_thenReturnsNull() {
+        // bits=16 is fp16 (not an MOS width); the flat proxy should not be wired.
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=16").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNull(result);
+    }
+
+    @SneakyThrows
     public void testCreate_whenNonSQField_thenReturnsNull() {
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
         FlatVectorsReader mockReader = mock(FlatVectorsReader.class);

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -774,7 +774,6 @@ public class RecallTestsIT extends KNNCompressionRestTestCase {
                 .field(DIMENSION, TEST_DIMENSION)
                 .startObject(KNN_METHOD)
                 .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-                .field(KNN_ENGINE, LUCENE_NAME)
                 .field(NAME, METHOD_FLAT)
                 .endObject()
                 .endObject()

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -2859,6 +2859,25 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Returns true when the BWC old-cluster version still accepts an explicit engine on method=flat.
+     * The reject was introduced in {@link org.opensearch.knn.common.KNNConstants#FLAT_METHOD_ENGINE_AGNOSTIC_VERSION}.
+     * Tests that verify the pre-gate → post-gate BWC path must only run when the old cluster
+     * predates the gate (otherwise the old cluster itself rejects the mapping).
+     */
+    protected boolean isFlatMethodEnginePermittedOnOldCluster(final Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get();
+        if (versionString.endsWith("-SNAPSHOT")) {
+            versionString = versionString.substring(0, versionString.length() - 9);
+        }
+        final Version version = Version.fromString(versionString);
+        return version.onOrAfter(Version.V_3_6_0)
+            && version.before(org.opensearch.knn.common.KNNConstants.FLAT_METHOD_ENGINE_AGNOSTIC_VERSION);
+    }
+
+    /**
      * Generates a random lowercase string with length between MIN_CODE_UNITS and MAX_CODE_UNITS.
      * This method is used for test fixtures to generate random string values that can be used
      * as identifiers, names, or other string-based test data.


### PR DESCRIPTION
### Description
Merge feature branch `feature/sq-2bit-4bit` to `main` which includes the changes from following PRs:
 - #3428 
 - #3429 
 - #3431 
 - #3459 
 - #3463 
 - #3471
 - Resolving conflicts
 - [Preserve engine=lucene on toXContent for pre-gate flat mappings](https://github.com/opensearch-project/k-NN/pull/3544/commits/6e991c22a7cdc1e39fdf1a7757cd73d584460a54)
 - [Enforce single-field invariant on Faiss1040SQKnnVectorsWriter](https://github.com/opensearch-project/k-NN/pull/3544/commits/15ddfcf4cdf1599da9e101110d7a77a38025a8d0)


### Related Issues
#3427 

### Check List
- [x] New functionality includes testing.
- [] New functionality has been documented.
- [] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
