### PR TITLE
[FP16 PR-7] Add `half_float` Support for `index.knn=false`

### DIFF
--- a/src/main/java/org/opensearch/knn/index/VectorField.java
+++ b/src/main/java/org/opensearch/knn/index/VectorField.java
@@ -9,16 +9,29 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfFloatsSerializer;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfHalfFloatsSerializer;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
 
 public class VectorField extends Field {
 
     public VectorField(String name, float[] value, IndexableFieldType type) {
+        this(name, value, type, VectorDataType.FLOAT);
+    }
+
+    /**
+     * Serializes a float vector into the binary DocValues representation of the given data type. HALF_FLOAT is
+     * encoded as FP16 (2 bytes per dimension), everything else as FP32 (4 bytes per dimension). The encoding must
+     * match {@link VectorDataType#getVectorFromBytesRef(BytesRef)}, which is what reads these bytes back.
+     *
+     * @param name FieldType name
+     * @param value an array of float vector values
+     * @param type FieldType to build DocValues
+     * @param vectorDataType data type the vector is stored as
+     */
+    public VectorField(String name, float[] value, IndexableFieldType type, VectorDataType vectorDataType) {
         super(name, new BytesRef(), type);
         try {
-            final KNNVectorSerializer vectorSerializer = KNNVectorAsCollectionOfFloatsSerializer.INSTANCE;
-            final byte[] floatToByte = vectorSerializer.floatToByteArray(value);
-            this.setBytesValue(floatToByte);
+            this.setBytesValue(serialize(value, vectorDataType));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -37,5 +50,15 @@ public class VectorField extends Field {
             throw new RuntimeException(e);
         }
 
+    }
+
+    private static byte[] serialize(final float[] value, final VectorDataType vectorDataType) {
+        if (VectorDataType.HALF_FLOAT == vectorDataType) {
+            final byte[] halfFloatToByte = new byte[value.length * 2];
+            KNNVectorAsCollectionOfHalfFloatsSerializer.INSTANCE.floatToByteArray(value, halfFloatToByte, value.length);
+            return halfFloatToByte;
+        }
+        final KNNVectorSerializer vectorSerializer = KNNVectorAsCollectionOfFloatsSerializer.INSTANCE;
+        return vectorSerializer.floatToByteArray(value);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/FlatVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FlatVectorFieldMapper.java
@@ -13,6 +13,8 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
 import java.util.Map;
 
 /**
@@ -87,6 +89,9 @@ public class FlatVectorFieldMapper extends KNNVectorFieldMapper {
         this.perDimensionValidator = selectPerDimensionValidator(vectorDataType);
         this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
         this.fieldType.setDocValuesType(DocValuesType.BINARY);
+        if (VectorDataType.HALF_FLOAT == vectorDataType) {
+            this.fieldType.putAttribute(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
+        }
         this.fieldType.freeze();
     }
 
@@ -97,6 +102,10 @@ public class FlatVectorFieldMapper extends KNNVectorFieldMapper {
 
         if (VectorDataType.BYTE == vectorDataType) {
             return PerDimensionValidator.DEFAULT_BYTE_VALIDATOR;
+        }
+
+        if (VectorDataType.HALF_FLOAT == vectorDataType) {
+            return PerDimensionValidator.DEFAULT_HALF_FLOAT_VALIDATOR;
         }
 
         return PerDimensionValidator.DEFAULT_FLOAT_VALIDATOR;

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -63,6 +63,7 @@ import static org.opensearch.knn.common.KNNValidationUtil.validateVectorDimensio
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createKNNMethodContextFromLegacy;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForByteVector;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForFloatVector;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForHalfFloatVector;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.useFullFieldNameValidation;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateIfCircuitBreakerIsNotTriggered;
 import static org.opensearch.knn.index.mapper.ModelFieldMapper.UNSET_MODEL_DIMENSION_IDENTIFIER;
@@ -306,11 +307,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
             // return FlatVectorFieldMapper only for indices that are created on or after 2.17.0, for others, use
             // EngineFieldMapper to maintain backwards compatibility.
-            // HALF_FLOAT is excluded because FlatVectorFieldMapper relies on binary DocValues storage.
-            final VectorDataType resolvedDataType = vectorDataType.getValue();
-            if (originalParameters.getResolvedKnnMethodContext() == null
-                && indexCreatedVersion.onOrAfter(Version.V_2_17_0)
-                && resolvedDataType != VectorDataType.HALF_FLOAT) {
+            if (originalParameters.getResolvedKnnMethodContext() == null && indexCreatedVersion.onOrAfter(Version.V_2_17_0)) {
                 // Prior to 3.0.0, hasDocValues defaulted to false. However, FlatVectorFieldMapper requires
                 // hasDocValues to be true to maintain proper functionality for vector search operations.
                 // For indices created on or after 3.0.0, we automatically set hasDocValues to true if not
@@ -420,17 +417,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             }
 
             final boolean isKNNDisabled = isKNNDisabled(parserContext.getSettings());
-            final VectorDataType parsedDataType = builder.vectorDataType.getValue();
-
-            // half_float needs the Lucene FP16 codec, which is only wired up when index.knn is true.
-            // Checked here rather than in validateFromFlat below so it is independent of the version
-            // gate, which exists only to preserve pre-2.17 flat-mapper behavior.
-            if (isKNNDisabled && parsedDataType == VectorDataType.HALF_FLOAT) {
-                throw new IllegalArgumentException(
-                    "HALF_FLOAT vector data type is not supported when index.knn is disabled. "
-                        + "Use method 'flat' with engine 'lucene' and index.knn enabled instead."
-                );
-            }
 
             // Check for flat configuration and validate only if index is created after 2.17
             if (isKNNDisabled && parserContext.indexVersionCreated().onOrAfter(Version.V_2_17_0)) {
@@ -723,7 +709,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         if (useLuceneBasedVectorField) {
             return new DerivedKnnFloatVectorField(name(), vectorValue, fieldType, isDerivedEnabled);
         }
-        return new VectorField(name(), vectorValue, fieldType);
+        return new VectorField(name(), vectorValue, fieldType, vectorDataType);
     }
 
     private Field createVectorField(byte[] vectorValue, boolean isDerivedEnabled) {
@@ -743,7 +729,11 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         final List<Field> fields = new ArrayList<>();
         fields.add(createVectorField(array, isDerivedEnabled));
         if (this.stored) {
-            fields.add(createStoredFieldForFloatVector(name(), array));
+            fields.add(
+                VectorDataType.HALF_FLOAT == vectorDataType
+                    ? createStoredFieldForHalfFloatVector(name(), array)
+                    : createStoredFieldForFloatVector(name(), array)
+            );
         }
         return fields;
     }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -9,6 +9,7 @@ import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -2156,8 +2157,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         assertTrue(knnVectorFieldMapper instanceof FlatVectorFieldMapper);
     }
 
-    public void testBuilder_whenHalfFloatWithLegacyKNNDisabled_thenThrows() {
-        // HALF_FLOAT is not supported when index.knn is disabled (DocValues path)
+    public void testTypeParser_whenHalfFloatWithLegacyKNNDisabled_thenFlatMapper() throws IOException {
+        // HALF_FLOAT with index.knn disabled stores vectors as binary DocValues, same as the other data types
         ModelDao modelDao = mock(ModelDao.class);
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
 
@@ -2166,23 +2167,175 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         String fieldName = "test-field-name-1";
         String indexName = "test-index";
 
-        XContentBuilder xContentBuilder;
-        try {
-            xContentBuilder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-                .field(DIMENSION_FIELD_NAME, 4)
-                .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.HALF_FLOAT.getValue())
-                .endObject();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 4)
+            .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.HALF_FLOAT.getValue())
+            .endObject();
 
-        IllegalArgumentException ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> typeParser.parse(fieldName, xContentBuilderToMap(xContentBuilder), buildParserContext(indexName, settings))
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext(indexName, settings)
         );
-        assertTrue("Should reject HALF_FLOAT when index.knn is disabled", ex.getMessage().contains("HALF_FLOAT"));
+
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
+        assertTrue(knnVectorFieldMapper instanceof FlatVectorFieldMapper);
+        assertEquals(VectorDataType.HALF_FLOAT, knnVectorFieldMapper.fieldType().getVectorDataType());
+    }
+
+    @SneakyThrows
+    public void testFlatFieldMapperParseCreateField_whenHalfFloat_thenStoresFp16DocValues() {
+        final int dimension = TEST_VECTOR.length;
+        final KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.HALF_FLOAT)
+            .versionCreated(CURRENT)
+            .dimension(dimension)
+            .build();
+
+        final IndexSettings indexSettingsMock = mock(IndexSettings.class);
+        when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
+        final ParseContext.Document document = new ParseContext.Document();
+        final ParseContext parseContext = mock(ParseContext.class);
+        when(parseContext.doc()).thenReturn(document);
+        when(parseContext.path()).thenReturn(new ContentPath());
+        when(parseContext.parser()).thenReturn(createXContentParserForFloatVector(TEST_VECTOR));
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
+
+        final KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(TEST_FIELD_NAME, null, CURRENT, null, null);
+        builder.vectorDataType.setValue(VectorDataType.HALF_FLOAT);
+        builder.dimension.setValue(dimension);
+        final FlatVectorFieldMapper flatFieldMapper = FlatVectorFieldMapper.createFieldMapper(
+            TEST_FIELD_NAME,
+            TEST_FIELD_NAME,
+            Collections.emptyMap(),
+            knnMethodConfigContext,
+            FieldMapper.MultiFields.empty(),
+            FieldMapper.CopyTo.empty(),
+            new Explicit<>(true, true),
+            false,
+            true,
+            new OriginalMappingParameters(builder)
+        );
+
+        flatFieldMapper.parseCreateField(parseContext, dimension, VectorDataType.HALF_FLOAT);
+
+        final List<IndexableField> fields = document.getFields();
+        assertEquals(1, fields.size());
+        final IndexableField field = fields.get(0);
+        assertTrue(field instanceof VectorField);
+        assertEquals(DocValuesType.BINARY, field.fieldType().docValuesType());
+        // Without this attribute readers that resolve the data type from FieldInfo decode the FP16 bytes as FP32
+        assertEquals(VectorDataType.HALF_FLOAT.getValue(), field.fieldType().getAttributes().get(VECTOR_DATA_TYPE_FIELD));
+
+        // FP16 is 2 bytes per dimension, and must round-trip through the same deserializer the read paths use
+        final BytesRef storedBytes = field.binaryValue();
+        assertEquals(dimension * 2, storedBytes.length);
+        final float[] deserialized = VectorDataType.HALF_FLOAT.getVectorFromBytesRef(storedBytes);
+        assertArrayEquals(TEST_VECTOR, deserialized, 0.01f);
+    }
+
+    @SneakyThrows
+    public void testFlatFieldMapperParseCreateField_whenHalfFloatStored_thenStoresFp16StoredField() {
+        final int dimension = TEST_VECTOR.length;
+        final KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.HALF_FLOAT)
+            .versionCreated(CURRENT)
+            .dimension(dimension)
+            .build();
+
+        final IndexSettings indexSettingsMock = mock(IndexSettings.class);
+        when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
+        final ParseContext.Document document = new ParseContext.Document();
+        final ParseContext parseContext = mock(ParseContext.class);
+        when(parseContext.doc()).thenReturn(document);
+        when(parseContext.path()).thenReturn(new ContentPath());
+        when(parseContext.parser()).thenReturn(createXContentParserForFloatVector(TEST_VECTOR));
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
+
+        final KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(TEST_FIELD_NAME, null, CURRENT, null, null);
+        builder.vectorDataType.setValue(VectorDataType.HALF_FLOAT);
+        builder.dimension.setValue(dimension);
+        final FlatVectorFieldMapper flatFieldMapper = FlatVectorFieldMapper.createFieldMapper(
+            TEST_FIELD_NAME,
+            TEST_FIELD_NAME,
+            Collections.emptyMap(),
+            knnMethodConfigContext,
+            FieldMapper.MultiFields.empty(),
+            FieldMapper.CopyTo.empty(),
+            new Explicit<>(true, true),
+            true,
+            true,
+            new OriginalMappingParameters(builder)
+        );
+
+        flatFieldMapper.parseCreateField(parseContext, dimension, VectorDataType.HALF_FLOAT);
+
+        final List<IndexableField> fields = document.getFields();
+        assertEquals(2, fields.size());
+
+        // The stored field must be FP16 too, otherwise _source recovery would read it back at the wrong width
+        final IndexableField storedField = fields.get(1);
+        final BytesRef storedBytes = storedField.binaryValue();
+        assertEquals(dimension * 2, storedBytes.length);
+        final Object deserialized = KNNVectorFieldMapperUtil.deserializeStoredVector(storedBytes, VectorDataType.HALF_FLOAT);
+        assertTrue(deserialized instanceof float[]);
+        assertArrayEquals(TEST_VECTOR, (float[]) deserialized, 0.01f);
+    }
+
+    public void testFlatFieldMapper_whenHalfFloatValueOutOfRange_thenThrows() {
+        final int dimension = 2;
+        final KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.HALF_FLOAT)
+            .versionCreated(CURRENT)
+            .dimension(dimension)
+            .build();
+
+        final IndexSettings indexSettingsMock = mock(IndexSettings.class);
+        when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
+        final ParseContext parseContext = mock(ParseContext.class);
+        when(parseContext.doc()).thenReturn(new ParseContext.Document());
+        when(parseContext.path()).thenReturn(new ContentPath());
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
+
+        final KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(TEST_FIELD_NAME, null, CURRENT, null, null);
+        builder.vectorDataType.setValue(VectorDataType.HALF_FLOAT);
+        builder.dimension.setValue(dimension);
+        final FlatVectorFieldMapper flatFieldMapper = FlatVectorFieldMapper.createFieldMapper(
+            TEST_FIELD_NAME,
+            TEST_FIELD_NAME,
+            Collections.emptyMap(),
+            knnMethodConfigContext,
+            FieldMapper.MultiFields.empty(),
+            FieldMapper.CopyTo.empty(),
+            new Explicit<>(true, true),
+            false,
+            true,
+            new OriginalMappingParameters(builder)
+        );
+
+        final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> {
+            when(parseContext.parser()).thenReturn(createXContentParserForFloatVector(new float[] { 70000.0f, 1.0f }));
+            flatFieldMapper.parseCreateField(parseContext, dimension, VectorDataType.HALF_FLOAT);
+        });
+        assertTrue(ex.getMessage(), ex.getMessage().contains("half_float"));
+    }
+
+    public void testBuilder_whenHalfFloatWithLegacyKNNDisabled_thenValid() {
+        // Mirrors testBuilder_whenBinaryWithLegacyKNNDisabled_thenValid for the HALF_FLOAT data type
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao, CURRENT, null, null);
+        builder.vectorDataType.setValue(VectorDataType.HALF_FLOAT);
+        builder.dimension.setValue(4);
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, false).build();
+
+        builder.setOriginalParameters(new OriginalMappingParameters(builder));
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
+        assertTrue(knnVectorFieldMapper instanceof FlatVectorFieldMapper);
     }
 
     public void testTypeParser_whenBinaryWithLegacyKNNEnabled_thenValid() throws IOException {
@@ -3284,6 +3437,19 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         byte[] array = new byte[dimension];
         Arrays.fill(array, value);
         return array;
+    }
+
+    private XContentParser createXContentParserForFloatVector(final float[] vector) throws IOException {
+        XContentParser parser = XContentHelper.createParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            new BytesArray("{\"" + TEST_FIELD_NAME + "\":" + Arrays.toString(vector) + "}"),
+            MediaTypeRegistry.JSON
+        );
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        return parser;
     }
 
     private XContentParser createXContentParser(final VectorDataType dataType) throws IOException {

--- a/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
@@ -1342,6 +1342,70 @@ public class DocValueFieldsIT extends KNNCompressionRestTestCase {
     }
 
     /**
+     * Same as {@link #testDocValueFields_scriptScoreQuery_indexKnnFalse()} but for the half_float data type, whose
+     * DocValues are FP16 (2 bytes per dimension) rather than FP32. The read path resolves the data type from
+     * FieldInfo, so a field that failed to record it would decode these bytes as FP32 and return a vector of half
+     * the mapped dimension.
+     */
+    @SneakyThrows
+    public void testDocValueFields_halfFloat_indexKnnFalse() {
+        String indexName = TEST_INDEX + "_half_float_flat";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(VECTOR_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("data_type", VectorDataType.HALF_FLOAT.getValue())
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        Settings settings = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", false).build();
+
+        createKnnIndex(indexName, settings, mapping);
+        addKnnDoc(indexName, "1", VECTOR_FIELD, Floats.asList(VECTOR_1).toArray());
+        addKnnDoc(indexName, "2", VECTOR_FIELD, Floats.asList(VECTOR_2).toArray());
+        refreshIndex(indexName);
+
+        String query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .startArray("docvalue_fields")
+            .startObject()
+            .field("field", VECTOR_FIELD)
+            .field("format", "array")
+            .endObject()
+            .endArray()
+            .field("_source", false)
+            .endObject()
+            .toString();
+
+        Response response = searchKNNIndex(indexName, query, 10);
+        List<Map<String, Object>> hits = parseSearchHits(EntityUtils.toString(response.getEntity()));
+        assertEquals(2, hits.size());
+
+        for (Map<String, Object> hit : hits) {
+            List<List<Double>> vectorField = getDocValueField(hit, VECTOR_FIELD);
+            assertNotNull("Expected vector in docvalue_fields", vectorField);
+            assertEquals("Expected single vector value", 1, vectorField.size());
+            assertEquals("FP16 DocValues decoded at the wrong width", DIMENSION, vectorField.get(0).size());
+
+            float[] expected = "1".equals(hit.get("_id")) ? VECTOR_1 : VECTOR_2;
+            for (int i = 0; i < DIMENSION; i++) {
+                assertEquals("Vector component mismatch at index " + i, expected[i], vectorField.get(0).get(i).floatValue(), 0.01f);
+            }
+        }
+
+        deleteKNNIndex(indexName);
+    }
+
+    /**
      * Verifies that when a segment contains documents without the vector field,
      * docvalue_fields gracefully returns no vector for those documents instead of failing.
      * This exercises the EMPTY_DOCVALUE_FETCHER_LEAF path in KNNVectorDVLeafFieldData.

--- a/src/test/java/org/opensearch/knn/integ/HalfFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/HalfFloatIndexIT.java
@@ -388,12 +388,104 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
     }
 
     // ────────────────────────────────────────────────────────────────────────────
-    // Negative tests - blocked configurations
+    // Binary DocValues (index.knn=false). No ANN structure is built, so the supported
+    // access paths are script scoring, docvalue_fields and _source - same as every other
+    // data type on this path.
     // ────────────────────────────────────────────────────────────────────────────
 
     @SneakyThrows
-    public void testHalfFloatWithoutMethod_indexKnnFalse_shouldFail() {
-        // HALF_FLOAT is not supported for the binary DocValues (index.knn=false) path
+    public void testHalfFloatWithoutMethod_indexKnnFalse_scriptScore() {
+        createHalfFloatFlatIndex();
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        refreshIndex(INDEX_NAME);
+
+        String query = buildKnnScoreScriptQuery(new float[] { 0.0f, 0.0f, 0.0f, 0.0f });
+        Response response = searchKNNIndex(INDEX_NAME, query, 3);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(3, results.size());
+        assertEquals("3", results.get(0).getDocId());
+        assertEquals("1", results.get(1).getDocId());
+        assertEquals("2", results.get(2).getDocId());
+    }
+
+    /**
+     * The DocValues bytes are FP16, so a reader that resolved the data type incorrectly would decode them as FP32
+     * and hand back a vector of the wrong length. Reading the vectors back through the script doc values catches that.
+     */
+    @SneakyThrows
+    public void testHalfFloatWithoutMethod_indexKnnFalse_vectorRoundTripsThroughDocValues() {
+        createHalfFloatFlatIndex();
+
+        Float[] vector = { 1.5f, -2.25f, 3.125f, 4.0f };
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
+        refreshIndex(INDEX_NAME);
+
+        String query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("script_score")
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .startObject("script")
+            .field("source", "doc['" + FIELD_NAME + "'].value.length")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        Response response = searchKNNIndex(INDEX_NAME, query, 1);
+        List<Float> scores = parseSearchResponseScore(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+        assertEquals(1, scores.size());
+        assertEquals("Vector read back from DocValues should have the mapped dimension", (float) DIMENSION, scores.get(0), 0.0f);
+    }
+
+    /**
+     * Binary DocValues are merged by the default Lucene codec here, since no k-NN codec is installed when
+     * index.knn is false. Force merging exercises that path for the FP16 encoding.
+     */
+    @SneakyThrows
+    public void testHalfFloatWithoutMethod_indexKnnFalse_forceMerge() {
+        createHalfFloatFlatIndex();
+
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, new Float[] { 5.0f, 6.0f, 7.0f, 8.0f });
+        flushIndex(INDEX_NAME, true);
+        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, new Float[] { 0.1f, 0.2f, 0.3f, 0.4f });
+        flushIndex(INDEX_NAME, true);
+
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        String query = buildKnnScoreScriptQuery(new float[] { 0.0f, 0.0f, 0.0f, 0.0f });
+        Response response = searchKNNIndex(INDEX_NAME, query, 3);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertEquals(3, results.size());
+        assertEquals("3", results.get(0).getDocId());
+        assertEquals("1", results.get(1).getDocId());
+        assertEquals("2", results.get(2).getDocId());
+    }
+
+    @SneakyThrows
+    public void testHalfFloatWithoutMethod_indexKnnFalse_rejectsOutOfRangeValue() {
+        createHalfFloatFlatIndex();
+
+        // 70000 exceeds the half_float maximum (65504), so it must be rejected rather than silently stored as Inf
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 70000.0f, 1.0f, 2.0f, 3.0f })
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("half_float"));
+    }
+
+    private void createHalfFloatFlatIndex() throws IOException {
         String mapping = KNNJsonIndexMappingsBuilder.builder()
             .fieldName(FIELD_NAME)
             .dimension(DIMENSION)
@@ -402,12 +494,31 @@ public class HalfFloatIndexIT extends KNNRestTestCase {
             .getIndexMapping();
 
         Settings settings = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", false).build();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+    }
 
-        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, settings, mapping));
-        assertTrue(
-            "Should reject half_float when index.knn is disabled",
-            ex.getMessage().contains("HALF_FLOAT") || ex.getMessage().contains("half_float")
-        );
+    private String buildKnnScoreScriptQuery(final float[] queryVector) throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("script_score")
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .startObject("script")
+            .field("source", "knn_score")
+            .field("lang", "knn")
+            .startObject("params")
+            .field("field", FIELD_NAME)
+            .field("query_value", queryVector)
+            .field("space_type", SpaceType.L2.getValue())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Adds support for `half_float` when `index.knn` is false, storing vectors as FP16 binary doc values (2 bytes/dim).

### Related Issues
Resolves #3438

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
