### PR TITLE
[FP16 PR-6] Add SQ 1-bit Support for Lucene

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatFlatVectorsFormat.java
@@ -26,7 +26,7 @@ import java.util.Locale;
  */
 public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
 
-    static final String NAME = "KNN1040HalfFloatFlatVectorsFormat";
+    static final String FORMAT_NAME = "KNN1040HalfFloatFlatVectorsFormat";
     static final String META_CODEC_NAME = "KNN1040HalfFloatFlatVectorsFormatMeta";
     static final String VECTOR_DATA_CODEC_NAME = "KNN1040HalfFloatFlatVectorsFormatData";
     static final String META_EXTENSION = "vemf";
@@ -41,7 +41,7 @@ public class KNN1040HalfFloatFlatVectorsFormat extends FlatVectorsFormat {
     );
 
     public KNN1040HalfFloatFlatVectorsFormat() {
-        super(NAME);
+        super(FORMAT_NAME);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormat.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.opensearch.knn.index.VectorDataType;
+
+/**
+ * SQ 1-bit format for {@code half_float} with the same mechanism as {@link KNN1040ScalarQuantizedVectorsFormat},
+ * but with an FP16 raw delegate instead of FP32. Separate class as Lucene reconstructs formats
+ * by name via a no-arg constructor, so sharing a name with the FLOAT variant would silently pick the
+ * wrong delegate on read.
+ */
+public class KNN1040HalfFloatScalarQuantizedVectorsFormat extends KNN1040ScalarQuantizedVectorsFormat {
+
+    public KNN1040HalfFloatScalarQuantizedVectorsFormat() {
+        this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
+    }
+
+    public KNN1040HalfFloatScalarQuantizedVectorsFormat(final ScalarEncoding encoding) {
+        super(encoding, VectorDataType.HALF_FLOAT);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormat.java
@@ -16,11 +16,18 @@ import org.opensearch.knn.index.VectorDataType;
  */
 public class KNN1040HalfFloatScalarQuantizedVectorsFormat extends KNN1040ScalarQuantizedVectorsFormat {
 
+    private static final String FORMAT_NAME = "KNN1040HalfFloatScalarQuantizedVectorsFormat";
+
     public KNN1040HalfFloatScalarQuantizedVectorsFormat() {
         this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
     }
 
     public KNN1040HalfFloatScalarQuantizedVectorsFormat(final ScalarEncoding encoding) {
         super(encoding, VectorDataType.HALF_FLOAT);
+    }
+
+    @Override
+    public String getName() {
+        return FORMAT_NAME;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormat.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.opensearch.knn.index.VectorDataType;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_NUM_MERGE_WORKER;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_GRAPH_THRESHOLD;
+
+/**
+ * HNSW + SQ 1-bit format for {@code half_float} with the same mechanism as
+ * {@link KNN1040HnswScalarQuantizedVectorsFormat}, but with an FP16 raw delegate instead of FP32.
+ * Separate class on purpose as Lucene reconstructs formats by name via a no-arg constructor, so
+ * sharing a name with the FLOAT variant would silently pick the wrong delegate on read.
+ */
+public class KNN1040HnswHalfFloatScalarQuantizedVectorsFormat extends KNN1040HnswScalarQuantizedVectorsFormat {
+
+    public KNN1040HnswHalfFloatScalarQuantizedVectorsFormat() {
+        this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null);
+    }
+
+    public KNN1040HnswHalfFloatScalarQuantizedVectorsFormat(
+        ScalarEncoding encoding,
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec
+    ) {
+        this(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, HNSW_GRAPH_THRESHOLD);
+    }
+
+    public KNN1040HnswHalfFloatScalarQuantizedVectorsFormat(
+        ScalarEncoding encoding,
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec,
+        int tinySegmentsThreshold
+    ) {
+        super(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, tinySegmentsThreshold, VectorDataType.HALF_FLOAT);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormat.java
@@ -23,6 +23,8 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_G
  */
 public class KNN1040HnswHalfFloatScalarQuantizedVectorsFormat extends KNN1040HnswScalarQuantizedVectorsFormat {
 
+    private static final String FORMAT_NAME = "KNN1040HnswHalfFloatScalarQuantizedVectorsFormat";
+
     public KNN1040HnswHalfFloatScalarQuantizedVectorsFormat() {
         this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null);
     }
@@ -46,5 +48,10 @@ public class KNN1040HnswHalfFloatScalarQuantizedVectorsFormat extends KNN1040Hns
         int tinySegmentsThreshold
     ) {
         super(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, tinySegmentsThreshold, VectorDataType.HALF_FLOAT);
+    }
+
+    @Override
+    public String getName() {
+        return FORMAT_NAME;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatVectorsFormat.java
@@ -41,7 +41,7 @@ public class KNN1040HnswHalfFloatVectorsFormat extends KnnVectorsFormat {
     private final TaskExecutor mergeExec;
     private static final FlatVectorsFormat flatVectorsFormat = new KNN1040HalfFloatFlatVectorsFormat();
 
-    private static final String NAME = "KNN1040HnswHalfFloatVectorsFormat";
+    private static final String FORMAT_NAME = "KNN1040HnswHalfFloatVectorsFormat";
 
     public KNN1040HnswHalfFloatVectorsFormat() {
         this(DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null, HNSW_GRAPH_THRESHOLD);
@@ -58,7 +58,7 @@ public class KNN1040HnswHalfFloatVectorsFormat extends KnnVectorsFormat {
         ExecutorService mergeExec,
         int tinySegmentsThreshold
     ) {
-        super(NAME);
+        super(FORMAT_NAME);
         if (maxConn <= 0 || maxConn > MAXIMUM_MAX_CONN) {
             throw new IllegalArgumentException(
                 "maxConn must be positive and less than or equal to " + MAXIMUM_MAX_CONN + "; maxConn=" + maxConn

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
@@ -16,6 +16,7 @@ import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.TaskExecutor;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
@@ -62,13 +63,27 @@ public class KNN1040HnswScalarQuantizedVectorsFormat extends Lucene104HnswScalar
         ExecutorService mergeExec,
         int tinySegmentsThreshold
     ) {
+        this(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, tinySegmentsThreshold, VectorDataType.FLOAT);
+    }
+
+    KNN1040HnswScalarQuantizedVectorsFormat(
+        ScalarEncoding encoding,
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec,
+        int tinySegmentsThreshold,
+        VectorDataType rawVectorDataType
+    ) {
         super(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, tinySegmentsThreshold);
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
         this.tinySegmentsThreshold = tinySegmentsThreshold;
         this.numMergeWorkers = numMergeWorkers;
         this.mergeExec = mergeExec != null ? new TaskExecutor(mergeExec) : null;
-        this.flatVectorsFormat = new KNN1040ScalarQuantizedVectorsFormat(encoding);
+        this.flatVectorsFormat = VectorDataType.HALF_FLOAT == rawVectorDataType
+            ? new KNN1040HalfFloatScalarQuantizedVectorsFormat(encoding)
+            : new KNN1040ScalarQuantizedVectorsFormat(encoding);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
@@ -34,6 +34,8 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_G
  */
 public class KNN1040HnswScalarQuantizedVectorsFormat extends Lucene104HnswScalarQuantizedVectorsFormat {
 
+    private static final String FORMAT_NAME = "KNN1040HnswScalarQuantizedVectorsFormat";
+
     private final int maxConn;
     private final int beamWidth;
     private final int tinySegmentsThreshold;
@@ -112,7 +114,7 @@ public class KNN1040HnswScalarQuantizedVectorsFormat extends Lucene104HnswScalar
 
     @Override
     public String getName() {
-        return getClass().getSimpleName();
+        return FORMAT_NAME;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -108,6 +108,16 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             final Tuple<Integer, ExecutorService> merge = getMergeThreadCountAndExecutorService();
             final int threshold = toTinySegmentsThreshold(ctx.getApproximateThreshold());
             if (p.getBits() == LuceneSQEncoder.Bits.ONE.getValue()) {
+                if (ctx.getVectorDataType() == VectorDataType.HALF_FLOAT) {
+                    return new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat(
+                        p.getBitEncoding(),
+                        p.getMaxConnections(),
+                        p.getBeamWidth(),
+                        merge.v1(),
+                        merge.v2(),
+                        threshold
+                    );
+                }
                 return new KNN1040HnswScalarQuantizedVectorsFormat(
                     p.getBitEncoding(),
                     p.getMaxConnections(),
@@ -128,9 +138,10 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 threshold
             );
         }, LuceneVectorsFormatType.FLAT, ctx -> {
-            // TODO: This branches on data type alone. Once x16 (SQ over FP16) lands, half_float will
-            // also need to select a quantized format, so this must additionally gate on compression level.
             if (ctx.getVectorDataType() == VectorDataType.HALF_FLOAT) {
+                if (ctx.getCompressionLevel() == CompressionLevel.x16) {
+                    return new KNN1040HalfFloatScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
+                }
                 return new KNN1040HalfFloatFlatVectorsFormat();
             }
             return new KNN1040ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -26,6 +26,7 @@ import org.opensearch.knn.index.codec.params.KNNVectorsFormatParams;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.faiss.FaissCodecFormatResolver;
 import org.opensearch.knn.index.engine.lucene.LuceneCodecFormatResolver;
+import org.opensearch.knn.index.engine.lucene.LuceneFlatMethodResolver;
 import org.opensearch.knn.index.engine.lucene.LuceneSQEncoder;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
@@ -144,7 +145,7 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 }
                 return new KNN1040HalfFloatFlatVectorsFormat();
             }
-            return new KNN1040ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
+            return new KNN1040ScalarQuantizedVectorsFormat(resolveFlatScalarEncoding(ctx.getCompressionLevel()));
         });
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import java.util.Locale;
 
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
@@ -16,6 +17,7 @@ import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsWriter;
 import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
@@ -33,19 +35,27 @@ public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantize
     // Must use the default Lucene scorer here, not KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER.
     // KNN1040ScalarQuantizedVectorScorer.getRandomVectorScorer(float[]) always assumes quantized
     // vectors and will fail (NPE/exception) when called with raw OffHeapFloatVectorValues.
-    private static final Lucene99FlatVectorsFormat RAW_VECTOR_FORMAT = new Lucene99FlatVectorsFormat(
+    private static final Lucene99FlatVectorsFormat RAW_VECTOR_FORMAT_FLOAT = new Lucene99FlatVectorsFormat(
         FlatVectorsScorerProvider.getLucene99FlatVectorsScorer()
     );
 
+    private static final KNN1040HalfFloatFlatVectorsFormat RAW_VECTOR_FORMAT_HALF_FLOAT = new KNN1040HalfFloatFlatVectorsFormat();
+
     private final ScalarEncoding encoding;
+    private final FlatVectorsFormat rawVectorFormat;
 
     public KNN1040ScalarQuantizedVectorsFormat() {
         this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
     }
 
     public KNN1040ScalarQuantizedVectorsFormat(final ScalarEncoding encoding) {
+        this(encoding, VectorDataType.FLOAT);
+    }
+
+    KNN1040ScalarQuantizedVectorsFormat(final ScalarEncoding encoding, final VectorDataType rawVectorDataType) {
         super(encoding);
         this.encoding = encoding;
+        this.rawVectorFormat = VectorDataType.HALF_FLOAT == rawVectorDataType ? RAW_VECTOR_FORMAT_HALF_FLOAT : RAW_VECTOR_FORMAT_FLOAT;
     }
 
     @Override
@@ -53,7 +63,7 @@ public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantize
         return new Lucene104ScalarQuantizedVectorsWriter(
             state,
             encoding,
-            RAW_VECTOR_FORMAT.fieldsWriter(state),
+            rawVectorFormat.fieldsWriter(state),
             KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER
         );
     }
@@ -66,7 +76,7 @@ public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantize
             getClass().getSimpleName(),
             encoding,
             KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER,
-            RAW_VECTOR_FORMAT
+            rawVectorFormat
         );
     }
 
@@ -74,7 +84,7 @@ public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantize
     public FlatVectorsReader fieldsReader(SegmentReadState state) throws IOException {
         return new Lucene104ScalarQuantizedVectorsReader(
             state,
-            RAW_VECTOR_FORMAT.fieldsReader(state),
+            rawVectorFormat.fieldsReader(state),
             KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER
         );
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
@@ -29,6 +29,8 @@ import java.io.IOException;
  */
 public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantizedVectorsFormat {
 
+    private static final String FORMAT_NAME = "KNN1040ScalarQuantizedVectorsFormat";
+
     private static final KNN1040ScalarQuantizedVectorScorer KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER = FlatVectorsScorerProvider
         .getKNN1040ScalarQuantizedVectorScorer(FlatVectorsScorerProvider.getLucene99FlatVectorsScorer());
 
@@ -96,6 +98,6 @@ public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantize
 
     @Override
     public String getName() {
-        return getClass().getSimpleName();
+        return FORMAT_NAME;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolver.java
@@ -26,13 +26,14 @@ import static org.opensearch.knn.index.engine.lucene.LuceneFlatMethod.FLAT_METHO
 
 /**
  * Resolves method configuration for the Lucene flat method. For FLOAT vectors, the flat method uses scalar
- * quantization without an HNSW graph (brute-force scan). Supported compression levels are
+ * quantization without an HNSW graph (brute-force scan). Supported compression levels for FLOAT are
  * {@link org.opensearch.knn.index.mapper.CompressionLevel#x32} (SQ 1-bit),
  * {@link org.opensearch.knn.index.mapper.CompressionLevel#x16} (SQ 2-bit), and
  * {@link org.opensearch.knn.index.mapper.CompressionLevel#x8} (SQ 4-bit).
  * HALF_FLOAT vectors don't go through an encoder - compression is expressed purely via
- * {@link org.opensearch.knn.index.mapper.CompressionLevel}, currently supporting only {@link
- * org.opensearch.knn.index.mapper.CompressionLevel#x1} (raw FP16, no further reduction).
+ * {@link org.opensearch.knn.index.mapper.CompressionLevel}, currently supported compression levels
+ * for HALF_FLOAT are {@link org.opensearch.knn.index.mapper.CompressionLevel#x16} (SQ 1-bit),
+ * and {@link org.opensearch.knn.index.mapper.CompressionLevel#x1} (raw FP16, no further reduction).
  */
 public class LuceneFlatMethodResolver extends AbstractMethodResolver {
 
@@ -41,9 +42,9 @@ public class LuceneFlatMethodResolver extends AbstractMethodResolver {
         CompressionLevel.x16,
         CompressionLevel.x8
     );
-    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_HALF_FLOAT = Set.of(CompressionLevel.x1);
+    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS_HALF_FLOAT = Set.of(CompressionLevel.x1, CompressionLevel.x16);
     static final CompressionLevel DEFAULT_COMPRESSION = CompressionLevel.x32;
-    static final CompressionLevel DEFAULT_COMPRESSION_HALF_FLOAT = CompressionLevel.x1;
+    static final CompressionLevel DEFAULT_COMPRESSION_HALF_FLOAT = CompressionLevel.x16;
 
     @Override
     public ResolvedMethodContext resolveMethod(
@@ -99,7 +100,7 @@ public class LuceneFlatMethodResolver extends AbstractMethodResolver {
     }
 
     private CompressionLevel validateAndResolveCompressionLevel(KNNMethodConfigContext knnMethodConfigContext) {
-        boolean isHalfFloat = VectorDataType.HALF_FLOAT == knnMethodConfigContext.getVectorDataType();
+        final boolean isHalfFloat = VectorDataType.HALF_FLOAT == knnMethodConfigContext.getVectorDataType();
         final CompressionLevel defaultCompression = isHalfFloat ? DEFAULT_COMPRESSION_HALF_FLOAT : DEFAULT_COMPRESSION;
 
         CompressionLevel compressionLevel = knnMethodConfigContext.getCompressionLevel();
@@ -107,7 +108,7 @@ public class LuceneFlatMethodResolver extends AbstractMethodResolver {
             if (isHalfFloat) {
                 ValidationException validationException = validateCompressionSupported(
                     compressionLevel,
-                    SUPPORTED_COMPRESSION_HALF_FLOAT,
+                    SUPPORTED_COMPRESSION_LEVELS_HALF_FLOAT,
                     KNNEngine.LUCENE,
                     knnMethodConfigContext.getVectorDataType(),
                     null

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolver.java
@@ -18,11 +18,14 @@ import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.ResolvedMethodContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SCALAR_QUANTIZER_DEFAULT_BITS_AFTER_V360;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_DEFAULT_BITS;
@@ -33,13 +36,8 @@ import static org.opensearch.knn.index.engine.lucene.LuceneHNSWMethod.SUPPORTED_
 
 /**
  * Resolves method configuration for the Lucene HNSW method. Supports optional scalar quantization
- * encoding and compression-level-based resolution, with supported compression levels of x1, x4, and x32.
- * HALF_FLOAT vectors don't go through an encoder - compression is expressed purely via {@link
- * org.opensearch.knn.index.mapper.CompressionLevel}, currently supporting only {@link
- * org.opensearch.knn.index.mapper.CompressionLevel#x1} (raw FP16, no further reduction), which is also
- * the default (mirrors {@link LuceneFlatMethodResolver}). {@link
- * org.opensearch.knn.index.mapper.CompressionLevel#x16} (an actual quantization scheme on top of FP16)
- * is added in a follow-up.
+ * encoding and compression-level-based resolution, with supported compression levels of x1, x4, and x32
+ * for FLOAT, and x1 and x16 for HALF_FLOAT.
  */
 public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
 
@@ -48,8 +46,8 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
         CompressionLevel.x4,
         CompressionLevel.x32
     );
+    private static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS_HALF_FLOAT = Set.of(CompressionLevel.x1, CompressionLevel.x16);
     static final CompressionLevel DEFAULT_COMPRESSION_HALF_FLOAT = CompressionLevel.x1;
-    static final Set<CompressionLevel> SUPPORTED_COMPRESSION_HALF_FLOAT = Set.of(CompressionLevel.x1);
 
     @Override
     public ResolvedMethodContext resolveMethod(
@@ -91,14 +89,29 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
         SpaceType spaceType
     ) {
         ValidationException validationException = validateNotTrainingContext(shouldRequireTraining, KNNEngine.LUCENE, null);
-        CompressionLevel compressionLevel = knnMethodConfigContext.getCompressionLevel();
         validationException = validateCompressionSupported(
-            compressionLevel,
-            SUPPORTED_COMPRESSION_HALF_FLOAT,
+            knnMethodConfigContext.getCompressionLevel(),
+            SUPPORTED_COMPRESSION_LEVELS_HALF_FLOAT,
             KNNEngine.LUCENE,
             knnMethodConfigContext.getVectorDataType(),
             validationException
         );
+        // half_float's only encoder configuration (SQ 1-bit) is fully determined by compression_level
+        // (x16) and auto-resolved internally - there's no tunable parameter surface to expose, so
+        // users configure it via compression_level, not by writing an encoder block themselves.
+        if (isEncoderSpecified(knnMethodContext)) {
+            validationException = validationException == null ? new ValidationException() : validationException;
+            validationException.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "\"%s\" parameter is not supported for \"%s\" data type; use \"%s\" instead.",
+                    METHOD_ENCODER_PARAMETER,
+                    VectorDataType.HALF_FLOAT.getValue(),
+                    COMPRESSION_LEVEL_PARAMETER
+                )
+            );
+        }
+        validationException = validateCompressionNotx1WhenOnDisk(knnMethodConfigContext, validationException);
         if (validationException != null) {
             throw validationException;
         }
@@ -109,15 +122,35 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
             spaceType,
             METHOD_HNSW
         );
+        resolveEncoder(resolvedKNNMethodContext, knnMethodConfigContext);
+        resolveEncoderBitsAndValidate(knnMethodContext, resolvedKNNMethodContext, knnMethodConfigContext);
         resolveMethodParams(resolvedKNNMethodContext.getMethodComponentContext(), knnMethodConfigContext, HNSW_METHOD_COMPONENT);
 
-        CompressionLevel resolvedCompressionLevel = CompressionLevel.isConfigured(compressionLevel)
-            ? compressionLevel
-            : DEFAULT_COMPRESSION_HALF_FLOAT;
+        CompressionLevel resolvedCompressionLevel = isEncoderSpecified(resolvedKNNMethodContext)
+            ? resolveCompressionLevelFromMethodContext(
+                resolvedKNNMethodContext,
+                knnMethodConfigContext,
+                LuceneHNSWMethod.SUPPORTED_ENCODERS
+            )
+            : getDataTypeAwareDefaultCompressionLevel(knnMethodConfigContext);
+        validateCompressionConflicts(knnMethodConfigContext.getCompressionLevel(), resolvedCompressionLevel);
         return ResolvedMethodContext.builder()
             .knnMethodContext(resolvedKNNMethodContext)
             .compressionLevel(resolvedCompressionLevel)
             .build();
+    }
+
+    @Override
+    protected boolean shouldEncoderBeResolved(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
+        if (isEncoderSpecified(knnMethodContext)) {
+            return false;
+        }
+
+        if (knnMethodConfigContext.getVectorDataType() == VectorDataType.HALF_FLOAT) {
+            return getDataTypeAwareDefaultCompressionLevel(knnMethodConfigContext) == CompressionLevel.x16;
+        }
+
+        return super.shouldEncoderBeResolved(knnMethodContext, knnMethodConfigContext);
     }
 
     protected void resolveEncoder(KNNMethodContext resolvedKNNMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
@@ -125,7 +158,7 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
             return;
         }
 
-        CompressionLevel resolvedCompressionLevel = getDefaultCompressionLevel(knnMethodConfigContext);
+        CompressionLevel resolvedCompressionLevel = getDataTypeAwareDefaultCompressionLevel(knnMethodConfigContext);
         if (resolvedCompressionLevel == CompressionLevel.x1) {
             return;
         }
@@ -172,10 +205,10 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
         if (bitsAlreadySet == false && skipAutoResolve == false) {
             CompressionLevel effectiveCompression = CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())
                 ? knnMethodConfigContext.getCompressionLevel()
-                : getDefaultCompressionLevel(knnMethodConfigContext);
+                : getDataTypeAwareDefaultCompressionLevel(knnMethodConfigContext);
             boolean useNewDefault = isV360OrLater
                 && LuceneSQEncoder.Bits.fromValue(LUCENE_SCALAR_QUANTIZER_DEFAULT_BITS_AFTER_V360)
-                    .getCompressionLevel() == effectiveCompression;
+                    .getCompressionLevel(knnMethodConfigContext.getVectorDataType()) == effectiveCompression;
             encoderComponentContext.getParameters()
                 .put(LUCENE_SQ_BITS, useNewDefault ? LUCENE_SCALAR_QUANTIZER_DEFAULT_BITS_AFTER_V360 : LUCENE_SQ_DEFAULT_BITS);
         }
@@ -206,5 +239,15 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
 
     private CompressionLevel getDefaultCompressionLevel(KNNMethodConfigContext knnMethodConfigContext) {
         return getDefaultCompressionLevel(knnMethodConfigContext, CompressionLevel.x4);
+    }
+
+    private CompressionLevel getDataTypeAwareDefaultCompressionLevel(KNNMethodConfigContext knnMethodConfigContext) {
+        if (knnMethodConfigContext.getVectorDataType() != VectorDataType.HALF_FLOAT) {
+            return getDefaultCompressionLevel(knnMethodConfigContext);
+        }
+        if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())) {
+            return knnMethodConfigContext.getCompressionLevel();
+        }
+        return Mode.ON_DISK == knnMethodConfigContext.getMode() ? CompressionLevel.x16 : DEFAULT_COMPRESSION_HALF_FLOAT;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.engine.lucene;
 import com.google.common.collect.ImmutableSet;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import org.opensearch.Version;
 import org.opensearch.common.ValidationException;
@@ -40,24 +39,40 @@ import static org.opensearch.knn.common.KNNConstants.MINIMUM_CONFIDENCE_INTERVAL
  * Lucene scalar quantization encoder
  */
 public class LuceneSQEncoder implements Encoder {
-    private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT);
+    private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT, VectorDataType.HALF_FLOAT);
     static final Set<Integer> LUCENE_SQ_BITS_SUPPORTED = Arrays.stream(Bits.values())
         .map(Bits::getValue)
         .collect(Collectors.toUnmodifiableSet());
     static final Bits LUCENE_PRE_360_SUPPORTED_SQ_BITS = Bits.SEVEN;
 
     /**
-     * Supported bit widths for SQ quantization. Each maps to a specific quantization strategy
-     * and compression level.
+     * Supported bit widths for SQ quantization. Each maps to a specific quantization strategy.
+     * {@code bits=1}'s compression level depends on the vector data type: FLOAT is 32-bit, so 1-bit
+     * quantization is 32x; HALF_FLOAT is 16-bit, so the same 1-bit quantization is only 16x.
+     * {@code bits=7} is FLOAT-only, so its compression level (x4) doesn't vary by data type.
      */
     @Getter
-    @RequiredArgsConstructor
     public enum Bits {
-        ONE(1, CompressionLevel.x32),
-        SEVEN(7, CompressionLevel.x4);
+        ONE(1),
+        SEVEN(7);
 
         private final int value;
-        private final CompressionLevel compressionLevel;
+
+        Bits(int value) {
+            this.value = value;
+        }
+
+        /**
+         * @param vectorDataType the vector data type being quantized, needed since {@code bits=1}'s
+         *                       compression level depends on the original (pre-quantization) bit width
+         * @return the compression level {@code bits} quantization achieves for that data type
+         */
+        public CompressionLevel getCompressionLevel(VectorDataType vectorDataType) {
+            return switch (this) {
+                case ONE -> vectorDataType == VectorDataType.HALF_FLOAT ? CompressionLevel.x16 : CompressionLevel.x32;
+                case SEVEN -> CompressionLevel.x4;
+            };
+        }
 
         public static Bits fromValue(int value) {
             for (Bits b : values()) {
@@ -135,6 +150,21 @@ public class LuceneSQEncoder implements Encoder {
         }
 
         if (bitsObj instanceof Integer bits) {
+            // half_float only supports the 1-bit path; bits=7 stays float-only.
+            if (configContext.getVectorDataType() == VectorDataType.HALF_FLOAT && bits != Bits.ONE.getValue()) {
+                validationException.addValidationError(
+                    String.format(
+                        Locale.ROOT,
+                        "[%s] data type only supports [%s=%d] for encoder [%s].",
+                        VectorDataType.HALF_FLOAT.getValue(),
+                        LUCENE_SQ_BITS,
+                        Bits.ONE.getValue(),
+                        ENCODER_SQ
+                    )
+                );
+                throw validationException;
+            }
+
             if (bits == Bits.ONE.getValue()) {
                 Set<String> nonBitParameters = encoderParams.keySet()
                     .stream()
@@ -171,7 +201,7 @@ public class LuceneSQEncoder implements Encoder {
 
             CompressionLevel configuredCompression = configContext.getCompressionLevel();
             if (CompressionLevel.isConfigured(configuredCompression)) {
-                CompressionLevel expectedCompression = Bits.fromValue(bits).getCompressionLevel();
+                CompressionLevel expectedCompression = Bits.fromValue(bits).getCompressionLevel(configContext.getVectorDataType());
                 if (configuredCompression != expectedCompression) {
                     validationException.addValidationError(
                         String.format(
@@ -212,13 +242,13 @@ public class LuceneSQEncoder implements Encoder {
         if (methodComponentContext != null && methodComponentContext.getParameters() != null) {
             Object bitsObj = methodComponentContext.getParameters().get(LUCENE_SQ_BITS);
             if (bitsObj instanceof Integer) {
-                return Bits.fromValue((Integer) bitsObj).getCompressionLevel();
+                return Bits.fromValue((Integer) bitsObj).getCompressionLevel(knnMethodConfigContext.getVectorDataType());
             }
         }
 
-        // For indices after version 3.6.0, we want to default to 32x compression
+        // For indices after version 3.6.0, we want to default to 1-bit SQ's compression level.
         if (knnMethodConfigContext.getVersionCreated().onOrAfter(Version.V_3_6_0)) {
-            return CompressionLevel.x32;
+            return Bits.ONE.getCompressionLevel(knnMethodConfigContext.getVectorDataType());
         }
         return CompressionLevel.x4;
     }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -472,13 +472,13 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
         private void validateModeAndCompression(KNNVectorFieldMapper.Builder builder, Version indexCreatedVersion) {
             VectorDataType vectorDataType = builder.vectorDataType.getValue();
-            // TODO: Revisit half_float here once Lucene SQ on top of FP16 lands. Mode resolves to an
-            // engine plus a compression level, and neither value means anything for half_float yet:
-            // on_disk implies Faiss (half_float is Lucene-only) and in_memory implies x1, which is
-            // already the default. It only becomes meaningful once x16 gives half_float a second tier.
-            if (builder.mode.isConfigured() && vectorDataType != VectorDataType.FLOAT) {
+            // half_float resolves mode the same way float32 does - on_disk quantizes as far as the data
+            // type goes (x16, SQ 1-bit on 16-bit storage, the counterpart of float32's x32 on 32-bit) and
+            // in_memory stays uncompressed. byte and binary have no compression levels to select, so mode
+            // stays rejected for them.
+            if (builder.mode.isConfigured() && vectorDataType != VectorDataType.FLOAT && vectorDataType != VectorDataType.HALF_FLOAT) {
                 throw new MapperParsingException(
-                    String.format(Locale.ROOT, "Mode cannot be used for non-float32 data type for field %s", builder.name)
+                    String.format(Locale.ROOT, "Mode cannot be used for non-float data type for field %s", builder.name)
                 );
             }
             if (builder.compressionLevel.isConfigured()

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -13,6 +13,8 @@ org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.Faiss1040ScalarQuantizedKnnVectorsFormat
 org.opensearch.knn.index.codec.KNN9120Codec.KNN9120HnswBinaryVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorsFormat
+org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatScalarQuantizedVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HnswScalarQuantizedVectorsFormat
+org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HnswHalfFloatScalarQuantizedVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HalfFloatFlatVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HnswHalfFloatVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormatComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormatComponentTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.index.codec.util.UnitTestCodec;
+
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+
+/**
+ * Component test for {@link KNN1040HalfFloatScalarQuantizedVectorsFormat}: index a few float vector documents
+ * through a segment written with this format (SQ 1-bit over an FP16 raw delegate), read the segment back, and
+ * validate the scorer wiring, end-to-end search behavior, unsupported operations, and merge behavior under an
+ * index sort. Scores are not compared against an analytic similarity function like the plain FP16 format's
+ * component tests do - 1-bit scalar quantization is lossy, so only descending order and non-NaN scores are
+ * asserted.
+ */
+public class KNN1040HalfFloatScalarQuantizedVectorsFormatComponentTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_sq_vector";
+    private static final int DIMENSION = 8;
+    private static final int NUM_DOCS = 10;
+
+    /**
+     * Index vectors, read them back, and validate the returned scorer.
+     *
+     * <p>The type assertions confirm the reader's flat scorer is {@link KNN1040ScalarQuantizedVectorScorer}
+     * (shared with the FLOAT SQ format - only the raw delegate differs) and that random vector scorers it hands
+     * out are prefetchable.
+     */
+    @SneakyThrows
+    public void testIndexAndRead_whenHalfFloatScalarQuantizedVectorsFormat_thenScorerIsScalarQuantizedScorer() {
+        try (Directory dir = newDirectory()) {
+            final float[][] vectors = indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = flatVectorsReaderFor(reader, FIELD_NAME);
+
+                final RandomVectorScorer scorer = flatVectorsReader.getRandomVectorScorer(FIELD_NAME, vectors[0]);
+                assertTrue(
+                    "random vector scorer must be the prefetchable variant but was " + scorer.getClass().getName(),
+                    scorer instanceof PrefetchableRandomVectorScorer
+                );
+                assertEquals("maxOrd should match number of vectors", NUM_DOCS, scorer.maxOrd());
+            }
+        }
+    }
+
+    /**
+     * Runs an actual kNN search over the indexed, SQ 1-bit quantized vectors. Quantization is lossy, so this only
+     * checks that every doc is returned, scores are non-NaN, and scores come back in descending order - not that
+     * scores match an analytic similarity computation.
+     */
+    @SneakyThrows
+    public void testSearch_whenHalfFloatScalarQuantizedVectorsFormat_thenScoresDescendingAndNotNaN() {
+        try (Directory dir = newDirectory()) {
+            final float[][] vectors = indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final float[] query = vectors[2];
+
+                final TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FIELD_NAME, query, NUM_DOCS), NUM_DOCS);
+
+                assertEquals("all indexed docs should be returned", NUM_DOCS, topDocs.scoreDocs.length);
+
+                float previousScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    assertFalse("score should not be NaN for doc " + scoreDoc.doc, Float.isNaN(scoreDoc.score));
+                    assertTrue("scores must be in descending order", scoreDoc.score <= previousScore);
+                    previousScore = scoreDoc.score;
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_whenHalfFloatScalarQuantizedVectorsFormatWithCosine_thenScoresDescendingAndNotNaN() {
+        try (Directory dir = newDirectory()) {
+            final float[][] vectors = indexFloatDocs(dir, VectorSimilarityFunction.COSINE);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final float[] query = vectors[2];
+
+                final TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FIELD_NAME, query, NUM_DOCS), NUM_DOCS);
+
+                assertEquals("all indexed docs should be returned", NUM_DOCS, topDocs.scoreDocs.length);
+
+                float previousScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    assertFalse("score should not be NaN for doc " + scoreDoc.doc, Float.isNaN(scoreDoc.score));
+                    assertTrue("scores must be in descending order", scoreDoc.score <= previousScore);
+                    previousScore = scoreDoc.score;
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testGetByteVectorValues_whenCalled_thenThrows() {
+        try (Directory dir = newDirectory()) {
+            indexFloatDocs(dir);
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = flatVectorsReaderFor(reader, FIELD_NAME);
+                expectThrows(UnsupportedOperationException.class, () -> flatVectorsReader.getByteVectorValues(FIELD_NAME));
+            }
+        }
+    }
+
+    /**
+     * Unlike {@link KNN1040HalfFloatFlatVectorsReader}, this format's reader is Lucene's own
+     * {@code Lucene104ScalarQuantizedVectorsReader}, which returns {@code null} for an unknown field rather
+     * than throwing.
+     */
+    @SneakyThrows
+    public void testGetFloatVectorValues_whenUnknownField_thenReturnsNull() {
+        try (Directory dir = newDirectory()) {
+            indexFloatDocs(dir);
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = flatVectorsReaderFor(reader, FIELD_NAME);
+                assertNull(flatVectorsReader.getFloatVectorValues("nonexistent"));
+            }
+        }
+    }
+
+    /**
+     * Merges segments under a descending index sort, so later segments land entirely before earlier ones, and
+     * checks every doc still resolves to a vector (quantization means the round-tripped value cannot be compared
+     * exactly against the original, so only presence/count is asserted, not value equality).
+     */
+    @SneakyThrows
+    public void testMerge_whenIndexSorted_thenPreservesDocCount() {
+        final int docsPerSegment = 5;
+        final int numSegments = 3;
+        final int totalDocs = docsPerSegment * numSegments;
+        final String sortFieldName = "sort_key";
+        final String idFieldName = "id";
+
+        try (Directory dir = newDirectory()) {
+            final Codec codec = new Lucene104Codec() {
+                @Override
+                public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                    return new KNN1040HalfFloatScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE);
+                }
+            };
+
+            final IndexWriterConfig iwc = new IndexWriterConfig().setCodec(codec)
+                .setIndexSort(new Sort(new SortField(sortFieldName, SortField.Type.LONG, true)));
+
+            final float[][] vectors = generateVectors(totalDocs);
+
+            try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+                for (int i = 0; i < totalDocs; i++) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vectors[i], VectorSimilarityFunction.EUCLIDEAN));
+                    doc.add(new NumericDocValuesField(sortFieldName, i));
+                    doc.add(new StoredField(idFieldName, i));
+                    writer.addDocument(doc);
+                    if ((i + 1) % docsPerSegment == 0) {
+                        writer.commit();
+                    }
+                }
+                writer.forceMerge(1);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                assertEquals("force merge should leave a single segment", 1, reader.leaves().size());
+                LeafReader leaf = reader.leaves().get(0).reader();
+
+                FloatVectorValues values = leaf.getFloatVectorValues(FIELD_NAME);
+                assertNotNull(values);
+                assertEquals(totalDocs, values.size());
+
+                int seen = 0;
+                int previousId = Integer.MAX_VALUE;
+                KnnVectorValues.DocIndexIterator iterator = values.iterator();
+                for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+                    int id = leaf.storedFields().document(doc).getField(idFieldName).numericValue().intValue();
+
+                    // Descending sort on an ascending key: ids must come back in descending order, which is what
+                    // proves the segments actually interleaved during the merge.
+                    assertTrue("docs should be in descending id order, got " + id + " after " + previousId, id < previousId);
+                    previousId = id;
+                    seen++;
+                }
+                assertEquals(totalDocs, seen);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSpiReconstruction_resolvesToHalfFloatVariant() {
+        final KNN1040HalfFloatScalarQuantizedVectorsFormat writeFormat = new KNN1040HalfFloatScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE
+        );
+        KnnVectorsFormat readFormat = KnnVectorsFormat.forName(writeFormat.getName());
+        assertTrue(
+            "forName(" + writeFormat.getName() + ") should resolve to the half_float SQ format",
+            readFormat instanceof KNN1040HalfFloatScalarQuantizedVectorsFormat
+        );
+    }
+
+    /**
+     * Navigates a reader to the per-field {@link FlatVectorsReader} backing the given field (leaf 0). This format is
+     * registered directly as the per-field {@code KnnVectorsFormat} (no HNSW wrapper in between), so the per-field
+     * reader already {@code is} the {@link FlatVectorsReader} - no inner-field unwrap needed.
+     */
+    private static FlatVectorsReader flatVectorsReaderFor(final DirectoryReader reader, final String field) throws Exception {
+        final LeafReader leafReader = reader.leaves().get(0).reader();
+        final SegmentReader segmentReader = Lucene.segmentReader(leafReader);
+
+        final KnnVectorsReader perFieldReader = segmentReader.getVectorReader();
+        if (perFieldReader instanceof PerFieldKnnVectorsFormat.FieldsReader == false) {
+            throw new IllegalStateException("expected a PerFieldKnnVectorsFormat.FieldsReader but was " + perFieldReader);
+        }
+        final KnnVectorsReader fieldReader = ((PerFieldKnnVectorsFormat.FieldsReader) perFieldReader).getFieldReader(field);
+        if (fieldReader == null) {
+            throw new IllegalStateException("expected a per-field reader for " + field);
+        }
+        return (FlatVectorsReader) fieldReader;
+    }
+
+    private float[][] indexFloatDocs(final Directory dir) throws Exception {
+        return indexFloatDocs(dir, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private float[][] indexFloatDocs(final Directory dir, final VectorSimilarityFunction similarity) throws Exception {
+        final Codec codec = new UnitTestCodec(() -> new KNN1040HalfFloatScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE));
+        final IndexWriterConfig iwc = newIndexWriterConfig().setCodec(codec);
+        final float[][] vectors = generateVectors(NUM_DOCS);
+        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+            for (int i = 0; i < NUM_DOCS; i++) {
+                final Document doc = new Document();
+                doc.add(new KnnFloatVectorField(FIELD_NAME, vectors[i], similarity));
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+            writer.commit();
+        }
+        return vectors;
+    }
+
+    private float[][] generateVectors(int count) {
+        float[][] vectors = new float[count][DIMENSION];
+        for (int i = 0; i < count; i++) {
+            for (int d = 0; d < DIMENSION; d++) {
+                vectors[i][d] = (random().nextFloat() * 2 - 1) * 10;
+            }
+        }
+        return vectors;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HalfFloatScalarQuantizedVectorsFormatTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+
+public class KNN1040HalfFloatScalarQuantizedVectorsFormatTests extends KNNTestCase {
+
+    public void testConstructor_withHalfFloatRawVectorDataType_doesNotThrow() {
+        KNN1040HalfFloatScalarQuantizedVectorsFormat format = new KNN1040HalfFloatScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE);
+        assertNotNull(format);
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testDefaultConstructor_usesSingleBitQueryNibble() {
+        KNN1040HalfFloatScalarQuantizedVectorsFormat format = new KNN1040HalfFloatScalarQuantizedVectorsFormat();
+        assertTrue(format.toString().contains(SINGLE_BIT_QUERY_NIBBLE.name()));
+    }
+
+    public void testGetName_returnsClassName() {
+        KNN1040HalfFloatScalarQuantizedVectorsFormat format = new KNN1040HalfFloatScalarQuantizedVectorsFormat();
+        assertEquals("KNN1040HalfFloatScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    public void testGetName_floatAndHalfFloatVariantsAreDistinct() {
+        KNN1040ScalarQuantizedVectorsFormat floatFormat = new KNN1040ScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE);
+        KNN1040HalfFloatScalarQuantizedVectorsFormat halfFloatFormat = new KNN1040HalfFloatScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE
+        );
+        assertNotEquals(
+            "FLOAT and HALF_FLOAT SQ 1-bit formats must have different names or read-time SPI reconstruction cannot tell them apart",
+            floatFormat.getName(),
+            halfFloatFormat.getName()
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormatComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormatComponentTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableScorerTestUtils;
+import org.opensearch.knn.index.codec.util.UnitTestCodec;
+
+/**
+ * Component test for {@link KNN1040HnswHalfFloatScalarQuantizedVectorsFormat}: index a few float vector documents
+ * through a segment written with this format (HNSW graph over SQ 1-bit-quantized, FP16-sourced vectors), read the
+ * segment back, and validate the scorer wiring and end-to-end search behavior. As with the flat SQ component test,
+ * scores are not compared against an analytic similarity function - 1-bit scalar quantization is lossy, so only
+ * descending order and non-NaN scores are asserted.
+ */
+public class KNN1040HnswHalfFloatScalarQuantizedVectorsFormatComponentTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "fp16_sq_vector";
+    private static final int DIMENSION = 8;
+    private static final int NUM_DOCS = 10;
+
+    /**
+     * Index vectors through the HNSW + SQ 1-bit format, read them back, and validate the returned scorer.
+     *
+     * <p>{@link KNN1040HnswHalfFloatScalarQuantizedVectorsFormat} delegates flat storage and scoring to
+     * {@link KNN1040HalfFloatScalarQuantizedVectorsFormat}, so the random vector scorer handed out for graph
+     * traversal must still be prefetchable, same as the bare flat SQ format.
+     */
+    @SneakyThrows
+    public void testIndexAndRead_whenHnswHalfFloatScalarQuantizedVectorsFormat_thenScorerIsPrefetchable() {
+        try (Directory dir = newDirectory()) {
+            final float[][] vectors = indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final FlatVectorsReader flatVectorsReader = PrefetchableScorerTestUtils.flatVectorsReaderFor(reader, FIELD_NAME);
+
+                final RandomVectorScorer scorer = flatVectorsReader.getRandomVectorScorer(FIELD_NAME, vectors[0]);
+                assertTrue(
+                    "random vector scorer must be the prefetchable variant but was " + scorer.getClass().getName(),
+                    scorer instanceof PrefetchableRandomVectorScorer
+                );
+                assertEquals("maxOrd should match number of vectors", NUM_DOCS, scorer.maxOrd());
+            }
+        }
+    }
+
+    /**
+     * Runs an actual kNN search over the indexed vectors (via the HNSW graph). Quantization is lossy, so this only
+     * checks that every doc is returned, scores are non-NaN, and scores come back in descending order.
+     */
+    @SneakyThrows
+    public void testSearch_whenHnswHalfFloatScalarQuantizedVectorsFormat_thenScoresDescendingAndNotNaN() {
+        try (Directory dir = newDirectory()) {
+            final float[][] vectors = indexFloatDocs(dir);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final float[] query = vectors[2];
+
+                final TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FIELD_NAME, query, NUM_DOCS), NUM_DOCS);
+
+                assertEquals("all indexed docs should be returned", NUM_DOCS, topDocs.scoreDocs.length);
+
+                float previousScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    assertFalse("score should not be NaN for doc " + scoreDoc.doc, Float.isNaN(scoreDoc.score));
+                    assertTrue("scores must be in descending order", scoreDoc.score <= previousScore);
+                    previousScore = scoreDoc.score;
+                }
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testSearch_whenHnswHalfFloatScalarQuantizedVectorsFormatWithCosine_thenScoresDescendingAndNotNaN() {
+        try (Directory dir = newDirectory()) {
+            final float[][] vectors = indexFloatDocs(dir, VectorSimilarityFunction.COSINE);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                final IndexSearcher searcher = new IndexSearcher(reader);
+                final float[] query = vectors[2];
+
+                final TopDocs topDocs = searcher.search(new KnnFloatVectorQuery(FIELD_NAME, query, NUM_DOCS), NUM_DOCS);
+
+                assertEquals("all indexed docs should be returned", NUM_DOCS, topDocs.scoreDocs.length);
+
+                float previousScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    assertFalse("score should not be NaN for doc " + scoreDoc.doc, Float.isNaN(scoreDoc.score));
+                    assertTrue("scores must be in descending order", scoreDoc.score <= previousScore);
+                    previousScore = scoreDoc.score;
+                }
+            }
+        }
+    }
+
+    private float[][] indexFloatDocs(final Directory dir) throws Exception {
+        return indexFloatDocs(dir, VectorSimilarityFunction.EUCLIDEAN);
+    }
+
+    private float[][] indexFloatDocs(final Directory dir, final VectorSimilarityFunction similarity) throws Exception {
+        final Codec codec = new UnitTestCodec(KNN1040HnswHalfFloatScalarQuantizedVectorsFormat::new);
+        final IndexWriterConfig iwc = newIndexWriterConfig().setCodec(codec);
+        final float[][] vectors = generateVectors(NUM_DOCS);
+        try (IndexWriter writer = new IndexWriter(dir, iwc)) {
+            for (int i = 0; i < NUM_DOCS; i++) {
+                final Document doc = new Document();
+                doc.add(new KnnFloatVectorField(FIELD_NAME, vectors[i], similarity));
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+            writer.commit();
+        }
+        return vectors;
+    }
+
+    private float[][] generateVectors(int count) {
+        float[][] vectors = new float[count][DIMENSION];
+        for (int i = 0; i < count; i++) {
+            for (int d = 0; d < DIMENSION; d++) {
+                vectors[i][d] = (random().nextFloat() * 2 - 1) * 10;
+            }
+        }
+        return vectors;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswHalfFloatScalarQuantizedVectorsFormatTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+
+public class KNN1040HnswHalfFloatScalarQuantizedVectorsFormatTests extends KNNTestCase {
+
+    public void testDefaultConstructor() {
+        KNN1040HnswHalfFloatScalarQuantizedVectorsFormat format = new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat();
+        assertNotNull(format);
+        String str = format.toString();
+        assertTrue(str.contains("KNN1040HnswHalfFloatScalarQuantizedVectorsFormat"));
+        assertTrue(str.contains(SINGLE_BIT_QUERY_NIBBLE.name()));
+    }
+
+    public void testCustomConstructor() {
+        KNN1040HnswHalfFloatScalarQuantizedVectorsFormat format = new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE,
+            32,
+            200,
+            1,
+            null
+        );
+        assertNotNull(format);
+        assertEquals("KNN1040HnswHalfFloatScalarQuantizedVectorsFormat", format.getName());
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testConstructor_whenCustomTinySegmentsThreshold_thenSucceeds() {
+        KNN1040HnswHalfFloatScalarQuantizedVectorsFormat format = new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE,
+            16,
+            100,
+            1,
+            null,
+            500
+        );
+        assertNotNull(format);
+        assertEquals("KNN1040HnswHalfFloatScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    public void testConstructor_invalidMaxConn_thenThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE, 0, 100, 1, null)
+        );
+    }
+
+    public void testGetName_floatAndHalfFloatVariantsAreDistinct() {
+        KNN1040HnswScalarQuantizedVectorsFormat floatFormat = new KNN1040HnswScalarQuantizedVectorsFormat();
+        KNN1040HnswHalfFloatScalarQuantizedVectorsFormat halfFloatFormat = new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat();
+        assertNotEquals(
+            "FLOAT and HALF_FLOAT HNSW SQ 1-bit formats must have different names or read-time SPI "
+                + "reconstruction cannot tell them apart",
+            floatFormat.getName(),
+            halfFloatFormat.getName()
+        );
+    }
+
+    public void testSpiReconstruction_resolvesToHalfFloatVariant() {
+        KNN1040HnswHalfFloatScalarQuantizedVectorsFormat writeFormat = new KNN1040HnswHalfFloatScalarQuantizedVectorsFormat();
+        KnnVectorsFormat readFormat = KnnVectorsFormat.forName(writeFormat.getName());
+        assertTrue(
+            "forName(" + writeFormat.getName() + ") should resolve to the half_float HNSW SQ format",
+            readFormat instanceof KNN1040HnswHalfFloatScalarQuantizedVectorsFormat
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneFlatMethodResolverTests.java
@@ -225,11 +225,11 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
     }
 
     /**
-     * HALF_FLOAT must not inherit the x32 default: it does not go through an encoder, and x32
-     * combined with the flat method switches on a default rescore that cannot change an exhaustive
-     * FP16 ranking.
+     * HALF_FLOAT must not inherit FLOAT's x32 default: absent an explicit choice, it defaults to x16
+     * (SQ 1-bit on 16-bit storage) - unlike {@link LuceneHNSWMethodResolver}, which defaults HALF_FLOAT
+     * to x1 (exact FP16, no SQ) instead.
      */
-    public void testResolveMethod_whenFlatMethodWithHalfFloat_thenCompressionX1AndNoRescore() {
+    public void testResolveMethod_whenFlatMethodWithHalfFloat_thenCompressionX16() {
         KNNMethodContext flatMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
             SpaceType.L2,
@@ -242,11 +242,7 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
             SpaceType.L2
         );
 
-        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
-        assertNull(
-            "half_float flat must not default to a rescore pass",
-            resolvedMethodContext.getCompressionLevel().getDefaultRescoreContext()
-        );
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
 
         // FLOAT keeps the existing x32 default and its rescore behaviour.
         ResolvedMethodContext floatContext = TEST_RESOLVER.resolveMethod(
@@ -258,7 +254,10 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
         assertEquals(CompressionLevel.x32, floatContext.getCompressionLevel());
     }
 
-    /** The default (x1) must also be accepted when set explicitly, not just by default. */
+    /**
+     * HALF_FLOAT may opt into x1 explicitly: exact FP16 storage, no further reduction (the flat
+     * method's default is x16, so this only applies when x1 is explicitly requested).
+     */
     public void testResolveMethod_whenFlatMethodWithHalfFloatAndExplicitX1_thenResolve() {
         KNNMethodContext flatMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
@@ -278,21 +277,37 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
         assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
     }
 
-    /**
-     * Every compression level outside {@link LuceneFlatMethodResolver#SUPPORTED_COMPRESSION_HALF_FLOAT}
-     * must throw. Driving the loop off that set rather than a hardcoded level keeps this honest as
-     * levels are added: a newly supported level drops out of the loop, the rest still have to fail.
-     */
-    public void testResolveMethod_whenFlatMethodWithHalfFloatAndUnsupportedCompression_thenThrow() {
+    public void testResolveMethod_whenFlatMethodWithHalfFloatAndExplicitX16_thenResolve() {
         KNNMethodContext flatMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
             SpaceType.L2,
             new MethodComponentContext(METHOD_FLAT, Map.of())
         );
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            flatMethodContext,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.HALF_FLOAT)
+                .compressionLevel(CompressionLevel.x16)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
+    }
+
+    /** Every compression level besides x1 (opt-in exact FP16) and x16 (default, SQ 1-bit) must still be rejected for HALF_FLOAT. */
+    public void testResolveMethod_whenFlatMethodWithHalfFloatAndUnsupportedCompression_thenThrow() {
         for (CompressionLevel level : CompressionLevel.values()) {
-            if (level == CompressionLevel.NOT_CONFIGURED || LuceneFlatMethodResolver.SUPPORTED_COMPRESSION_HALF_FLOAT.contains(level)) {
+            if (level == CompressionLevel.NOT_CONFIGURED
+                || LuceneFlatMethodResolver.SUPPORTED_COMPRESSION_LEVELS_HALF_FLOAT.contains(level)) {
                 continue;
             }
+            KNNMethodContext flatMethodContext = new KNNMethodContext(
+                KNNEngine.LUCENE,
+                SpaceType.L2,
+                new MethodComponentContext(METHOD_FLAT, Map.of())
+            );
             expectThrows(
                 ValidationException.class,
                 () -> TEST_RESOLVER.resolveMethod(
@@ -323,5 +338,23 @@ public class LuceneFlatMethodResolverTests extends KNNTestCase {
         );
         assertEquals(METHOD_FLAT, resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getName());
         assertEquals(SpaceType.INNER_PRODUCT, resolvedMethodContext.getKnnMethodContext().getSpaceType());
+    }
+
+    public void testResolveMethod_whenHalfFloatWithMode_thenThrows() {
+        for (Mode mode : new Mode[] { Mode.ON_DISK, Mode.IN_MEMORY }) {
+            expectThrows(
+                ValidationException.class,
+                () -> TEST_RESOLVER.resolveMethod(
+                    new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_FLAT, java.util.Map.of())),
+                    KNNMethodConfigContext.builder()
+                        .vectorDataType(VectorDataType.HALF_FLOAT)
+                        .mode(mode)
+                        .versionCreated(Version.CURRENT)
+                        .build(),
+                    false,
+                    SpaceType.L2
+                )
+            );
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
@@ -515,6 +515,51 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveMethod_whenHalfFloatExplicitCompression16x_thenResolvesToSQOneBit() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.HALF_FLOAT)
+                .compressionLevel(CompressionLevel.x16)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
+        assertEquals(
+            ENCODER_SQ,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+        assertEquals(
+            1,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getParameters().get(LUCENE_SQ_BITS)
+        );
+    }
+
+    // half_float only supports the SQ 1-bit path; x4 (bits=7) has no valid encoder to auto-resolve to.
+    public void testResolveMethod_whenHalfFloatExplicitCompression4x_thenThrows() {
+        expectThrows(
+            ValidationException.class,
+            () -> TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder()
+                    .vectorDataType(VectorDataType.HALF_FLOAT)
+                    .compressionLevel(CompressionLevel.x4)
+                    .versionCreated(Version.CURRENT)
+                    .build(),
+                false,
+                SpaceType.L2
+            )
+        );
+    }
+
     public void testResolveMethod_whenExplicitCompression4x_thenResolvesToSQSevenBit() {
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
@@ -690,6 +735,95 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         }
     }
 
+    public void testResolveMethod_whenHalfFloatOnDisk_thenResolvesToX16WithSQOneBit() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.HALF_FLOAT)
+                .mode(Mode.ON_DISK)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
+        MethodComponentContext encoder = (MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_SQ, encoder.getName());
+        // Without the data-type-aware default this resolves x32, which picks bits=7 - rejected for half_float.
+        assertEquals(1, encoder.getParameters().get(LUCENE_SQ_BITS));
+    }
+
+    public void testResolveMethod_whenHalfFloatOnDiskWithX16_thenResolvesToX16() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.HALF_FLOAT)
+                .mode(Mode.ON_DISK)
+                .compressionLevel(CompressionLevel.x16)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+
+        assertEquals(CompressionLevel.x16, resolvedMethodContext.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenHalfFloatOnDiskWithX1_thenThrows() {
+        expectThrows(
+            ValidationException.class,
+            () -> TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder()
+                    .vectorDataType(VectorDataType.HALF_FLOAT)
+                    .mode(Mode.ON_DISK)
+                    .compressionLevel(CompressionLevel.x1)
+                    .versionCreated(Version.CURRENT)
+                    .build(),
+                false,
+                SpaceType.L2
+            )
+        );
+    }
+
+    public void testResolveMethod_whenHalfFloatInMemory_thenStillResolvesToX1() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.HALF_FLOAT)
+                .mode(Mode.IN_MEMORY)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenHalfFloatOnDiskWithFloatOnlyCompression_thenThrows() {
+        for (CompressionLevel unsupported : java.util.List.of(CompressionLevel.x2, CompressionLevel.x4, CompressionLevel.x32)) {
+            expectThrows(
+                ValidationException.class,
+                () -> TEST_RESOLVER.resolveMethod(
+                    null,
+                    KNNMethodConfigContext.builder()
+                        .vectorDataType(VectorDataType.HALF_FLOAT)
+                        .mode(Mode.ON_DISK)
+                        .compressionLevel(unsupported)
+                        .versionCreated(Version.CURRENT)
+                        .build(),
+                    false,
+                    SpaceType.L2
+                )
+            );
+        }
+    }
+
     public void testResolveMethod_whenHalfFloat_thenResolvesToX1WithoutEncoder() {
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
@@ -702,7 +836,7 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         assertEquals(SpaceType.L2, resolvedMethodContext.getKnnMethodContext().getSpaceType());
         assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
         assertFalse(
-            "half_float must not go through an encoder",
+            "half_float must not go through the SQ encoder",
             resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
         );
     }
@@ -725,31 +859,23 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         );
     }
 
-    /**
-     * Every compression level outside {@link LuceneHNSWMethodResolver#SUPPORTED_COMPRESSION_HALF_FLOAT}
-     * must be rejected, not silently ignored or conflated with an encoder. Driving the loop off that
-     * set rather than a hardcoded level keeps this honest as levels are added: a newly supported
-     * level drops out of the loop, the rest still have to fail.
-     */
-    public void testResolveMethod_whenHalfFloatWithUnsupportedCompression_thenThrow() {
-        for (CompressionLevel level : CompressionLevel.values()) {
-            if (level == CompressionLevel.NOT_CONFIGURED || LuceneHNSWMethodResolver.SUPPORTED_COMPRESSION_HALF_FLOAT.contains(level)) {
-                continue;
-            }
-            expectThrows(
-                ValidationException.class,
-                () -> TEST_RESOLVER.resolveMethod(
-                    null,
-                    KNNMethodConfigContext.builder()
-                        .vectorDataType(VectorDataType.HALF_FLOAT)
-                        .compressionLevel(level)
-                        .versionCreated(Version.CURRENT)
-                        .build(),
-                    false,
-                    SpaceType.L2
-                )
-            );
-        }
+    /** x16 now resolves to SQ 1-bit for half_float too - see testResolveMethod_whenHalfFloatExplicitCompression16x_thenResolvesToSQOneBit.
+     *  Any level other than x1/x16 must still be rejected, not silently ignored - see
+     *  testResolveMethod_whenHalfFloatExplicitCompression4x_thenThrows. */
+    public void testResolveMethod_whenHalfFloatWithExplicitX8_thenThrow() {
+        expectThrows(
+            ValidationException.class,
+            () -> TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder()
+                    .vectorDataType(VectorDataType.HALF_FLOAT)
+                    .compressionLevel(CompressionLevel.x8)
+                    .versionCreated(Version.CURRENT)
+                    .build(),
+                false,
+                SpaceType.L2
+            )
+        );
     }
 
     public void testResolveMethod_whenHalfFloatWithTraining_thenThrow() {
@@ -762,6 +888,30 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
                 SpaceType.L2
             )
         );
+    }
+
+    // half_float's SQ 1-bit is fully determined by compression_level and auto-resolved internally -
+    // users must not be able to configure it by writing an encoder block themselves.
+    public void testResolveMethod_whenHalfFloatWithExplicitEncoder_thenThrow() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 1)))
+            )
+        );
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> TEST_RESOLVER.resolveMethod(
+                knnMethodContext,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.HALF_FLOAT).versionCreated(Version.CURRENT).build(),
+                false,
+                SpaceType.L2
+            )
+        );
+        assertTrue(e.getMessage().contains(METHOD_ENCODER_PARAMETER));
+        assertTrue(e.getMessage().contains("half_float"));
     }
 
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
@@ -224,10 +224,31 @@ public class LuceneSQEncoderTests extends KNNTestCase {
         encoder.validate(null, null);
     }
 
+    public void testValidate_whenHalfFloatWithBits1_thenOk() {
+        callValidateEncoderParams(Version.CURRENT, VectorDataType.HALF_FLOAT, CompressionLevel.x16, Map.of(LUCENE_SQ_BITS, 1));
+    }
+
+    public void testValidate_whenHalfFloatWithBits7_thenError() {
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> callValidateEncoderParams(Version.CURRENT, VectorDataType.HALF_FLOAT, CompressionLevel.x4, Map.of(LUCENE_SQ_BITS, 7))
+        );
+        assertTrue(e.getMessage().contains("half_float"));
+    }
+
     private void callValidateEncoderParams(Version version, CompressionLevel compressionLevel, Map<String, Object> encoderParams) {
+        callValidateEncoderParams(version, VectorDataType.FLOAT, compressionLevel, encoderParams);
+    }
+
+    private void callValidateEncoderParams(
+        Version version,
+        VectorDataType vectorDataType,
+        CompressionLevel compressionLevel,
+        Map<String, Object> encoderParams
+    ) {
         KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
             .versionCreated(version)
-            .vectorDataType(VectorDataType.FLOAT)
+            .vectorDataType(vectorDataType)
             .dimension(128)
             .compressionLevel(compressionLevel)
             .build();

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.mapper;
 import org.opensearch.Version;
 import org.opensearch.core.common.Strings;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.Encoder.QuantizationBits;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -265,7 +266,7 @@ public class CompressionLevelTests extends KNNTestCase {
         assertEquals(CompressionLevel.x32, QuantizationBits.ONE.getCompressionLevel());
         assertEquals(1, QuantizationBits.ONE.getValue());
 
-        assertEquals(CompressionLevel.x32, LuceneSQEncoder.Bits.ONE.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, LuceneSQEncoder.Bits.ONE.getCompressionLevel(VectorDataType.FLOAT));
         assertEquals(1, LuceneSQEncoder.Bits.ONE.getValue());
 
         assertEquals(1, ScalarQuantizationType.ONE_BIT.getId());
@@ -324,9 +325,9 @@ public class CompressionLevelTests extends KNNTestCase {
         QuantizationBits faissBits1 = QuantizationBits.fromValue(1);
         LuceneSQEncoder.Bits luceneBits1 = LuceneSQEncoder.Bits.fromValue(1);
 
-        assertEquals(faissBits1.getCompressionLevel(), luceneBits1.getCompressionLevel());
+        assertEquals(faissBits1.getCompressionLevel(), luceneBits1.getCompressionLevel(VectorDataType.FLOAT));
         assertEquals(CompressionLevel.x32, faissBits1.getCompressionLevel());
-        assertEquals(CompressionLevel.x32, luceneBits1.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, luceneBits1.getCompressionLevel(VectorDataType.FLOAT));
     }
 
     private ResolvedIndexSpec buildSpec(CompressionLevel compression, Mode mode, int dimension, KNNEngine engine) {

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -2873,7 +2873,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
 
         // half_float + flat with no compression_level set must still succeed
-        // and implicitly resolve to 1x
+        // and implicitly resolve to 16x
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
@@ -2922,7 +2922,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testTypeParser_whenHalfFloatFlatWithExplicitX32Compression_thenThrow() {
+    public void testTypeParser_whenHalfFloatFlatWithExplicitX16Compression_thenSuccess() {
         String fieldName = "test-field-name";
         String indexName = "test-index-name";
 
@@ -2930,15 +2930,42 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
 
-        // x32 is 1-bit scalar quantization, which half_float never resolves to. The rejection no
-        // longer comes from the mapper's blanket non-float compression check -- it comes from
-        // LuceneFlatMethodResolver's per-data-type validation.
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
             .field(DIMENSION_FIELD_NAME, TEST_DIMENSION)
             .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.HALF_FLOAT.getValue())
-            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x32.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x16.getName())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_FLAT)
+            .endObject()
+            .endObject();
+
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext(indexName, settings)
+        );
+        assertNotNull(builder);
+    }
+
+    @SneakyThrows
+    public void testTypeParser_whenHalfFloatFlatWithUnsupportedCompression_thenThrow() {
+        String fieldName = "test-field-name";
+        String indexName = "test-index-name";
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        // half_float only supports x1 or x16 (opt-in SQ 1-bit, also the default); anything else must
+        // still be rejected, by LuceneFlatMethodResolver's per-data-type validation.
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, TEST_DIMENSION)
+            .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.HALF_FLOAT.getValue())
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x4.getName())
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_FLAT)
             .endObject()
