### PR TITLE
Fix flaky testBuildFromModelTemplate CheckIndex mock #2257

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix shared mutable PerLeafResult.EMPTY_RESULT causing NPE [#3534](https://github.com/opensearch-project/k-NN/pull/3534)
 * Drop HasIndexSlice from ScalarQuantizedFloatVectorValues and expose float/quantized delegates via getters [#3486](https://github.com/opensearch-project/k-NN/pull/3486)
 * Fix exact search and rescore scoring innerproduct and cosinesimil fields with L2 on model based and 2.17 to 2.19 indices [#3537](https://github.com/opensearch-project/k-NN/pull/3537)
+* Fix flaky testBuildFromModelTemplate when CheckIndex runs off the test thread [#2257](https://github.com/opensearch-project/k-NN/issues/2257)
 
 ### Refactoring
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -17,7 +17,6 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
-import org.mockito.MockedStatic;
 import org.opensearch.Version;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -246,53 +245,42 @@ public class KNNCodecTestCase extends KNNTestCase {
             KNNEngine.FAISS
         );
 
-        // Set the mocked OpenSearchKNNModelDao to INSTANCE.
-        // Mockito’s static mocking is unreliable when multiple threads call the mocked static method concurrently.
-        // Lucene’s test framework uses a random seed to decide whether to create a real FSDirectory instance,
-        // which rarely happens. In most cases, it creates a mocked Directory and never calls the mocked static method.
-        // However, when a real FSDirectory is created, it can spawn multiple threads to perform index checks.
-        // In such cases, a thread may end up calling the actual static method instead of the mocked one.
-        // To prevent this, we explicitly assign the mocked DAO to INSTANCE so that even if the real method is invoked,
-        // the mocked DAO will still be returned.
+        // mockStatic(getInstance) is thread-local. Lucene CheckIndex can run on another
+        // thread when the directory closes, so the stub never applies there and the test
+        // flakes with "Model ID is not created". Point the singleton at the mock instead.
         final ModelDao.OpenSearchKNNModelDao modelDao = mock(ModelDao.OpenSearchKNNModelDao.class);
-
-        // Access private static field
         final Field instanceField = ModelDao.OpenSearchKNNModelDao.class.getDeclaredField("INSTANCE");
         instanceField.setAccessible(true);
 
-        // Set mock instance
-        instanceField.set(null, modelDao);
+        // Set model state to created
+        ModelMetadata modelMetadata1 = new ModelMetadata(
+            knnEngine,
+            spaceType,
+            dimension,
+            ModelState.CREATED,
+            ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
+            "",
+            "",
+            MethodComponentContext.EMPTY,
+            VectorDataType.FLOAT,
+            Mode.NOT_CONFIGURED,
+            CompressionLevel.NOT_CONFIGURED,
+            Version.V_EMPTY
+        );
+
+        Model mockModel = new Model(modelMetadata1, modelBlob, modelId);
+        when(modelDao.get(modelId)).thenReturn(mockModel);
+        when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata1);
+
+        final Object previousInstance;
+        synchronized (ModelDao.OpenSearchKNNModelDao.class) {
+            previousInstance = instanceField.get(null);
+            instanceField.set(null, modelDao);
+        }
 
         // Setup model cache
-        try (
-            MockedStatic<ModelDao.OpenSearchKNNModelDao> modelDaoMockedStatic = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class);
-            AutoCloseable resetModelDao = () -> {
-                instanceField.set(null, null);
-            }
-        ) {
-            modelDaoMockedStatic.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(modelDao);
-
-            // Set model state to created
-            ModelMetadata modelMetadata1 = new ModelMetadata(
-                knnEngine,
-                spaceType,
-                dimension,
-                ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(),
-                "",
-                "",
-                "",
-                MethodComponentContext.EMPTY,
-                VectorDataType.FLOAT,
-                Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED,
-                Version.V_EMPTY
-            );
-
-            Model mockModel = new Model(modelMetadata1, modelBlob, modelId);
-            when(modelDao.get(modelId)).thenReturn(mockModel);
-            when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata1);
-
+        try {
             Settings settings = settings(CURRENT).put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), "10%").build();
             ClusterSettings clusterSettings = new ClusterSettings(settings, ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
 
@@ -344,8 +332,10 @@ public class KNNCodecTestCase extends KNNTestCase {
             reader.close();
             dir.close();
             NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance().close();
-
-            Thread.sleep(10000);
+        } finally {
+            synchronized (ModelDao.OpenSearchKNNModelDao.class) {
+                instanceField.set(null, previousInstance);
+            }
         }
     }
 


### PR DESCRIPTION
### Description
`testBuildFromModelTemplate` flakes when Lucene CheckIndex opens the index on another thread. Mockito's `mockStatic(getInstance)` is thread-local, so that thread hits a real/empty ModelDao and throws `Model ID 'test-model' is not created`.

I pointed `OpenSearchKNNModelDao.INSTANCE` at the mock so every thread sees it, and dropped the 10s sleep at the end of the test.

### Related Issues
Resolves #2257

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
