### PR TITLE
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (k-NN)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ plugins {
     id 'java-library'
     id 'java-test-fixtures'
     id 'idea'
-    id "com.diffplug.spotless" version "8.6.0" apply false
+    id "com.diffplug.spotless" version "8.10.1" apply false
     id 'io.freefair.lombok' version '8.14'
     id "de.undercouch.download" version "5.3.0"
 }

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -5,11 +5,22 @@
 
 allprojects {
     project.apply plugin: "com.diffplug.spotless"
+
+    // Only wire the Eclipse JDT step when a spotless task is actually being run, so non-spotless
+    // Gradle invocations (test, assemble, JNI, BWC) don't provision the formatter at configuration time.
+    def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
+
     spotless {
         java {
             target 'src/**/*.java'
             removeUnusedImports()
-            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
+            // Pin 4.39 explicitly: spotless 8.10.0+ ships an embedded lockfile for it, so the
+            // formatter resolves from Maven Central through the mirror below instead of querying a
+            // P2 update site at configuration time. Keep withP2Mirrors so any non-lockfile fallback
+            // still hits the ci.opensearch.org mirror rather than the eclipse.org origin.
+            if (runningSpotlessTask) {
+                eclipse('4.39').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
+            }
             trimTrailingWhitespace()
         }
     }

--- a/remote-index-build-client/build.gradle
+++ b/remote-index-build-client/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'java-library'
     id 'jacoco'
     id "io.freefair.lombok" version "8.14"
-    id 'com.diffplug.spotless' version '8.6.0'
+    id 'com.diffplug.spotless' version '8.10.1'
     id 'opensearch.build'
     id 'opensearch.java-agent'
 }


### PR DESCRIPTION
### Description
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