@@ -2948,7 +2975,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             ValidationException.class,
             () -> typeParser.parse(fieldName, xContentBuilderToMap(xContentBuilder), buildParserContext(indexName, settings))
         );
-        assertTrue(exception.getMessage().contains("\"32x\" compression"));
+        assertTrue(exception.getMessage().contains("compression"));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/integ/HalfFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/HalfFloatIndexIT.java
@@ -282,6 +282,461 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
     }
 
     // ────────────────────────────────────────────────────────────────────────────
+    // SQ 1-bit (16x compression) — flat method, FP16 rescoring copy instead of FP32
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_indexAndSearch() {
+        String mapping = buildHalfFloatSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Closest to origin should be doc 3
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_innerProductSpace() {
+        String mapping = buildHalfFloatSq1BitMapping("innerproduct");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 0.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 0.0f, 1.0f, 0.0f, 0.0f });
+
+        float[] queryVector = { 1.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 2, queryVector, null), 2);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        assertEquals(2, parseHits(responseBody));
+    }
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_cosineSpace() {
+        String mapping = buildHalfFloatSq1BitMapping("cosinesimil");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 0.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 0.0f, 1.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 1.0f, 1.0f, 0.0f, 0.0f });
+
+        float[] queryVector = { 1.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Doc 1 is identical direction to query, should be the top result
+        assertEquals("1", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_forceMerge() {
+        String mapping = buildHalfFloatSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        // Index docs one by one to create multiple segments
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        flushIndex(INDEX_NAME, true);
+
+        // Force merge into 1 segment — recomputes .veq from the merged (FP16-decoded) source
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Closest to origin should be doc 3
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_indexSortedForceMerge() {
+        final String sortFieldName = "sort_key";
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.sort.field", sortFieldName)
+            .put("index.sort.order", "desc")
+            .build();
+        String mapping = buildHalfFloatSq1BitMappingWithSortField(sortFieldName);
+        createIndex(INDEX_NAME, settings, mapping.substring(1, mapping.length() - 1));
+
+        Float[][] vectors = {
+            { 1.0f, 2.0f, 3.0f, 4.0f },
+            { 5.0f, 6.0f, 7.0f, 8.0f },
+            { 0.1f, 0.2f, 0.3f, 0.4f },
+            { 10.0f, 10.0f, 10.0f, 10.0f } };
+        for (int i = 0; i < vectors.length; i++) {
+            addKnnDocWithAttributes(INDEX_NAME, String.valueOf(i + 1), FIELD_NAME, vectors[i], Map.of(sortFieldName, String.valueOf(i)));
+        }
+
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 4, queryVector, null), 4);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(4, results.size());
+        assertEquals("3", results.get(0).getDocId());
+        assertEquals("1", results.get(1).getDocId());
+        assertEquals("2", results.get(2).getDocId());
+        assertEquals("4", results.get(3).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_deleteAndSearch() {
+        String mapping = buildHalfFloatSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, new Float[] { 10.0f, 10.0f, 10.0f, 10.0f });
+
+        // Delete doc 2 (creates sparse segment)
+        deleteKnnDoc(INDEX_NAME, "2");
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        assertTrue(results.stream().noneMatch(r -> "2".equals(r.getDocId())));
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_multipleSegments() {
+        String mapping = buildHalfFloatSq1BitMapping("l2");
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.refresh_interval", "-1")
+            .build();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+
+        int totalDocs = 20;
+        for (int i = 0; i < totalDocs; i++) {
+            Float[] vec = { (float) i, (float) (i + 1), (float) (i + 2), (float) (i + 3) };
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, vec);
+            if (i % 5 == 4) {
+                flushIndex(INDEX_NAME, true);
+            }
+        }
+        refreshIndex(INDEX_NAME);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 5, queryVector, null), 5);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(5, results.size());
+        assertEquals("0", results.get(0).getDocId());
+    }
+
+    // Any compression level other than 1x (default) or 16x (this feature) must still be rejected.
+    @SneakyThrows
+    public void testHalfFloatFlat_withUnsupportedCompression_shouldFail() {
+        // half_float supports only 1x and 16x - every level defined against FLOAT's 32 bits is rejected.
+        for (String compression : new String[] { "2x", "4x", "8x", "32x" }) {
+            String mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(FIELD_NAME)
+                .dimension(DIMENSION)
+                .vectorDataType("half_float")
+                .compressionLevel(compression)
+                .method(KNNJsonIndexMappingsBuilder.Method.builder().methodName("flat").spaceType("l2").build())
+                .build()
+                .getIndexMapping();
+
+            // A distinct index per case, so a create that unexpectedly succeeds cannot make the next
+            // iteration fail with "already exists" and hide which level was accepted.
+            final String indexName = INDEX_NAME + "_" + compression;
+            ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(indexName, mapping));
+            assertTrue(compression + " -> " + ex.getMessage(), ex.getMessage().contains("compression"));
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // SQ 1-bit (16x compression) — hnsw method, FP16 rescoring copy instead of FP32
+    // ────────────────────────────────────────────────────────────────────────────
+
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_indexAndSearch() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Closest to origin should be doc 3
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_innerProductSpace() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("innerproduct");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 0.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 0.0f, 1.0f, 0.0f, 0.0f });
+
+        float[] queryVector = { 1.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 2, queryVector, null), 2);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        assertEquals(2, parseHits(responseBody));
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_cosineSpace() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("cosinesimil");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 0.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 0.0f, 1.0f, 0.0f, 0.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 1.0f, 1.0f, 0.0f, 0.0f });
+
+        float[] queryVector = { 1.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Doc 1 is identical direction to query, should be the top result
+        assertEquals("1", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_forceMerge() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        // Index docs one by one to create multiple segments, each with its own HNSW graph
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        flushIndex(INDEX_NAME, true);
+
+        // Force merge into 1 segment — rebuilds the HNSW graph and recomputes .veq from the merged
+        // (FP16-decoded) source
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Closest to origin should be doc 3
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    /**
+     * Force merges an index-sorted index. Same rationale as
+     * {@link #testHalfFloatFlatSq1BitIndex_indexSortedForceMerge}, but for the HNSW graph wrapper:
+     * the merge must interleave segments while also rebuilding the graph and recomputing .veq codes
+     * from the reordered source.
+     */
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_indexSortedForceMerge() {
+        final String sortFieldName = "sort_key";
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.sort.field", sortFieldName)
+            .put("index.sort.order", "desc")
+            .build();
+        String mapping = buildHalfFloatHnswSq1BitMappingWithSortField(sortFieldName);
+        createIndex(INDEX_NAME, settings, mapping.substring(1, mapping.length() - 1));
+
+        Float[][] vectors = {
+            { 1.0f, 2.0f, 3.0f, 4.0f },
+            { 5.0f, 6.0f, 7.0f, 8.0f },
+            { 0.1f, 0.2f, 0.3f, 0.4f },
+            { 10.0f, 10.0f, 10.0f, 10.0f } };
+        for (int i = 0; i < vectors.length; i++) {
+            addKnnDocWithAttributes(INDEX_NAME, String.valueOf(i + 1), FIELD_NAME, vectors[i], Map.of(sortFieldName, String.valueOf(i)));
+        }
+
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 4, queryVector, null), 4);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(4, results.size());
+        assertEquals("3", results.get(0).getDocId());
+        assertEquals("1", results.get(1).getDocId());
+        assertEquals("2", results.get(2).getDocId());
+        assertEquals("4", results.get(3).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_deleteAndSearch() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, new Float[] { 10.0f, 10.0f, 10.0f, 10.0f });
+
+        // Delete doc 2 (creates sparse segment)
+        deleteKnnDoc(INDEX_NAME, "2");
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        assertTrue(results.stream().noneMatch(r -> "2".equals(r.getDocId())));
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_multipleSegments() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("l2");
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.refresh_interval", "-1")
+            .build();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+
+        int totalDocs = 20;
+        for (int i = 0; i < totalDocs; i++) {
+            Float[] vec = { (float) i, (float) (i + 1), (float) (i + 2), (float) (i + 3) };
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, vec);
+            if (i % 5 == 4) {
+                flushIndex(INDEX_NAME, true);
+            }
+        }
+        refreshIndex(INDEX_NAME);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 5, queryVector, null), 5);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(5, results.size());
+        assertEquals("0", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnsw_withExplicitEncoder_shouldFail() {
+        String mapping = buildHalfFloatHnswSqMapping("l2", 7);
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, mapping));
+        assertTrue(ex.getMessage().contains("encoder"));
+        assertTrue(ex.getMessage().contains("compression_level"));
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnsw_withUnsupportedCompression_shouldFail() {
+        // half_float supports only 1x and 16x - every level defined against FLOAT's 32 bits is rejected.
+        for (String compression : new String[] { "2x", "4x", "8x", "32x" }) {
+            String mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(FIELD_NAME)
+                .dimension(DIMENSION)
+                .vectorDataType("half_float")
+                .compressionLevel(compression)
+                .method(KNNJsonIndexMappingsBuilder.Method.builder().methodName("hnsw").engine("lucene").spaceType("l2").build())
+                .build()
+                .getIndexMapping();
+
+            final String indexName = INDEX_NAME + "_" + compression;
+            ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(indexName, mapping));
+            assertTrue(compression + " -> " + ex.getMessage(), ex.getMessage().contains("compression"));
+        }
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswOnDisk_indexAndSearch() {
+        // ON_DISK now resolves half_float to x16 (SQ 1-bit), the counterpart of FLOAT's ON_DISK -> x32.
+        String mapping = "{"
+            + "\"properties\":{"
+            + "\""
+            + FIELD_NAME
+            + "\":{"
+            + "\"type\":\"knn_vector\","
+            + "\"dimension\":"
+            + DIMENSION
+            + ","
+            + "\"data_type\":\"half_float\","
+            + "\"mode\":\"on_disk\","
+            + "\"method\":{"
+            + "\"name\":\"hnsw\","
+            + "\"engine\":\"lucene\","
+            + "\"space_type\":\"l2\""
+            + "}}}}";
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(3, results.size());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatHnswOnDiskWithX1_shouldFail() {
+        String mapping = "{"
+            + "\"properties\":{"
+            + "\""
+            + FIELD_NAME
+            + "\":{"
+            + "\"type\":\"knn_vector\","
+            + "\"dimension\":"
+            + DIMENSION
+            + ","
+            + "\"data_type\":\"half_float\","
+            + "\"mode\":\"on_disk\","
+            + "\"compression_level\":\"1x\","
+            + "\"method\":{"
+            + "\"name\":\"hnsw\","
+            + "\"engine\":\"lucene\","
+            + "\"space_type\":\"l2\""
+            + "}}}}";
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, mapping));
+        assertTrue(ex.getMessage(), ex.getMessage().contains("x1"));
+        assertTrue(ex.getMessage(), ex.getMessage().contains("on_disk"));
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
     // HNSW (Lucene engine)
     // ────────────────────────────────────────────────────────────────────────────
 
