### PR TITLE
Fix rolling-upgrade BWC SPR branch using wrong bwc.version env var

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -208,7 +208,7 @@ jobs:
           if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq
           then
             echo "the system is an Intel(R) Sapphire Rapids or a newer-generation processor"
-            ./gradlew :qa:rolling-upgrade:testRollingUpgrade -Dtests.bwc.version=$BWC_VERSION_RESTART_UPGRADE -Dnproc.count=`nproc` -Davx512_spr.enabled=true
+            ./gradlew :qa:rolling-upgrade:testRollingUpgrade -Dtests.bwc.version=$BWC_VERSION_ROLLING_UPGRADE -Dnproc.count=`nproc` -Davx512_spr.enabled=true
           else  
             echo "avx512 available on system"
             ./gradlew :qa:rolling-upgrade:testRollingUpgrade -Dtests.bwc.version=$BWC_VERSION_ROLLING_UPGRADE -Dnproc.count=`nproc` -Davx512_spr.enabled=false


### PR DESCRIPTION
### Description
Fix rolling-upgrade BWC SPR branch using wrong bwc.version env var

The Sapphire Rapids branch of the rolling-upgrade BWC job passed $BWC_VERSION_RESTART_UPGRADE, which is undefined in that job, so tests.bwc.version expanded to empty and Gradle configuration failed with 'Invalid version format:' on SPR-class runners. Use $BWC_VERSION_ROLLING_UPGRADE to match the other branches.

The wrong env var stayed latent for ~1.5 years because it only fires when CI happens to schedule the job on an SPR-class Intel runner, which is why it surfaced now as an intermittent failure.

Ref: https://github.com/opensearch-project/k-NN/pull/2444

### Related Issues
One of the failed request:
https://github.com/opensearch-project/k-NN/actions/runs/33789674065/attempts/1 

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