@@ -616,6 +1071,17 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
             .getIndexMapping();
     }
 
+    private String buildHalfFloatSq1BitMapping(String spaceType) throws Exception {
+        return KNNJsonIndexMappingsBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .dimension(DIMENSION)
+            .vectorDataType("half_float")
+            .compressionLevel("16x")
+            .method(KNNJsonIndexMappingsBuilder.Method.builder().methodName("flat").spaceType(spaceType).build())
+            .build()
+            .getIndexMapping();
+    }
+
     private String buildHalfFloatHnswMapping(String spaceType) throws Exception {
         return KNNJsonIndexMappingsBuilder.builder()
             .fieldName(FIELD_NAME)
@@ -624,6 +1090,80 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
             .method(KNNJsonIndexMappingsBuilder.Method.builder().methodName("hnsw").engine("lucene").spaceType(spaceType).build())
             .build()
             .getIndexMapping();
+    }
+
+    private String buildHalfFloatHnswSq1BitMapping(String spaceType) {
+        return "{"
+            + "\"properties\":{"
+            + "\""
+            + FIELD_NAME
+            + "\":{"
+            + "\"type\":\"knn_vector\","
+            + "\"dimension\":"
+            + DIMENSION
+            + ","
+            + "\"data_type\":\"half_float\","
+            + "\"compression_level\":\"16x\","
+            + "\"method\":{"
+            + "\"name\":\"hnsw\","
+            + "\"engine\":\"lucene\","
+            + "\"space_type\":\""
+            + spaceType
+            + "\""
+            + "}"
+            + "}"
+            + "}}";
+    }
+
+    private String buildHalfFloatHnswSqMapping(String spaceType, int bits) {
+        return "{"
+            + "\"properties\":{"
+            + "\""
+            + FIELD_NAME
+            + "\":{"
+            + "\"type\":\"knn_vector\","
+            + "\"dimension\":"
+            + DIMENSION
+            + ","
+            + "\"data_type\":\"half_float\","
+            + "\"method\":{"
+            + "\"name\":\"hnsw\","
+            + "\"engine\":\"lucene\","
+            + "\"space_type\":\""
+            + spaceType
+            + "\","
+            + "\"parameters\":{"
+            + "\"encoder\":{\"name\":\"sq\",\"parameters\":{\"bits\":"
+            + bits
+            + "}}"
+            + "}"
+            + "}"
+            + "}"
+            + "}}";
+    }
+
+    private String buildHalfFloatHnswSq1BitMappingWithSortField(String sortFieldName) {
+        return "{"
+            + "\"properties\":{"
+            + "\""
+            + FIELD_NAME
+            + "\":{"
+            + "\"type\":\"knn_vector\","
+            + "\"dimension\":"
+            + DIMENSION
+            + ","
+            + "\"data_type\":\"half_float\","
+            + "\"compression_level\":\"16x\","
+            + "\"method\":{"
+            + "\"name\":\"hnsw\","
+            + "\"engine\":\"lucene\","
+            + "\"space_type\":\"l2\""
+            + "}"
+            + "},"
+            + "\""
+            + sortFieldName
+            + "\":{\"type\":\"long\"}"
+            + "}}";
     }
 
     private String buildHalfFloatMappingWithSortField(String sortFieldName) {
@@ -652,6 +1192,26 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
             + "\":{\"type\":\""
             + extraFieldType
             + "\"}"
+            + "}}";
+    }
+
+    private String buildHalfFloatSq1BitMappingWithSortField(String sortFieldName) {
+        return "{"
+            + "\"properties\":{"
+            + "\""
+            + FIELD_NAME
+            + "\":{"
+            + "\"type\":\"knn_vector\","
+            + "\"dimension\":"
+            + DIMENSION
+            + ","
+            + "\"data_type\":\"half_float\","
+            + "\"compression_level\":\"16x\","
+            + "\"method\":{\"name\":\"flat\",\"space_type\":\"l2\"}"
+            + "},"
+            + "\""
+            + sortFieldName
+            + "\":{\"type\":\"long\"}"
             + "}}";
     }
 

--- a/src/test/java/org/opensearch/knn/integ/HalfFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/HalfFloatIndexIT.java
@@ -364,6 +364,33 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testHalfFloatFlatSq1BitIndex_closeAndReopen() {
+        String mapping = buildHalfFloatSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        flushIndex(INDEX_NAME, true);
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        closeKNNIndex(INDEX_NAME);
+        openIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Closest to origin should be doc 3
+        assertEquals("3", results.get(0).getDocId());
+    }
+
+    @SneakyThrows
     public void testHalfFloatFlatSq1BitIndex_indexSortedForceMerge() {
         final String sortFieldName = "sort_key";
 
@@ -557,12 +584,33 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
         assertEquals("3", results.get(0).getDocId());
     }
 
-    /**
-     * Force merges an index-sorted index. Same rationale as
-     * {@link #testHalfFloatFlatSq1BitIndex_indexSortedForceMerge}, but for the HNSW graph wrapper:
-     * the merge must interleave segments while also rebuilding the graph and recomputing .veq codes
-     * from the reordered source.
-     */
+    @SneakyThrows
+    public void testHalfFloatHnswSq1BitIndex_closeAndReopen() {
+        String mapping = buildHalfFloatHnswSq1BitMapping("l2");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        flushIndex(INDEX_NAME, true);
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        closeKNNIndex(INDEX_NAME);
+        openIndex(INDEX_NAME);
+        ensureGreen(INDEX_NAME);
+
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        Response response = searchKNNIndex(INDEX_NAME, buildSearchQuery(FIELD_NAME, 3, queryVector, null), 3);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(3, results.size());
+        // Closest to origin should be doc 3
+        assertEquals("3", results.get(0).getDocId());
+    }
+
     @SneakyThrows
     public void testHalfFloatHnswSq1BitIndex_indexSortedForceMerge() {
         final String sortFieldName = "sort_key";

--- a/src/test/java/org/opensearch/knn/search/processor/mmr/MMRRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/mmr/MMRRerankProcessorTests.java
@@ -101,10 +101,7 @@ public class MMRRerankProcessorTests extends KNNTestCase {
         float[][] diverseVectors = new float[][] { { 1.1f, 1.9f }, { 1.9f, 1.1f } };
         for (int i = 0; i < 2; i++) {
             int idx = i + 8;
-            XContentBuilder sourceBuilder = JsonXContent.contentBuilder()
-                .startObject()
-                .array("knn_vector", diverseVectors[i])
-                .endObject();
+            XContentBuilder sourceBuilder = JsonXContent.contentBuilder().startObject().array("knn_vector", diverseVectors[i]).endObject();
             SearchHit hit = new SearchHit(idx, String.valueOf(idx), Map.of(), Map.of());
             hit.sourceRef(BytesReference.bytes(sourceBuilder));
             hit.score(0.8f);


### PR DESCRIPTION
### Description
Extends Lucene's SQ support to `half_float` vectors, adding a new x16 compression (SQ 1-bit over 16-bit FP16 storage) alongside the existing x1 (exact FP16, no quantization). This applies to both the flat and hnsw methods.

**About ~1400 lines of changes are just tests**

### Related Issues
Resolves #3515 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
